### PR TITLE
clang port

### DIFF
--- a/examples/src/examples.cpp
+++ b/examples/src/examples.cpp
@@ -1,6 +1,7 @@
 // Copyright 2013 Daniel Parker
 // Distributed under Boost license
 
+#include <stdexcept>
 #include <string>
 #include "jsoncons/json.hpp"
 #include "csv_examples.h"
@@ -124,7 +125,7 @@ void mulitple_json_objects()
     std::ifstream is("input/multiple-json-objects.json");
     if (!is.is_open())
     {
-        throw std::exception("Cannot open file");
+        throw std::runtime_error("Cannot open file");
     }
 
     json_deserializer handler;

--- a/src/jsoncons/error_handler.hpp
+++ b/src/jsoncons/error_handler.hpp
@@ -42,7 +42,7 @@ public:
           column_number_(other.column_number_)
     {
     }
-    const char* what() const
+    const char* what() const JSONCONS_NOEXCEPT
     {
         std::ostringstream os;
         os << message_ << " on line " << line_number_ << " at column " << column_number_;

--- a/src/jsoncons/json1.hpp
+++ b/src/jsoncons/json1.hpp
@@ -257,7 +257,7 @@ public:
 
         const basic_json<Char>& operator[](size_t i) const
         {
-            return val_.[i];
+            return val_[i];
         }
 
         const basic_json<Char>& operator[](const std::basic_string<Char>& name) const
@@ -471,20 +471,20 @@ public:
         template <class T>
         std::vector<T> as_vector() const
         {
-            return val_.at(name_).as_vector<T>();
+            return val_.at(name_).template as_vector<T>();
         }
 
         template <class T>
         const T& custom_data() const
         {
-            return val_.at(name_).custom_data<T>();
+            return val_.at(name_).template custom_data<T>();
         }
         // Returns a const reference to the custom data associated with name
 
         template <class T>
         T& custom_data() 
         {
-            return val_.at(name_).custom_data<T>();
+            return val_.at(name_).template custom_data<T>();
         }
         // Returns a reference to the custom data associated with name
 
@@ -562,7 +562,7 @@ public:
 
         void remove_range(size_t from_index, size_t to_index)
         {
-            val_.at(name_).remove_range(size_t from_index, size_t to_index);
+            val_.at(name_).remove_range(from_index, to_index);
         }
         // Remove a range of elements from an array 
 
@@ -945,7 +945,7 @@ public:
         std::vector<T> v(size());
         for (size_t i = 0; i < v.size(); ++i)
         {
-            v[i] = at(i).as_value<T>();
+            v[i] = as_value<Char,T>(at(i)).get();
         }
         return v;
     }
@@ -957,68 +957,62 @@ public:
 private:
 	basic_json(value_type t);
 
-    template <class T>
-    T as_value() const;
-
-    template<>
-    std::basic_string<Char> as_value() const
+    template<typename C, typename T>
+    class as_value
     {
-        return as_string();
-    }
+    public:
+        as_value (const basic_json<C>& value) : value_(value)
+        {}
 
-    template<>
-    bool as_value() const
-    {
-        return as_bool();
-    }
+        T get () const
+        {
+            return static_cast<T>(*this);
+        }
+        
+        operator std::basic_string<C> () const
+        {
+            return value_.as_string();
+        }
+        operator bool () const
+        {
+            return value_.as_bool();
+        }
+        operator char () const
+        {
+            return value_.as_char();
+        }
+        operator double () const
+        {
+            return value_.as_double();
+        }
+        operator int () const
+        {
+            return value_.as_int();
+        }
+        operator unsigned int () const
+        {
+            return value_.as_uint();
+        }
+        operator long () const
+        {
+            return value_.as_long();
+        }
+        operator unsigned long () const
+        {
+            return value_.as_ulong();
+        }
+        operator long long () const
+        {
+            return value_.as_longlong();
+        }
+        operator unsigned long long () const
+        {
+            return value_.as_ulonglong();
+        }
 
-    template<>
-    char as_value() const
-    {
-        return as_char();
-    }
-
-    template<>
-    double as_value() const
-    {
-        return as_double();
-    }
-
-    template<>
-    int as_value() const
-    {
-        return as_int();
-    }
-
-    template<>
-    unsigned int as_value() const
-    {
-        return as_uint();
-    }
-
-    template<>
-    long as_value() const
-    {
-        return as_long();
-    }
-
-    template<>
-    unsigned long as_value() const
-    {
-        return as_ulong();
-    }
-
-    template<>
-    long long as_value() const
-    {
-        return as_longlong();
-    }
-
-    template<>
-    unsigned long long as_value() const
-    {
-        return as_ulonglong();
-    }
+    private:
+        const basic_json<C>& value_;
+    };
 
 	value_type type_;
     union

--- a/src/jsoncons/json2.hpp
+++ b/src/jsoncons/json2.hpp
@@ -648,7 +648,8 @@ template <class Char>
 std::basic_string<Char> basic_json<Char>::to_string() const
 {
     std::basic_ostringstream<Char> os;
-    to_stream(basic_json_serializer<Char>(os)); 
+    basic_json_serializer<Char> serializer(os);
+    to_stream(serializer);
     return os.str();
 }
 
@@ -656,7 +657,8 @@ template <class Char>
 std::basic_string<Char> basic_json<Char>::to_string(const basic_output_format<Char>& format) const
 {
     std::basic_ostringstream<Char> os;
-    to_stream(basic_json_serializer<Char>(os,format)); 
+    basic_json_serializer<Char> serializer(os,format);
+    to_stream(serializer);
     return os.str();
 }
 
@@ -722,19 +724,22 @@ void basic_json<Char>::to_stream(basic_json_output_handler<Char>& handler) const
 template <class Char>
 void basic_json<Char>::to_stream(std::basic_ostream<Char>& os) const
 {
-    to_stream(basic_json_serializer<Char>(os)); 
+    basic_json_serializer<Char> serializer(os);
+    to_stream(serializer); 
 }
 
 template <class Char>
 void basic_json<Char>::to_stream(std::basic_ostream<Char>& os, const basic_output_format<Char>& format) const
 {
-    to_stream(basic_json_serializer<Char>(os,format));
+    basic_json_serializer<Char> serializer(os,format);
+    to_stream(serializer);
 }
 
 template <class Char>
 void basic_json<Char>::to_stream(std::basic_ostream<Char>& os, const basic_output_format<Char>& format, bool indenting) const
 {
-    to_stream(basic_json_serializer<Char>(os,format,indenting));
+    basic_json_serializer<Char> serializer(os,format,indenting);
+    to_stream(serializer);
 }
 
 template <class Char>
@@ -1309,9 +1314,9 @@ void escape_string(const std::basic_string<Char>& s,
                    const basic_output_format<Char>& format,
                    std::basic_ostream<Char>& os)
 {
-    std::basic_string<Char>::const_iterator begin = s.begin();
-    std::basic_string<Char>::const_iterator end = s.end();
-    for (std::basic_string<Char>::const_iterator it = begin; it != end; ++it)
+    typename std::basic_string<Char>::const_iterator begin = s.begin();
+    typename std::basic_string<Char>::const_iterator end = s.end();
+    for (typename std::basic_string<Char>::const_iterator it = begin; it != end; ++it)
     {
         Char c = *it;
         switch (c)

--- a/src/jsoncons/json_char_traits.hpp
+++ b/src/jsoncons/json_char_traits.hpp
@@ -123,7 +123,7 @@ struct json_char_traits<char>
 inline
 bool is_control_character(unsigned int c)
 {
-    return c >= 0 && c <= 0x1F;
+    return c <= 0x1F;
 }
 
 }

--- a/src/jsoncons/json_deserializer.hpp
+++ b/src/jsoncons/json_deserializer.hpp
@@ -53,8 +53,8 @@ class basic_json_deserializer : public basic_json_input_handler<Char>
 
         std::basic_string<Char> name_;
         bool is_object_;
-        std::auto_ptr<json_object<Char>> object_;
-        std::auto_ptr<json_array<Char>> array_;
+        std::unique_ptr<json_object<Char>> object_;
+        std::unique_ptr<json_array<Char>> array_;
         size_t minimum_structure_capacity_;
     };
 

--- a/src/jsoncons/json_exception.hpp
+++ b/src/jsoncons/json_exception.hpp
@@ -23,7 +23,10 @@ namespace jsoncons {
 class json_exception : public std::exception
 {
 public:
-    json_exception()
+    json_exception() JSONCONS_NOEXCEPT
+    {
+    }
+    ~json_exception() JSONCONS_NOEXCEPT
     {
     }
 };
@@ -31,11 +34,14 @@ public:
 class json_exception_0 : public json_exception
 {
 public:
-    json_exception_0(std::string s)
+    json_exception_0(std::string s) JSONCONS_NOEXCEPT
         : message_(s)
     {
     }
-    const char* what() const 
+    ~json_exception_0() JSONCONS_NOEXCEPT
+    {
+    }
+    const char* what() const JSONCONS_NOEXCEPT
     {
         return message_.c_str();
     }
@@ -47,11 +53,14 @@ template <class Char>
 class json_exception_1 : public json_exception
 {
 public:
-    json_exception_1(const std::string& format, const std::basic_string<Char>& arg1)
+    json_exception_1(const std::string& format, const std::basic_string<Char>& arg1) JSONCONS_NOEXCEPT
         : format_(format), arg1_(arg1)
     {
     }
-    const char* what() const 
+    ~json_exception_1() JSONCONS_NOEXCEPT
+    {
+    }
+    const char* what() const JSONCONS_NOEXCEPT
     {
         c99_snprintf(const_cast<char*>(message_),255, format_.c_str(),arg1_.c_str());
         return message_;

--- a/src/jsoncons/output_format.hpp
+++ b/src/jsoncons/output_format.hpp
@@ -29,7 +29,7 @@ public:
     basic_output_format()
         : indent_(default_indent),
           precision_(16),
-          floatfield_(0),
+          floatfield_(std::ios_base::fmtflags(0)),
           replace_nan_(true),replace_pos_inf_(true),replace_neg_inf_(true), 
           pos_inf_replacement_(json_char_traits<Char>::null_literal()),
           neg_inf_replacement_(json_char_traits<Char>::null_literal()),

--- a/src/jsoncons_ext/csv/csv_reader.hpp
+++ b/src/jsoncons_ext/csv/csv_reader.hpp
@@ -62,7 +62,7 @@ public:
         {
             JSONCONS_THROW_EXCEPTION("Input stream is invalid");
         }
-        init(json::an_object);
+        init(jsoncons::json::an_object);
     }
 
     basic_csv_reader(std::basic_istream<Char>& is,
@@ -102,7 +102,7 @@ public:
         {
             JSONCONS_THROW_EXCEPTION("Input stream is invalid");
         }
-        init(json::an_object);
+        init(jsoncons::json::an_object);
     }
 
     basic_csv_reader(std::basic_istream<Char>& is,

--- a/src/jsoncons_ext/csv/csv_serializer.hpp
+++ b/src/jsoncons_ext/csv/csv_serializer.hpp
@@ -69,9 +69,9 @@ void escape_string(const std::basic_string<Char>& s,
                    Char quote_char, Char quote_escape_char,
                    std::basic_ostream<Char>& os)
 {
-    std::basic_string<Char>::const_iterator begin = s.begin();
-    std::basic_string<Char>::const_iterator end = s.end();
-    for (std::basic_string<Char>::const_iterator it = begin; it != end; ++it)
+    typename std::basic_string<Char>::const_iterator begin = s.begin();
+    typename std::basic_string<Char>::const_iterator end = s.end();
+    for (typename std::basic_string<Char>::const_iterator it = begin; it != end; ++it)
     {
         Char c = *it;
         if (c == quote_char)
@@ -216,7 +216,7 @@ public:
             }
             else
             {
-                std::map<std::basic_string<Char>,size_t>::iterator it = header_.find(name);
+                typename std::map<std::basic_string<Char>,size_t>::iterator it = header_.find(name);
                 if (it == header_.end())
                 {
                     stack_.back().skip_ = true;

--- a/test_suite/src/double_to_string_tests.cpp
+++ b/test_suite/src/double_to_string_tests.cpp
@@ -39,11 +39,11 @@ BOOST_AUTO_TEST_CASE(test_double_to_string)
 
     x = 1234563;
     s = jsoncons::double_to_string<char>(x, 6);
-    BOOST_CHECK(s == std::string("1.23456e+6") || s == std::string("1.23456e+006"));
+    BOOST_CHECK(s == std::string("1.23456e+6") || s == std::string("1.23456e+06") || s == std::string("1.23456e+006"));
 
     x = 0.0000001234563;
     s = jsoncons::double_to_string<char>(x, 6);
-    BOOST_CHECK(s == std::string("1.23456e-7") || s == std::string("1.23456e-007"));
+    BOOST_CHECK(s == std::string("1.23456e-7") || s == std::string("1.23456e-07") || s == std::string("1.23456e-007"));
 
     x = -1.0e+100;
     s = jsoncons::double_to_string<char>(x, 16);

--- a/test_suite/src/jsoncons_test.cpp
+++ b/test_suite/src/jsoncons_test.cpp
@@ -53,7 +53,7 @@ BOOST_AUTO_TEST_CASE(test_assignment)
     root["myobject"] = json(json::an_object);
     root["myobject"]["double_2"] = json(7.0);
     root["myobject"]["bool_2"] = json(true);
-    root["myobject"]["int_2"] = json(long long(0));
+    root["myobject"]["int_2"] = json(0LL);
     root["myobject"]["string_2"] = json("my string");
     root["myarray"] = json::an_array;
 

--- a/test_suite/src/string_to_double_tests.cpp
+++ b/test_suite/src/string_to_double_tests.cpp
@@ -10,6 +10,7 @@
 #include <vector>
 #include <utility>
 #include <ctime>
+#include <cwchar>
 
 using jsoncons::json_serializer;
 using jsoncons::output_format;
@@ -25,7 +26,7 @@ BOOST_AUTO_TEST_CASE(test_string_to_double)
     char* endptr = begin + strlen(begin);
     double value1 = 1.15507e-173;
     double value2 = strtod( begin, &endptr );
-    double value3 = jsoncons::string_to_double(begin);
+    double value3 = jsoncons::string_to_double(std::string(begin));
 
     BOOST_CHECK(value1 == value2);
     BOOST_CHECK(value2 == value3);
@@ -37,7 +38,7 @@ BOOST_AUTO_TEST_CASE(test_wstring_to_double)
     wchar_t* endptr = begin + wcslen(begin);
     double value1 = 1.15507e-173;
     double value2 = wcstod( begin, &endptr );
-    double value3 = jsoncons::string_to_double(begin);
+    double value3 = jsoncons::string_to_double(std::wstring(begin));
 
     BOOST_CHECK(value1 == value2);
     BOOST_CHECK(value2 == value3);


### PR DESCRIPTION
Major changes are:
- introduction of macro JSONCONS_NOEXCEPT to handle various method signatures including, or not, noexcept or throw() keyword. Mainly used for exception declarations.
- change how exceptions are raised because std::exception cannot be directly used to create instances, as specified by C++ standard, only derived classes can be used.
- change private method basic_json::as_value to a local template class as_value because standard does not allow to specialize a method inside a template definition (mainly because the result is equivalent to a partial specialization which is not allowed).
- change std::auto_ptr to std::unique_ptr inside basic_json_deserializer::stack_item because it is not allowed to used auto_ptr in conjunction with containers. Anyway, auto_ptr is, for this reason, deprecated with c++11.
