### PR TITLE
add template methods is<> and as<> to facilitate json handling as part o...

### DIFF
--- a/src/jsoncons/json1.hpp
+++ b/src/jsoncons/json1.hpp
@@ -92,6 +92,9 @@ public:
     static const basic_json<Char> an_array;
     static const basic_json<Char> null;
 
+    typedef json_object<Char> object_type;
+    typedef json_array<Char> array_type;
+    
     typedef typename json_object<Char>::iterator object_iterator;
     typedef typename json_object<Char>::const_iterator const_object_iterator;
 
@@ -111,6 +114,12 @@ public:
         bool has_member(const std::basic_string<Char>& name) const
         {
             return val_.has_member(name);
+        }
+
+        template<typename T>
+        bool is() const
+        {
+            return val_.template is<T>();
         }
 
         bool is_null() const
@@ -181,6 +190,12 @@ public:
         std::basic_string<Char> as_string(const basic_output_format<Char>& format) const
         {
             return val_.as_string(format);
+        }
+
+        template<typename T>
+        T as() const
+        {
+            return val_.template as<T>();
         }
 
         Char as_char() const
@@ -368,6 +383,12 @@ public:
             val_.at(name_).resize_array(n,val);
         }
 
+        template<typename T>
+        bool is() const
+        {
+            return val_.at(name_).template is<T>();
+        }
+
         bool is_string() const
         {
             return val_.at(name_).is_string();
@@ -421,6 +442,12 @@ public:
         std::basic_string<Char> as_string(const basic_output_format<Char>& format) const
         {
             return val_.at(name_).as_string(format);
+        }
+
+        template<typename T>
+        T as() const
+        {
+            return val_.at(name_).template as<T>();
         }
 
         Char as_char() const
@@ -777,6 +804,12 @@ public:
 
     bool has_member(const std::basic_string<Char>& name) const;
 
+    template<typename T>
+    bool is() const
+    {
+        return is_type<Char,T>(*this);
+    }
+
     bool is_string() const
     {
         return type_ == string_t;
@@ -831,6 +864,12 @@ public:
     void resize_array(size_t n);
 
     void resize_array(size_t n, const basic_json<Char>& val);
+
+    template<typename T>
+    T as() const
+    {
+        return as_value<Char,T>(*this);
+    }
 
     bool as_bool() const;
 
@@ -956,6 +995,184 @@ public:
     }
 private:
 	basic_json(value_type t);
+
+    template<typename C, typename T>
+    class is_type
+    {
+    public:
+        is_type (const basic_json<C>& value)
+        {}
+
+        operator bool () const
+        {
+            return false;
+        }
+    };
+    template<typename C>
+    class is_type<C,std::basic_string<C>>
+    {
+      public:
+        is_type (const basic_json<C>& value) : value_(value)
+        {}
+        
+        operator bool () const
+        {
+            return value_.is_string();
+        }
+
+      private:
+        const basic_json<C>& value_;
+    };
+    template<typename C>
+    class is_type<C,bool>
+    {
+      public:
+        is_type (const basic_json<C>& value) : value_(value)
+        {}
+        
+        operator bool () const
+        {
+            return value_.is_bool();
+        }
+
+      private:
+        const basic_json<C>& value_;
+    };
+    template<typename C>
+    class is_type<C,double>
+    {
+      public:
+        is_type (const basic_json<C>& value) : value_(value)
+        {}
+        
+        operator bool () const
+        {
+            return value_.is_double();
+        }
+
+      private:
+        const basic_json<C>& value_;
+    };
+    template<typename C>
+    class is_type<C,int>
+    {
+      public:
+        is_type (const basic_json<C>& value) : value_(value)
+        {}
+        
+        operator bool () const
+        {
+            return value_.is_longlong();
+        }
+
+      private:
+        const basic_json<C>& value_;
+    };
+    template<typename C>
+    class is_type<C,unsigned int>
+    {
+      public:
+        is_type (const basic_json<C>& value) : value_(value)
+        {}
+        
+        operator bool () const
+        {
+            return value_.is_ulonglong();
+        }
+
+      private:
+        const basic_json<C>& value_;
+    };
+    template<typename C>
+    class is_type<C,long>
+    {
+      public:
+        is_type (const basic_json<C>& value) : value_(value)
+        {}
+        
+        operator bool () const
+        {
+            return value_.is_longlong();
+        }
+
+      private:
+        const basic_json<C>& value_;
+    };
+    template<typename C>
+    class is_type<C,unsigned long>
+    {
+      public:
+        is_type (const basic_json<C>& value) : value_(value)
+        {}
+        
+        operator bool () const
+        {
+            return value_.is_ulonglong();
+        }
+
+      private:
+        const basic_json<C>& value_;
+    };
+    template<typename C>
+    class is_type<C,long long>
+    {
+      public:
+        is_type (const basic_json<C>& value) : value_(value)
+        {}
+        
+        operator bool () const
+        {
+            return value_.is_longlong();
+        }
+
+      private:
+        const basic_json<C>& value_;
+    };
+    template<typename C>
+    class is_type<C,unsigned long long>
+    {
+      public:
+        is_type (const basic_json<C>& value) : value_(value)
+        {}
+        
+        operator bool () const
+        {
+            return value_.is_ulonglong();
+        }
+
+      private:
+        const basic_json<C>& value_;
+    };
+    template<typename C>
+    class is_type<C,object_type>
+    {
+      public:
+        is_type (const basic_json<C>& value) : value_(value)
+        {}
+        
+        operator bool () const
+        {
+            return value_.is_object();
+        }
+
+      private:
+        const basic_json<C>& value_;
+    };
+    template<typename C>
+    class is_type<C,array_type>
+    {
+      public:
+        is_type (const basic_json<C>& value) : value_(value)
+        {}
+        
+        operator bool () const
+        {
+            return value_.is_array();
+        }
+
+      private:
+        const basic_json<C>& value_;
+    };
 
     template<typename C, typename T>
     class as_value

--- a/test_suite/src/json_accessor_tests.cpp
+++ b/test_suite/src/json_accessor_tests.cpp
@@ -23,6 +23,7 @@ BOOST_AUTO_TEST_CASE(test_is_type)
 {
     json obj;
     BOOST_CHECK(obj.is_object());
+    BOOST_CHECK(obj.is<json::object_type>());
     std::cout << "HERE!!!"  << ", type=" << obj.type() <<  std::endl;
 
     // tests for proxy is_type methods
@@ -30,44 +31,57 @@ BOOST_AUTO_TEST_CASE(test_is_type)
     std::cout << "type=" << obj.type() << std::endl;
 
     BOOST_CHECK(obj.is_object());
+    BOOST_CHECK(obj.is<json::object_type>());
 
     BOOST_CHECK(obj["string"].is_string());
+    BOOST_CHECK(obj["string"].is<std::string>());
 
     obj["double"] = 10.7;
     BOOST_CHECK(obj["double"].is_double());
+    BOOST_CHECK(obj["double"].is<double>());
 
     obj["int"] = -10;
     BOOST_CHECK(obj["int"].is_longlong());
+    BOOST_CHECK(obj["int"].is<long long>());
 
     obj["uint"] = 10u;
     BOOST_CHECK(obj["uint"].is_ulonglong());
+    BOOST_CHECK(obj["uint"].is<unsigned long long>());
 
     obj["long"] = static_cast<long>(10);
     BOOST_CHECK(obj["long"].is_longlong());
+    BOOST_CHECK(obj["long"].is<long long>());
 
     obj["ulong"] = static_cast<unsigned long>(10);
     BOOST_CHECK(obj["ulong"].is_ulonglong());
+    BOOST_CHECK(obj["ulong"].is<unsigned long long>());
 
     obj["longlong"] = static_cast<long long>(10);
     BOOST_CHECK(obj["longlong"].is_longlong());
+    BOOST_CHECK(obj["longlong"].is<long long>());
 
     obj["ulonglong"] = static_cast<unsigned long long>(10);
     BOOST_CHECK(obj["ulonglong"].is_ulonglong());
+    BOOST_CHECK(obj["ulonglong"].is<unsigned long long>());
 
     obj["true"] = true;
     BOOST_CHECK(obj["true"].is_bool());
+    BOOST_CHECK(obj["true"].is<bool>());
 
     obj["false"] = false;
     BOOST_CHECK(obj["false"].is_bool());
+    BOOST_CHECK(obj["false"].is<bool>());
 
     obj["null1"] = json::null;
     BOOST_CHECK(obj["null1"].is_null());
 
     obj["object"] = json::an_object;
     BOOST_CHECK(obj["object"].is_object());
+    BOOST_CHECK(obj["object"].is<json::object_type>());
 
     obj["array"] = json::an_array;
     BOOST_CHECK(obj["array"].is_array());
+    BOOST_CHECK(obj["array"].is<json::array_type>());
 
     matrix<double> A;
     obj.set_custom_data("custom",A);
@@ -77,6 +91,7 @@ BOOST_AUTO_TEST_CASE(test_is_type)
 
     json str = obj["string"];
     BOOST_CHECK(str.is_string());
+    BOOST_CHECK(str.is<std::string>());
 }
 
 BOOST_AUTO_TEST_CASE(test_as_vector_of_double)

--- a/test_suite/src/json_array_tests.cpp
+++ b/test_suite/src/json_array_tests.cpp
@@ -23,6 +23,7 @@ BOOST_AUTO_TEST_CASE(test_add_element_to_array)
 {
     json arr = json::make_array();
     BOOST_CHECK(arr.is_array());
+    BOOST_CHECK(arr.is<json::array_type>());
     arr.add("Toronto");
     arr.add("Vancouver");
     arr.add(0,"Montreal");
@@ -32,12 +33,17 @@ BOOST_AUTO_TEST_CASE(test_add_element_to_array)
     BOOST_CHECK(arr[0].as_string() == std::string("Montreal"));
     BOOST_CHECK(arr[1].as_string() == std::string("Toronto"));
     BOOST_CHECK(arr[2].as_string() == std::string("Vancouver"));
+
+    BOOST_CHECK(arr[0].as<std::string>() == std::string("Montreal"));
+    BOOST_CHECK(arr[1].as<std::string>() == std::string("Toronto"));
+    BOOST_CHECK(arr[2].as<std::string>() == std::string("Vancouver"));
 }
 
 BOOST_AUTO_TEST_CASE(test_array_remove_range)
 {
     json arr = json::make_array();
     BOOST_CHECK(arr.is_array());
+    BOOST_CHECK(arr.is<json::array_type>());
     arr.add("Toronto");
     arr.add("Vancouver");
     arr.add(0,"Montreal");
@@ -54,12 +60,14 @@ BOOST_AUTO_TEST_CASE(test_reserve_array_capacity)
 {
     json cities = json::make_array();
     BOOST_CHECK(cities.is_array());
+    BOOST_CHECK(cities.is<json::array_type>());
     cities.reserve(10);  // storage is allocated
     BOOST_CHECK(cities.capacity() == 10);
     BOOST_CHECK(cities.size() == 0);
 
     cities.add("Toronto");  
     BOOST_CHECK(cities.is_array());
+    BOOST_CHECK(cities.is<json::array_type>());
     BOOST_CHECK(cities.capacity() == 10);
     BOOST_CHECK(cities.size() == 1);
     cities.add("Vancouver");
@@ -78,6 +86,10 @@ BOOST_AUTO_TEST_CASE(test_one_dim_array)
     BOOST_CHECK(a[1].as_longlong() == 1);
     BOOST_CHECK(a[2].as_longlong() == 2);
     BOOST_CHECK(a[9].as_longlong() == 0);
+    
+    BOOST_CHECK(a[1].as<long long>() == 1);
+    BOOST_CHECK(a[2].as<long long>() == 2);
+    BOOST_CHECK(a[9].as<long long>() == 0);
 }
 
 BOOST_AUTO_TEST_CASE(test_two_dim_array)
@@ -99,6 +111,9 @@ BOOST_AUTO_TEST_CASE(test_two_dim_array)
 
     BOOST_CHECK(a[0][0].as_string() == std::string("Tenor"));
     BOOST_CHECK_CLOSE(a[2][3].as_double(), -0.005, 0.00000001);
+
+    BOOST_CHECK(a[0][0].as<std::string>() == std::string("Tenor"));
+    BOOST_CHECK_CLOSE(a[2][3].as<double>(), -0.005, 0.00000001);
 }
 
 BOOST_AUTO_TEST_CASE(test_three_dim_array)
@@ -111,5 +126,9 @@ BOOST_AUTO_TEST_CASE(test_three_dim_array)
     BOOST_CHECK(a[0][2][0].as_longlong() == 2);
     BOOST_CHECK(a[0][2][1].as_longlong() == 3);
     BOOST_CHECK(a[3][2][1].as_longlong() == 0);
+
+    BOOST_CHECK(a[0][2][0].as<long long>() == 2);
+    BOOST_CHECK(a[0][2][1].as<long long>() == 3);
+    BOOST_CHECK(a[3][2][1].as<long long>() == 0);
 }
 

--- a/test_suite/src/json_object_tests.cpp
+++ b/test_suite/src/json_object_tests.cpp
@@ -35,6 +35,7 @@ BOOST_AUTO_TEST_CASE(test_empty_object)
     json a;
     BOOST_CHECK(a.size() == 0);
     BOOST_CHECK(a.is_object());
+    BOOST_CHECK(a.is<json::object_type>());
 
     json::object_iterator begin = a.begin_members();
     json::object_iterator end = a.end_members();
@@ -47,6 +48,7 @@ BOOST_AUTO_TEST_CASE(test_empty_object)
     a["key"] = "Hello";
     BOOST_CHECK(a.size() == 1);
     BOOST_CHECK(a.is_object());
+    BOOST_CHECK(a.is<json::object_type>());
 }
 
 BOOST_AUTO_TEST_CASE(test_const_empty_object)
@@ -54,6 +56,7 @@ BOOST_AUTO_TEST_CASE(test_const_empty_object)
     const json b;
     BOOST_CHECK(b.size() == 0);
     BOOST_CHECK(b.is_object());
+    BOOST_CHECK(b.is<json::object_type>());
 
     json::const_object_iterator begin = b.begin_members();
     json::const_object_iterator end = b.end_members();
@@ -69,11 +72,13 @@ BOOST_AUTO_TEST_CASE(test_empty_object_reserve)
     json c;
     BOOST_CHECK(c.size() == 0);
     BOOST_CHECK(c.is_object());
+    BOOST_CHECK(c.is<json::object_type>());
     c.reserve(100);
     BOOST_CHECK(c.capacity() == 100);
     c["key"] = "Hello";
     BOOST_CHECK(c.size() == 1);
     BOOST_CHECK(c.is_object());
+    BOOST_CHECK(c.is<json::object_type>());
     BOOST_CHECK(c.capacity() == 100);
 }
 
@@ -82,10 +87,12 @@ BOOST_AUTO_TEST_CASE(test_empty_object_copy)
     json a;
     BOOST_CHECK(a.size() == 0);
     BOOST_CHECK(a.is_object());
+    BOOST_CHECK(a.is<json::object_type>());
 
     json b = a;
     BOOST_CHECK(b.size() == 0);
     BOOST_CHECK(b.is_object());
+    BOOST_CHECK(b.is<json::object_type>());
 }
 
 BOOST_AUTO_TEST_CASE(test_empty_object_assignment)
@@ -93,23 +100,28 @@ BOOST_AUTO_TEST_CASE(test_empty_object_assignment)
     json a;
     BOOST_CHECK(a.size() == 0);
     BOOST_CHECK(a.is_object());
+    BOOST_CHECK(a.is<json::object_type>());
 
     json b = json::make_array(10);
     BOOST_CHECK(b.size() == 10);
     BOOST_CHECK(b.is_array());
+    BOOST_CHECK(b.is<json::array_type>());
 
     b = a;  
     BOOST_CHECK(b.size() == 0);
     BOOST_CHECK(b.is_object());
+    BOOST_CHECK(b.is<json::object_type>());
 
     json c;
     c["key"] = "value";
     BOOST_CHECK(c.size() == 1);
     BOOST_CHECK(c.is_object());
+    BOOST_CHECK(c.is<json::object_type>());
 
     c = a;
     BOOST_CHECK(c.size() == 0);
     BOOST_CHECK(c.is_object());
+    BOOST_CHECK(c.is<json::object_type>());
 }
 
 BOOST_AUTO_TEST_CASE(test_get)

--- a/test_suite/src/jsoncons_test.cpp
+++ b/test_suite/src/jsoncons_test.cpp
@@ -30,12 +30,15 @@ BOOST_AUTO_TEST_CASE( test1 )
 
     json root = json::parse(is);
     BOOST_CHECK(root.is_object());
+    BOOST_CHECK(root.is<json::object_type>());
 
     root["double_1"] = json(10.0);
 
     json double_1 = root["double_1"];
 
     BOOST_CHECK_CLOSE(double_1.as_double(), 10.0, 0.000001);
+
+    BOOST_CHECK_CLOSE(double_1.as<double>(), 10.0, 0.000001);
 
     json copy = root;
 }
@@ -64,6 +67,10 @@ BOOST_AUTO_TEST_CASE(test_assignment)
     BOOST_CHECK(root["myobject"]["bool_2"].as_bool());
     BOOST_CHECK(root["myobject"]["int_2"].as_longlong() == 0);
     BOOST_CHECK(root["myobject"]["string_2"].as_string() == std::string("my string"));
+
+    BOOST_CHECK(root["myobject"]["bool_2"].as<bool>());
+    BOOST_CHECK(root["myobject"]["int_2"].as<long long>() == 0);
+    BOOST_CHECK(root["myobject"]["string_2"].as<std::string>() == std::string("my string"));
 
 	//std::cout << root << std::endl;
 
@@ -150,6 +157,14 @@ BOOST_AUTO_TEST_CASE(test_to_string)
     BOOST_CHECK(root["neg-integer"].as_int() == -87654321);
     BOOST_CHECK_CLOSE(root["double"].as_double(), 123456.01, 0.0000001);
     BOOST_CHECK(root["escaped-string"].as_string() == std::string("\\\n"));
+    
+    BOOST_CHECK(!root["bool1"].as<bool>());
+    BOOST_CHECK(root["bool2"].as<bool>());
+    BOOST_CHECK(root["integer"].as<int>() == 12345678);
+    BOOST_CHECK(root["integer"].as<unsigned int>() == 12345678);
+    BOOST_CHECK(root["neg-integer"].as<int>() == -87654321);
+    BOOST_CHECK_CLOSE(root["double"].as<double>(), 123456.01, 0.0000001);
+    BOOST_CHECK(root["escaped-string"].as<std::string>() == std::string("\\\n"));
 }
 
 BOOST_AUTO_TEST_CASE(test_serialize)
@@ -524,6 +539,7 @@ BOOST_AUTO_TEST_CASE(test_multiline_comments)
 {
     json obj = json::parse_file("input/json-multiline-comment.json");
     BOOST_CHECK(obj.is_array());
+    BOOST_CHECK(obj.is<json::array_type>());
     BOOST_CHECK_EQUAL(obj.size(),0);
 }
 


### PR DESCRIPTION
...f templates

This change is a proposition to extend basic_json class, as well as support ones (const_val_proxy and object_key_proxy), with two template methods enabling dynamic type handling. This extension is useful in case of usage of json as part of some other template.

To check current type of json object:
template<typename T>
bool basic_json<Char>::is<T> ();

types basic_json<Char>::object_type and basic_json<Char>::array_type are added to enable usage of method is<> with specific json objects.

To retrieve types value from json object:
template<typename T>
T basic_json<Char>::as<T> ();
