### PR TITLE
cmake files for compîlation

### DIFF
--- a/build/cmake/Darwin.cmake
+++ b/build/cmake/Darwin.cmake
@@ -1,0 +1,7 @@
+#
+# Global Configuration for MacOS platform
+#
+
+# customize compiler flags
+## Add new flags
+add_definitions (-std=c++11 -stdlib=libc++)

--- a/build/cmake/Linux.cmake
+++ b/build/cmake/Linux.cmake
@@ -1,0 +1,15 @@
+#
+# Global Configuration for linux platform
+#
+
+#
+# GNU libstdc++ runtime is not supported because not yet C++11 compliant
+#
+
+# customize compiler flags
+## Add new flags
+add_definitions (-std=c++11 -stdlib=libc++ -pthread)
+
+set (CMAKE_SHARED_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -stdlib=libc++ -pthread")
+set (CMAKE_MODULE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -stdlib=libc++ -pthread")
+set (CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -stdlib=libc++ -pthread")

--- a/build/cmake/Windows.cmake
+++ b/build/cmake/Windows.cmake
@@ -1,0 +1,6 @@
+#
+# Global Configuration for windows platform
+#
+
+# define some preprocessor flags
+add_definitions (/DWIN32_LEAN_AND_MEAN /D_UNICODE /DUNICODE)

--- a/build/cmake/config.cmake
+++ b/build/cmake/config.cmake
@@ -1,0 +1,10 @@
+
+# set compiler on some platforms
+if (UNIX)
+  if (NOT CMAKE_C_COMPILER)
+	set (CMAKE_C_COMPILER clang)
+  endif()
+  if (NOT CMAKE_CXX_COMPILER)
+	set (CMAKE_CXX_COMPILER clang++)
+  endif()
+endif()

--- a/examples/build/cmake/CMakeLists.txt
+++ b/examples/build/cmake/CMakeLists.txt
@@ -1,0 +1,28 @@
+
+#
+# jsoncons examples CMake file
+#
+
+cmake_minimum_required (VERSION 2.8)
+
+# load global config
+include (../../../build/cmake/config.cmake)
+
+
+project (Examples CXX)
+
+# load per-platform configuration
+include (../../../build/cmake/${CMAKE_SYSTEM_NAME}.cmake)
+
+include_directories (../../src
+                     ../../../src)
+
+add_executable (jsoncons_examples ../../src/array_examples.cpp
+                                  ../../src/csv_examples.cpp
+                                  ../../src/custom_data_examples.cpp
+                                  ../../src/examples.cpp)
+
+# special link option on Linux because llvm stl rely on GNU stl
+if (${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
+  target_link_libraries (jsoncons_examples -Wl,-lstdc++)
+endif()

--- a/test_suite/build/cmake/CMakeLists.txt
+++ b/test_suite/build/cmake/CMakeLists.txt
@@ -1,0 +1,45 @@
+
+#
+# jsoncons tests suite CMake file
+#
+
+cmake_minimum_required (VERSION 2.8)
+
+# load global config
+include (../../../build/cmake/config.cmake)
+
+
+project (Tests CXX)
+
+# load per-platform configuration
+include (../../../build/cmake/${CMAKE_SYSTEM_NAME}.cmake)
+
+
+set (Boost_NO_BOOST_CMAKE ON)
+find_package (Boost REQUIRED COMPONENTS unit_test_framework)
+
+add_executable (jsoncons_tests ../../src/csv_tests.cpp
+                               ../../src/double_to_string_tests.cpp
+                               ../../src/json_accessor_tests.cpp
+                               ../../src/json_array_tests.cpp
+                               ../../src/json_construction_tests.cpp
+                               ../../src/json_equals_tests.cpp
+                               ../../src/json_object_tests.cpp
+                               ../../src/json_parser_test.cpp
+                               ../../src/json_reader_exception_tests.cpp
+                               ../../src/json_serializer_tests.cpp
+                               ../../src/jsoncons_test.cpp
+                               ../../src/string_to_double_tests.cpp)
+
+target_compile_definitions (jsoncons_tests PUBLIC BOOST_DYN_LINK BOOST_TEST_DYN_LINK)
+
+target_include_directories (jsoncons_tests PUBLIC ${Boost_INCLUDE_DIRS}
+                                           PUBLIC ../../../src
+                                           PRIVATE ../../src)
+
+target_link_libraries (jsoncons_tests ${Boost_LIBRARIES})
+
+# special link option on Linux because llvm stl rely on GNU stl
+if (${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
+  target_link_libraries (jsoncons_tests -Wl,-lstdc++)
+endif()

--- a/test_suite/src/json_accessor_tests.cpp
+++ b/test_suite/src/json_accessor_tests.cpp
@@ -34,7 +34,7 @@ BOOST_AUTO_TEST_CASE(test_as)
     int ushort_val = obj["field2"].as<unsigned short>();
     BOOST_CHECK_EQUAL(ushort_val,static_cast<unsigned short>(1));
     char char_val = obj["field2"].as<char>();
-    BOOST_CHECK_EQUAL(char_val,char(1));
+    BOOST_CHECK_EQUAL(int(char_val),1);
 
     json parent;
     parent["child"] = obj;


### PR DESCRIPTION
Hi Daniel,

here is the infrastructure to compile examples, as well as test_suite, on all platforms. For that purpose, I rely on cmake free tool (http://www.cmake.org).
CMake is able to generate vcproj on windows as well as GNU makefiles on Unix or Ninja files on all platforms (various other generators are available).

Compilation framework is as follow:
<root>/build/cmake directory contains configuration files
examples/build/cmake/CMakeLists.txt: description for examples compilation
test_suite/build/cmake/CMakeLists.txt: description for tests compilation

To generate makefiles, just set examples/build/cmake or test_suite/build/cmake as current directory and launch, for example, following command:
for Windows, to generate sln/vcproj: cmake -G "Visual Studio 10 Win64"
for Unix, to generate GNU makefiles: cmake -G "Unix Makefiles"

Currently, I validate on Linux using clang 3.3 with llvm C++ library. GNU C++ runtime cannot be used due to incompatibilities with C++11 standard (STL containers are not C++11 compliant).
FYI, I also use jsoncons on MacOS with XCode 5 which rely on clang 3.3 (tests not yet passed).

Marc
