### PR TITLE
Feature/json array

### DIFF
--- a/examples/src/array_examples.cpp
+++ b/examples/src/array_examples.cpp
@@ -113,7 +113,7 @@ void make_1_dimensional_array_2()
 void make_2_dimensional_array()
 {
     std::cout << "2 dimensional array" <<std::endl;
-    json a = json::make_2d_array(3,4,0);
+    json a = json::make_array<2>(3,4,0);
     a[0][0] = "Tenor";
     a[0][1] = "ATM vol";
     a[0][2] = "25-d-MS"; 
@@ -133,7 +133,7 @@ void make_2_dimensional_array()
 void make_3_dimensional_array()
 {
     std::cout << "3 dimensional array" <<std::endl;
-    json a = json::make_3d_array(4,3,2,0);
+    json a = json::make_array<3>(4,3,2,0);
     a[0][2][0] = 2;
     a[0][2][1] = 3;
     std::cout << pretty_print(a) << std::endl;

--- a/src/jsoncons/json1.hpp
+++ b/src/jsoncons/json1.hpp
@@ -8,6 +8,8 @@
 #ifndef JSONCONS_JSON1_HPP
 #define JSONCONS_JSON1_HPP
 
+#include <type_traits>
+
 #include <limits>
 #include <string>
 #include <vector>
@@ -724,11 +726,41 @@ public:
 
     static basic_json parse_file(const std::string& s);
 
-    static basic_json make_array();
-
-    static basic_json make_array(size_t n);
-
-    static basic_json make_array(size_t n, const basic_json<C>& val);
+    template<int size=1>
+    static typename std::enable_if<size==1,basic_json>::type make_array()
+    {
+        return build_array<C,size>()();
+    }
+    template<int size=1>
+    static typename std::enable_if<size==1,basic_json>::type make_array(size_t n)
+    {
+        return build_array<C,size>()(n);
+    }
+    template<int size=1>
+    static typename std::enable_if<size==1,basic_json>::type make_array(size_t n, const basic_json<C>& val)
+    {
+        return build_array<C,size>()(n, val);
+    }
+    template<int size>
+    static typename std::enable_if<size==2,basic_json>::type make_array(size_t m, size_t n)
+    {
+        return build_array<C,size>()(m, n);
+    }
+    template<int size>
+    static typename std::enable_if<size==2,basic_json>::type make_array(size_t m, size_t n, const basic_json<C>& val)
+    {
+        return build_array<C,size>()(m, n, val);
+    }
+    template<int size>
+    static typename std::enable_if<size==3,basic_json>::type make_array(size_t m, size_t n, size_t k)
+    {
+        return build_array<C,size>()(m, n, k);
+    }
+    template<int size>
+    static typename std::enable_if<size==3,basic_json>::type make_array(size_t m, size_t n, size_t k, const basic_json<C>& val)
+    {
+        return build_array<C,size>()(m, n, k, val);
+    }
 
     static basic_json make_2d_array(size_t m, size_t n);
 
@@ -1175,11 +1207,11 @@ private:
         return type_ == custom_t;
     }
 
-    template<typename C, typename T>
+    template<typename Char, typename T>
     class as_value
     {
     public:
-        as_value (const basic_json<C>& value) : value_(value)
+        as_value (const basic_json<Char>& value) : value_(value)
         {}
 
         T get () const
@@ -1252,7 +1284,54 @@ private:
         }
 
     private:
-        const basic_json<C>& value_;
+        const basic_json<Char>& value_;
+    };
+
+    template<typename Char, size_t size>
+    class build_array
+    {};
+    template<typename Char>
+    class build_array<Char,1>
+    {
+    public:
+        basic_json<Char> operator() ()
+        {
+            return basic_json<Char>(new json_array<Char>());
+        }
+        basic_json<Char> operator() (size_t n)
+        {
+            return basic_json<Char>(new json_array<Char>(n));
+        }
+        basic_json<Char> operator() (size_t n, const basic_json<Char>& val)
+        {
+            return basic_json<Char>(new json_array<Char>(n,val));
+        }
+    };
+    template<typename Char>
+    class build_array<Char,2>
+    {
+    public:
+        basic_json<Char> operator() (size_t m, size_t n)
+        {
+            return basic_json<Char>::make_2d_array (m, n);
+        }
+        basic_json<Char> operator() (size_t m, size_t n, const basic_json<Char>& val)
+        {
+            return basic_json<Char>::make_2d_array (m, n, val);
+        }
+    };
+    template<typename Char>
+    class build_array<Char,3>
+    {
+    public:
+        basic_json<Char> operator() (size_t m, size_t n, size_t k)
+        {
+            return basic_json<Char>::make_3d_array (m, n, k);
+        }
+        basic_json<C> operator() (size_t m, size_t n, size_t k, const basic_json<Char>& val)
+        {
+            return basic_json<Char>::make_3d_array (m, n, k, val);
+        }
     };
 
 	value_type type_;

--- a/src/jsoncons/json2.hpp
+++ b/src/jsoncons/json2.hpp
@@ -952,30 +952,12 @@ template <class C>
 const basic_json<C> basic_json<C>::null = basic_json<C>(basic_json<C>::null_t);
 
 template <class C> 
-basic_json<C> basic_json<C>::make_array()
-{
-    return basic_json<C>(new json_array<C>());
-}
-
-template <class C> 
-basic_json<C> basic_json<C>::make_array(size_t n)
-{
-    return basic_json<C>(new json_array<C>(n));
-}
-
-template <class C> 
-basic_json<C> basic_json<C>::make_array(size_t n, const basic_json<C>& val)
-{
-    return basic_json<C>(new json_array<C>(n,val));
-}
-
-template <class C> 
 basic_json<C> basic_json<C>::make_2d_array(size_t m, size_t n)
 {
     basic_json<C> a(basic_json<C>(new json_array<C>(m)));
     for (size_t i = 0; i < a.size(); ++i)
     {
-        a[i] = basic_json<C>::make_array(n);
+        a[i] = basic_json<C>::make_array<1>(n);
     }
     return a;
 }
@@ -986,7 +968,7 @@ basic_json<C> basic_json<C>::make_2d_array(size_t m, size_t n, const basic_json<
     basic_json<C> a(basic_json<C>(new json_array<C>(m)));
     for (size_t i = 0; i < a.size(); ++i)
     {
-        a[i] = basic_json<C>::make_array(n,val);
+        a[i] = basic_json<C>::make_array<1>(n,val);
     }
     return a;
 }

--- a/test_suite/src/json_array_tests.cpp
+++ b/test_suite/src/json_array_tests.cpp
@@ -94,7 +94,7 @@ BOOST_AUTO_TEST_CASE(test_one_dim_array)
 
 BOOST_AUTO_TEST_CASE(test_two_dim_array)
 {
-    json a = json::make_2d_array(3,4,0);
+    json a = json::make_array<2>(3,4,0);
     BOOST_CHECK(a.size() == 3);
     a[0][0] = "Tenor";
     a[0][1] = "ATM vol";
@@ -118,7 +118,7 @@ BOOST_AUTO_TEST_CASE(test_two_dim_array)
 
 BOOST_AUTO_TEST_CASE(test_three_dim_array)
 {
-    json a = json::make_3d_array(4,3,2,0);
+    json a = json::make_array<3>(4,3,2,0);
     BOOST_CHECK(a.size() == 4);
     a[0][2][0] = 2;
 	a[0][2][1] = 3;


### PR DESCRIPTION
Hi Daniel,

this pull request includes two things:
- Changes template name from C to Char for internal class as_value because clang does not like template name parameter re-use (clash error)!
- make_array is now a template method taking, as parameter, number of dimensions. this template parameter has 1 for default value so make_array without any template argument continue to be usable.
  To avoid any potential ambiguity with overloaded make_array methods, I rely on meta-programming (coming from standard header type_traits).
  relying on template parameter enables to have a uniform way to create arrays: all arrays are created using make_array.

Marc
