### PR TITLE
add template method make_array

### DIFF
--- a/examples/src/array_examples.cpp
+++ b/examples/src/array_examples.cpp
@@ -94,7 +94,7 @@ void make_empty_array()
 void make_1_dimensional_array_1()
 {
     std::cout << "1 dimensional array 1" <<std::endl;
-    json a = json::make_array();
+    json a = json::make_array<1>();
     a.resize_array(10,0);
     a[1] = 1;
     a[2] = 2;
@@ -104,7 +104,7 @@ void make_1_dimensional_array_1()
 void make_1_dimensional_array_2()
 { 
     std::cout << "1 dimensional array 2" <<std::endl;
-    json a = json::make_array(10,0);
+    json a = json::make_array<1>(10,0);
     a[1] = 1;
     a[2] = 2;
     std::cout << pretty_print(a) << std::endl;
@@ -113,7 +113,7 @@ void make_1_dimensional_array_2()
 void make_2_dimensional_array()
 {
     std::cout << "2 dimensional array" <<std::endl;
-    json a = json::make_2d_array(3,4,0);
+    json a = json::make_array<2>(3,4,0);
     a[0][0] = "Tenor";
     a[0][1] = "ATM vol";
     a[0][2] = "25-d-MS"; 
@@ -133,7 +133,7 @@ void make_2_dimensional_array()
 void make_3_dimensional_array()
 {
     std::cout << "3 dimensional array" <<std::endl;
-    json a = json::make_3d_array(4,3,2,0);
+    json a = json::make_array<3>(4,3,2,0);
     a[0][2][0] = 2;
     a[0][2][1] = 3;
     std::cout << pretty_print(a) << std::endl;

--- a/src/jsoncons/json1.hpp
+++ b/src/jsoncons/json1.hpp
@@ -724,6 +724,42 @@ public:
 
     static basic_json parse_file(const std::string& s);
 
+    template<int size>
+    static typename std::enable_if<size==1,basic_json>::type make_array()
+    {
+        return build_array<C,size>()();
+    }
+    template<int size>
+    static typename std::enable_if<size==1,basic_json>::type make_array(size_t n)
+    {
+        return build_array<C,size>()(n);
+    }
+    template<int size>
+    static typename std::enable_if<size==1,basic_json>::type make_array(size_t n, const basic_json<C>& val)
+    {
+        return build_array<C,size>()(n, val);
+    }
+    template<int size>
+    static typename std::enable_if<size==2,basic_json>::type make_array(size_t m, size_t n)
+    {
+        return build_array<C,size>()(m, n);
+    }
+    template<int size>
+    static typename std::enable_if<size==2,basic_json>::type make_array(size_t m, size_t n, const basic_json<C>& val)
+    {
+        return build_array<C,size>()(m, n, val);
+    }
+    template<int size>
+    static typename std::enable_if<size==3,basic_json>::type make_array(size_t m, size_t n, size_t k)
+    {
+        return build_array<C,size>()(m, n, k);
+    }
+    template<int size>
+    static typename std::enable_if<size==3,basic_json>::type make_array(size_t m, size_t n, size_t k, const basic_json<C>& val)
+    {
+        return build_array<C,size>()(m, n, k, val);
+    }
+
     static basic_json make_array();
 
     static basic_json make_array(size_t n);
@@ -1253,6 +1289,53 @@ private:
 
     private:
         const basic_json<C>& value_;
+    };
+
+    template<typename Char, size_t size>
+    class build_array
+    {};
+    template<typename Char>
+    class build_array<Char,1>
+    {
+    public:
+        basic_json<Char> operator() ()
+        {
+            return basic_json<Char>::make_array();
+        }
+        basic_json<Char> operator() (size_t n)
+        {
+            return basic_json<Char>::make_array(n);
+        }
+        basic_json<Char> operator() (size_t n, const basic_json<Char>& val)
+        {
+            return basic_json<Char>::make_array(n, val);
+        }
+    };
+    template<typename Char>
+    class build_array<Char,2>
+    {
+    public:
+        basic_json<Char> operator() (size_t m, size_t n)
+        {
+            return basic_json<Char>::make_2d_array(m, n);
+        }
+        basic_json<Char> operator() (size_t m, size_t n, const basic_json<Char>& val)
+        {
+            return basic_json<Char>::make_2d_array(m, n, val);
+        }
+    };
+    template<typename Char>
+    class build_array<Char,3>
+    {
+    public:
+        basic_json<Char> operator() (size_t m, size_t n, size_t k)
+        {
+            return basic_json<Char>::make_3d_array (m, n, k);
+        }
+        basic_json<Char> operator() (size_t m, size_t n, size_t k, const basic_json<Char>& val)
+        {
+            return basic_json<Char>::make_3d_array (m, n, k, val);
+        }
     };
 
 	value_type type_;

--- a/test_suite/src/json_array_tests.cpp
+++ b/test_suite/src/json_array_tests.cpp
@@ -78,7 +78,7 @@ BOOST_AUTO_TEST_CASE(test_reserve_array_capacity)
 
 BOOST_AUTO_TEST_CASE(test_one_dim_array)
 {
-    json a = json::make_array(10,0);
+    json a = json::make_array<1>(10,0);
     BOOST_CHECK(a.size() == 10);
     BOOST_CHECK(a[0].as_longlong() == 0);
     a[1] = 1;
@@ -94,7 +94,7 @@ BOOST_AUTO_TEST_CASE(test_one_dim_array)
 
 BOOST_AUTO_TEST_CASE(test_two_dim_array)
 {
-    json a = json::make_2d_array(3,4,0);
+    json a = json::make_array<2>(3,4,0);
     BOOST_CHECK(a.size() == 3);
     a[0][0] = "Tenor";
     a[0][1] = "ATM vol";
@@ -118,7 +118,7 @@ BOOST_AUTO_TEST_CASE(test_two_dim_array)
 
 BOOST_AUTO_TEST_CASE(test_three_dim_array)
 {
-    json a = json::make_3d_array(4,3,2,0);
+    json a = json::make_array<3>(4,3,2,0);
     BOOST_CHECK(a.size() == 4);
     a[0][2][0] = 2;
 	a[0][2][1] = 3;


### PR DESCRIPTION
New version of make_array<> including support for VS2010.

Nota: Because I rely on specializations of class build_array, it is required to include char type as part of template parameters to ensure compilation with clang.
