### PR TITLE
Gcc is now default compiler on Linux

### DIFF
--- a/build/cmake/Linux.cmake
+++ b/build/cmake/Linux.cmake
@@ -8,8 +8,16 @@
 
 # customize compiler flags
 ## Add new flags
-add_definitions (-std=c++11 -stdlib=libc++ -pthread)
+add_definitions (-std=c++11 -pthread)
+if (${CMAKE_CXX_COMPILER_ID} STREQUAL "Clang")
+  add_definitions (-stdlib=libc++)
+endif()
 
-set (CMAKE_SHARED_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -stdlib=libc++ -pthread")
-set (CMAKE_MODULE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -stdlib=libc++ -pthread")
-set (CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -stdlib=libc++ -pthread")
+set (CMAKE_SHARED_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -pthread")
+set (CMAKE_MODULE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -pthread")
+set (CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -pthread")
+if (${CMAKE_CXX_COMPILER_ID} STREQUAL "Clang")
+  set (CMAKE_SHARED_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -stdlib=libc++")
+  set (CMAKE_MODULE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -stdlib=libc++")
+  set (CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -stdlib=libc++")
+endif()

--- a/build/cmake/config.cmake
+++ b/build/cmake/config.cmake
@@ -1,9 +1,6 @@
 
 # set compiler on some platforms
-if (UNIX)
-  if (NOT CMAKE_C_COMPILER)
-	set (CMAKE_C_COMPILER clang)
-  endif()
+if (APPLE)
   if (NOT CMAKE_CXX_COMPILER)
 	set (CMAKE_CXX_COMPILER clang++)
   endif()

--- a/examples/build/cmake/CMakeLists.txt
+++ b/examples/build/cmake/CMakeLists.txt
@@ -22,7 +22,7 @@ add_executable (jsoncons_examples ../../src/array_examples.cpp
                                   ../../src/custom_data_examples.cpp
                                   ../../src/examples.cpp)
 
-# special link option on Linux because llvm stl rely on GNU stl
-if (${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
+if (${CMAKE_SYSTEM_NAME} STREQUAL "Linux" AND ${CMAKE_CXX_COMPILER_ID} STREQUAL "Clang")
+  # special link option on Linux because llvm stl rely on GNU stl
   target_link_libraries (jsoncons_examples -Wl,-lstdc++)
 endif()

--- a/test_suite/build/cmake/CMakeLists.txt
+++ b/test_suite/build/cmake/CMakeLists.txt
@@ -39,7 +39,7 @@ target_include_directories (jsoncons_tests PUBLIC ${Boost_INCLUDE_DIRS}
 
 target_link_libraries (jsoncons_tests ${Boost_LIBRARIES})
 
-# special link option on Linux because llvm stl rely on GNU stl
-if (${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
+if (${CMAKE_SYSTEM_NAME} STREQUAL "Linux" AND ${CMAKE_CXX_COMPILER_ID} STREQUAL "Clang")
+  # special link option on Linux because llvm stl rely on GNU stl
   target_link_libraries (jsoncons_tests -Wl,-lstdc++)
 endif()


### PR DESCRIPTION
Hi Daniel,

small pull-request to change default compiler on Linux: gcc is used as default compiler because it is now supported.

two remarks: 
- In the read-me, it is mentioned "build system for posix systems". I think it is confusing because the build tool (SCons) has nothing to do with posix. What is delivered based on SCons, is limited to posix systems (more precisely to posix systems using gcc as compiler). This is a bit disappointing because SCons is, by design, multi-compilers and multi-platforms (Same as cmake).
- Currently, SCons files organization is different than the other two (vcproj and cmake) which introduce some confusion in my point of view
