### PR TITLE
misc. fixes

### DIFF
--- a/examples/src/wjson_examples.cpp
+++ b/examples/src/wjson_examples.cpp
@@ -3,7 +3,9 @@
 
 #include <string>
 #include <cwchar>
+#ifdef _MSC_VER
 #include <codecvt>
+#endif
 #include "jsoncons/json.hpp"
 
 using jsoncons::json;

--- a/test_suite/build/cmake/CMakeLists.txt
+++ b/test_suite/build/cmake/CMakeLists.txt
@@ -32,7 +32,7 @@ add_executable (jsoncons_tests ../../src/csv_tests.cpp
                                ../../src/jsoncons_test.cpp
                                ../../src/string_to_double_tests.cpp
                                ../../src/unicode_tests.cpp
-                               ../../src/wjson_test.cpp)
+                               ../../src/wjson_tests.cpp)
 
 target_compile_definitions (jsoncons_tests PUBLIC BOOST_ALL_DYN_LINK)
 

--- a/test_suite/src/unicode_tests.cpp
+++ b/test_suite/src/unicode_tests.cpp
@@ -14,7 +14,6 @@
 #include <utility>
 #include <ctime>
 #include "my_custom_data.hpp"
-#include <codecvt>
 
 using jsoncons::parsing_context;
 using jsoncons::json_serializer;

--- a/test_suite/src/wjson_tests.cpp
+++ b/test_suite/src/wjson_tests.cpp
@@ -14,7 +14,6 @@
 #include <utility>
 #include <ctime>
 #include "my_custom_data.hpp"
-#include <codecvt>
 
 using jsoncons::parsing_context;
 using jsoncons::json_serializer;


### PR DESCRIPTION
fix various misc. problems.
Big one is the fact that gcc 4.8 does not have <codecvt> header.
