### PR TITLE
JSONCONS_ASSERT uses std::cerr, so include <iostream>.

### DIFF
--- a/src/jsoncons/jsoncons.hpp
+++ b/src/jsoncons/jsoncons.hpp
@@ -15,6 +15,7 @@
 #include <cstdlib>
 #include <cwchar>
 #include <cstdint> 
+#include <iostream>
 #include "jsoncons/jsoncons_config.hpp"
 
 namespace jsoncons {


### PR DESCRIPTION
Easily seen by adding jsoncons.hpp as the first include in a bare-bones cpp.
