### PR TITLE
Silence compiler warnings for unused variables

### DIFF
--- a/src/jsoncons/error_handler.hpp
+++ b/src/jsoncons/error_handler.hpp
@@ -110,19 +110,19 @@ template <typename Char>
 class default_basic_error_handler : public basic_error_handler<Char>
 {
 public:
-    virtual void warning(const std::string& error_code,
-                         const std::string& message,
-                         const basic_parsing_context<Char>& context) throw (json_parse_exception)
+    virtual void warning(const std::string&,
+                         const std::string&,
+                         const basic_parsing_context<Char>&) throw (json_parse_exception)
     {
         // Do nothing
     }
-    virtual void error(const std::string& error_code,
+    virtual void error(const std::string&,
                        const std::string& message,
                        const basic_parsing_context<Char>& context) throw (json_parse_exception)
     {
         throw json_parse_exception(message,context.line_number(),context.column_number());
     }
-    virtual void fatal_error(const std::string& error_code,
+    virtual void fatal_error(const std::string&,
                              const std::string& message,
                              const basic_parsing_context<Char>& context) throw (json_parse_exception)
     {

--- a/src/jsoncons/json1.hpp
+++ b/src/jsoncons/json1.hpp
@@ -27,7 +27,7 @@ struct storage
 };
 
 template <typename Char,class T> inline
-void serialize(basic_json_output_handler<Char>& os, const T& val)
+void serialize(basic_json_output_handler<Char>& os, const T&)
 {
     os.null_value();
 }
@@ -87,7 +87,7 @@ template <typename Char, typename Storage, typename T>
 class value_adapter
 {
 public:
-    bool is(const basic_json<Char,Storage>& val) const
+    bool is(const basic_json<Char,Storage>&) const
     {
         return false;
     }

--- a/src/jsoncons/json2.hpp
+++ b/src/jsoncons/json2.hpp
@@ -1578,7 +1578,7 @@ template <typename Char,typename Storage>
 class value_adapter<Char,Storage,basic_json<Char,Storage>>
 {
 public:
-    bool is(const basic_json<Char,Storage>& val) const
+    bool is(const basic_json<Char,Storage>&) const
     {
         return true;
     }

--- a/src/jsoncons/json_deserializer.hpp
+++ b/src/jsoncons/json_deserializer.hpp
@@ -103,7 +103,7 @@ public:
         stack_.push_back(stack_item(true,context.minimum_structure_capacity()));
     }
 
-    virtual void end_object(const basic_parsing_context<Char>& context)
+    virtual void end_object(const basic_parsing_context<Char>&)
     {
         stack_.back().object_->sort_members();
         basic_json<Char,Storage> val(stack_.back().release_object());	    
@@ -130,7 +130,7 @@ public:
         stack_.push_back(stack_item(false,context.minimum_structure_capacity()));
     }
 
-    virtual void end_array(const basic_parsing_context<Char>& context)
+    virtual void end_array(const basic_parsing_context<Char>&)
     {
         basic_json<Char,Storage> val(stack_.back().release_array());	    
         stack_.pop_back();
@@ -151,12 +151,12 @@ public:
         }
     }
 
-    virtual void name(const std::basic_string<Char>& name, const basic_parsing_context<Char>& context)
+    virtual void name(const std::basic_string<Char>& name, const basic_parsing_context<Char>&)
     {
         stack_.back().name_ = name;
     }
 
-    virtual void null_value(const basic_parsing_context<Char>& context)
+    virtual void null_value(const basic_parsing_context<Char>&)
     {
         if (stack_.back().is_object())
         {
@@ -175,7 +175,7 @@ public:
 
 // value(...) implementation
 
-    virtual void string_value(const std::basic_string<Char>& value, const basic_parsing_context<Char>& context)
+    virtual void string_value(const std::basic_string<Char>& value, const basic_parsing_context<Char>&)
     {
         if (stack_.back().is_object())
         {
@@ -187,7 +187,7 @@ public:
         }
     }
 
-    virtual void double_value(double value, const basic_parsing_context<Char>& context)
+    virtual void double_value(double value, const basic_parsing_context<Char>&)
     {
         if (stack_.back().is_object())
         {
@@ -199,7 +199,7 @@ public:
         }
     }
 
-    virtual void longlong_value(long long value, const basic_parsing_context<Char>& context)
+    virtual void longlong_value(long long value, const basic_parsing_context<Char>&)
     {
         if (stack_.back().is_object())
         {
@@ -211,7 +211,7 @@ public:
         }
     }
 
-    virtual void ulonglong_value(unsigned long long value, const basic_parsing_context<Char>& context)
+    virtual void ulonglong_value(unsigned long long value, const basic_parsing_context<Char>&)
     {
         if (stack_.back().is_object())
         {
@@ -223,7 +223,7 @@ public:
         }
     }
 
-    virtual void bool_value(bool value, const basic_parsing_context<Char>& context)
+    virtual void bool_value(bool value, const basic_parsing_context<Char>&)
     {
         if (stack_.back().is_object())
         {

--- a/src/jsoncons/json_input_handler.hpp
+++ b/src/jsoncons/json_input_handler.hpp
@@ -117,47 +117,47 @@ public:
     {
     }
 
-    virtual void begin_object(const basic_parsing_context<Char>& context)
+    virtual void begin_object(const basic_parsing_context<Char>&)
     {
     }
 
-    virtual void end_object(const basic_parsing_context<Char>& context)
+    virtual void end_object(const basic_parsing_context<Char>&)
     {
     }
 
-    virtual void begin_array(const basic_parsing_context<Char>& context)
+    virtual void begin_array(const basic_parsing_context<Char>&)
     {
     }
 
-    virtual void end_array(const basic_parsing_context<Char>& context)
+    virtual void end_array(const basic_parsing_context<Char>&)
     {
     }
 
-    virtual void name(const std::basic_string<Char>& name, const basic_parsing_context<Char>& context)
+    virtual void name(const std::basic_string<Char>&, const basic_parsing_context<Char>&)
     {
     }
 
-    virtual void null_value(const basic_parsing_context<Char>& context)
+    virtual void null_value(const basic_parsing_context<Char>&)
     {
     }
 // value(...) implementation
-    virtual void string_value(const std::basic_string<Char>& value, const basic_parsing_context<Char>& context)
+    virtual void string_value(const std::basic_string<Char>&, const basic_parsing_context<Char>&)
     {
     }
 
-    virtual void double_value(double value, const basic_parsing_context<Char>& context)
+    virtual void double_value(double, const basic_parsing_context<Char>&)
     {
     }
 
-    virtual void longlong_value(long long value, const basic_parsing_context<Char>& context)
+    virtual void longlong_value(long long, const basic_parsing_context<Char>&)
     {
     }
 
-    virtual void ulonglong_value(unsigned long long value, const basic_parsing_context<Char>& context)
+    virtual void ulonglong_value(unsigned long long, const basic_parsing_context<Char>&)
     {
     }
 
-    virtual void bool_value(bool value, const basic_parsing_context<Char>& context)
+    virtual void bool_value(bool, const basic_parsing_context<Char>&)
     {
     }
 };

--- a/src/jsoncons/json_output_handler.hpp
+++ b/src/jsoncons/json_output_handler.hpp
@@ -118,7 +118,7 @@ public:
     {
     }
 
-    virtual void name(const std::basic_string<Char>& name)
+    virtual void name(const std::basic_string<Char>&)
     {
     }
 
@@ -144,23 +144,23 @@ public:
 
 // value(...) implementation
 
-    virtual void string_value(const std::basic_string<Char>& value)
+    virtual void string_value(const std::basic_string<Char>&)
     {
     }
 
-    virtual void double_value(double value)
+    virtual void double_value(double)
     {
     }
 
-    virtual void longlong_value(long long value)
+    virtual void longlong_value(long long)
     {
     }
 
-    virtual void ulonglong_value(unsigned long long value)
+    virtual void ulonglong_value(unsigned long long)
     {
     }
 
-    virtual void bool_value(bool value)
+    virtual void bool_value(bool)
     {
     }
 

--- a/src/jsoncons/jsoncons.hpp
+++ b/src/jsoncons/jsoncons.hpp
@@ -111,7 +111,7 @@ struct json_char_traits<char,1>
 
     static const std::string true_literal() {return "true";};
 
-    static uint32_t convert_char_to_codepoint(std::string::const_iterator& it, std::string::const_iterator end)
+    static uint32_t convert_char_to_codepoint(std::string::const_iterator& it, std::string::const_iterator)
     {
         char c = *it;
         uint32_t u(c >= 0 ? c : 256 + c );
@@ -214,7 +214,7 @@ struct json_char_traits<wchar_t,2> // assume utf16
         }
     }
 
-    static uint32_t convert_char_to_codepoint(std::wstring::const_iterator& it, std::wstring::const_iterator end)
+    static uint32_t convert_char_to_codepoint(std::wstring::const_iterator& it, std::wstring::const_iterator)
     {
         uint32_t cp = (0xffff & *it);
         if ((cp >= min_lead_surrogate && cp <= max_lead_surrogate)) // surrogate pair
@@ -257,7 +257,7 @@ struct json_char_traits<wchar_t,4> // assume utf32
         }
     }
 
-    static uint32_t convert_char_to_codepoint(std::wstring::const_iterator& it, std::wstring::const_iterator end)
+    static uint32_t convert_char_to_codepoint(std::wstring::const_iterator& it, std::wstring::const_iterator)
     {
         uint32_t cp = static_cast<uint32_t>(*it);
         return cp;


### PR DESCRIPTION
I like to compile my libs with as many compiler warnings as possible. Sadly, including jsoncons.hpp pulls in lots of new ones. The unfortunate result is that I have to crank down the warnings on my own project.

As for unused args in particular, it helps with for example, variadic templates where some bad copy/paste and a left-out argument wouldn't cause a compile error.

If you're interested in pulling, I'd be happy to submit more cleanups. Using clang's -Weverything is great for finding subtle bugs, especially -Wsign-conversion and friends when dealing with serializing data.
