### PR TITLE
Fixed bug with not escaping reverse solidus...

### DIFF
--- a/src/jsoncons/json2.hpp
+++ b/src/jsoncons/json2.hpp
@@ -1473,7 +1473,7 @@ void escape_string(const std::basic_string<Char>& s,
         switch (c)
         {
         case '\\':
-            os << '\\';
+            os << '\\' <<'\\';
             break;
         case '"':
             os << '\\' << '\"';


### PR DESCRIPTION
I think there was a bug in original library when handling reverse solidus - it should be escaped in order to
conform with json document specification.
