### PR TITLE
Added 'template' to call basic_json::any::cast<T>().

### DIFF
--- a/src/jsoncons/json2.hpp
+++ b/src/jsoncons/json2.hpp
@@ -1376,7 +1376,7 @@ const T& basic_json<Char, Storage>::custom_data() const
     switch (type_)
     {
     case json_any_t:
-			const T& p = value_.any_value_->cast<T>();
+			const T& p = value_.any_value_->template cast<T>();
 			return p;
     default:
         JSONCONS_THROW_EXCEPTION("Not userdata");
@@ -1392,7 +1392,7 @@ T& basic_json<Char, Storage>::custom_data()
     {
     case json_any_t:
         {
-			T& p = value_.any_value_->cast<T>();
+			T& p = value_.any_value_->template cast<T>();
 			return p;
         }
     default:


### PR DESCRIPTION
I fixed the following compile errors with g++ 4.7.2 (Debian 4.7.2-5) and -std=gnu++0x options:

```
jsoncons/src/jsoncons/json2.hpp: In member function ‘const T& jsoncons::basic_json<Char, Storage>::custom_data() const’:
jsoncons/src/jsoncons/json2.hpp:1379:42: error: expected primary-expression before ‘>’ token
jsoncons/src/jsoncons/json2.hpp:1379:44: error: expected primary-expression before ‘)’ token
jsoncons/src/jsoncons/json2.hpp: In member function ‘T& jsoncons::basic_json<Char, Storage>::custom_data()’:
jsoncons/src/jsoncons/json2.hpp:1395:36: error: expected primary-expression before ‘>’ token
jsoncons/src/jsoncons/json2.hpp:1395:38: error: expected primary-expression before ‘)’ token
```
