### PR TITLE
JSON_ASSERT shouldn't use 'cerr', use exception instead

### DIFF
--- a/src/jsoncons/jsoncons.hpp
+++ b/src/jsoncons/jsoncons.hpp
@@ -79,9 +79,14 @@ private:
     char message_[255];
 };
 
+#define JSONCONS_STR2(x)  #x
+#define JSONCONS_STR(x)  JSONCONS_STR2(x)
+
 #define JSONCONS_THROW_EXCEPTION(x) throw jsoncons::json_exception_0((x))
 #define JSONCONS_THROW_EXCEPTION_1(fmt,arg1) throw jsoncons::json_exception_1<Char>((fmt),(arg1))
-#define JSONCONS_ASSERT(x) if (!(x)) {std::cerr << #x; abort();}
+#define JSONCONS_ASSERT(x) if (!(x)) { \
+	throw jsoncons::json_exception_0("assertion '" #x "' failed at " __FILE__ ":" \
+			JSONCONS_STR(__LINE__)); }
 
 // json_char_traits
 


### PR DESCRIPTION
Change is useful for deamons and produces more information
where assertion happened.
