### PR TITLE
Fixed unused-variable warning in basic_json::parse().

### DIFF
--- a/src/jsoncons/json_reader.hpp
+++ b/src/jsoncons/json_reader.hpp
@@ -499,7 +499,6 @@ void basic_json_reader<Char>::parse()
                 }
                 {
                     parse_string();
-                    size_t count1 = 0;
                     if (stack_.back().is_object() & ((stack_.back().state_ == parse_state_type::initial_s) | (stack_.back().state_ == parse_state_type::value_separator_s)))
                     {
                         handler_->name(string_buffer_.c_str(), string_buffer_.length(), *this);


### PR DESCRIPTION
Compiling a code includes `basic_json::parse_string()` with `g++ -Wall -std=gnu++11`, I got "unused variable" warning as follow:

    jsoncons/json_reader.hpp: In instantiation of ‘void jsoncons::basic_json_reader<Char>::parse() [with Char = char]’:
    jsoncons/json_reader.hpp:395:5:   required from ‘void jsoncons::basic_json_reader<Char>::read() [with Char = char]’
    jsoncons/json2.hpp:1105:5:   required from ‘static jsoncons::basic_json<Char, Alloc> jsoncons::basic_json<Char, Alloc>::parse_string(const std::basic_string<_CharT>&) [with Char = char; Alloc = std::allocator<void>]’
    jsoncons/json_reader.hpp:502:28: warning: unused variable ‘count1’ [-Wunused-variable]
