### PR TITLE
Generate parse errors if the top-level value is not object or array.

### DIFF
--- a/src/jsoncons/json_reader.hpp
+++ b/src/jsoncons/json_reader.hpp
@@ -102,6 +102,15 @@ class basic_json_reader : private basic_parsing_context<Char>
             return err;
         }
 
+        int check_sub_value_precondition() const
+        {
+            int err = check_value_precondition();
+    if (!err && is_top()) {
+err = json_parser_errc::expected_container;
+    }
+    return err;
+        }
+
         structure_type::structure_type_t structure_;
         parse_state_type::parse_state_type_t state_;
         size_t minimum_structure_capacity_;
@@ -506,7 +515,7 @@ void basic_json_reader<Char>::parse()
                     }
                     else
                     {
-                        int err = stack_.back().check_value_precondition();
+                        int err = stack_.back().check_sub_value_precondition();
                         if (err != 0)
                         {
                             err_handler_->error(std::error_code(err, json_parser_category()), *this);
@@ -572,7 +581,7 @@ void basic_json_reader<Char>::parse()
                 break;
             case 't':
                 {
-                    int err = stack_.back().check_value_precondition();
+                    int err = stack_.back().check_sub_value_precondition();
                     if (err != 0)
                     {
                         err_handler_->error(std::error_code(err, json_parser_category()), *this);
@@ -590,7 +599,7 @@ void basic_json_reader<Char>::parse()
                 break;
             case 'f':
                 {
-                    int err = stack_.back().check_value_precondition();
+                    int err = stack_.back().check_sub_value_precondition();
                     if (err != 0)
                     {
                         err_handler_->error(std::error_code(err, json_parser_category()), *this);
@@ -607,7 +616,7 @@ void basic_json_reader<Char>::parse()
                 break;
             case 'n':
                 {
-                    int err = stack_.back().check_value_precondition();
+                    int err = stack_.back().check_sub_value_precondition();
                     if (err != 0)
                     {
                         err_handler_->error(std::error_code(err, json_parser_category()), *this);
@@ -634,7 +643,7 @@ void basic_json_reader<Char>::parse()
             case '9':
             case '-':
                 {
-                    int err = stack_.back().check_value_precondition();
+                    int err = stack_.back().check_sub_value_precondition();
                     if (err != 0)
                     {
                         err_handler_->error(std::error_code(err, json_parser_category()), *this);

--- a/src/jsoncons/parse_error_handler.hpp
+++ b/src/jsoncons/parse_error_handler.hpp
@@ -176,7 +176,8 @@ namespace json_parser_errc
         invalid_number,
         unexpected_eof,
         eof_reading_string_value,
-        eof_reading_numeric_value
+        eof_reading_numeric_value,
+expected_container
     };
 }
 
@@ -226,6 +227,8 @@ public:
             return "Reached end of file while reading string value";
         case json_parser_errc::eof_reading_numeric_value:
             return "Reached end of file while reading numeric value";
+case json_parser_errc::expected_container:
+            return "Expected array or object ('[' or '{')";
         default:
             return "Unknown JSON parser error";
         }

--- a/test_suite/src/json_parse_tests.cpp
+++ b/test_suite/src/json_parse_tests.cpp
@@ -93,5 +93,14 @@ BOOST_AUTO_TEST_CASE(test_expected_value)
     test_error_code("[n]", jsoncons::json_parser_errc::expected_value);
 }
 
+BOOST_AUTO_TEST_CASE(test_expected_container)
+{
+    test_error_code("null", jsoncons::json_parser_errc::expected_container);
+    test_error_code("false", jsoncons::json_parser_errc::expected_container);
+    test_error_code("true", jsoncons::json_parser_errc::expected_container);
+    test_error_code("10", jsoncons::json_parser_errc::expected_container);
+    test_error_code("\"string\"", jsoncons::json_parser_errc::expected_container);
+}
+
 
 


### PR DESCRIPTION
Various bits of code assume the top-level value in a JSON string is an
object or an array; however, if this is not the case, it is not caught
as a parse error. This introduces the error code expected_container.

See issue #32.