### PR TITLE
Object equals

### DIFF
--- a/src/jsoncons/json_structures.hpp
+++ b/src/jsoncons/json_structures.hpp
@@ -452,7 +452,7 @@ public:
 
             auto rhs_it = std::lower_bound(rhs.members_.begin(), rhs.members_.end(), *it, member_compare<Char, Alloc>());
             // member_compare actually only compares keys, so we need to check the value separately
-            if (rhs_it == rhs.members_.end() || rhs_it->second != it->second)
+            if (rhs_it == rhs.members_.end() || rhs_it->first != it->first || rhs_it->second != it->second)
             {
                 return false;
             }

--- a/test_suite/src/json_checker_tests.cpp
+++ b/test_suite/src/json_checker_tests.cpp
@@ -11,7 +11,6 @@
 #include <vector>
 #include <utility>
 #include <ctime>
-#include "jsoncons/json_parser.hpp"
 
 using jsoncons::json_deserializer;
 using jsoncons::json;
@@ -21,11 +20,12 @@ using jsoncons::pretty_print;
 using std::string;
 using jsoncons::json_exception;
 using jsoncons::json_parse_exception;
-using jsoncons::json_parser;
 
 using namespace boost::filesystem;
 
-/*BOOST_AUTO_TEST_CASE(test_json_parser)
+/*
+using jsoncons::json_parser;
+BOOST_AUTO_TEST_CASE(test_json_parser)
 {
     std::string in_file = "input/JSON_checker/pass1.json";
     std::ifstream is(in_file);
@@ -36,7 +36,7 @@ using namespace boost::filesystem;
     std::cout << "JSON CHECKER 1" << std::endl;
     json val = std::move(handler.root());
     std::cout << val << std::endl;
-}*/
+}
 
 BOOST_AUTO_TEST_CASE(test_json_parser2)
 {
@@ -54,6 +54,7 @@ BOOST_AUTO_TEST_CASE(test_json_parser2)
     std::cout << jsoncons::pretty_print(val,format) << std::endl;
 
 }
+*/
 
 BOOST_AUTO_TEST_CASE(test_fail1)
 {

--- a/test_suite/src/json_equals_tests.cpp
+++ b/test_suite/src/json_equals_tests.cpp
@@ -15,7 +15,91 @@ using jsoncons::wjson;
 using jsoncons::basic_json_reader;
 using std::string;
 
-BOOST_AUTO_TEST_CASE(test_equals)
+BOOST_AUTO_TEST_CASE(test_object_equals_basic)
 {
+    json o1;
+    o1["a"] = 1;
+    o1["b"] = 2;
+    o1["c"] = 3;
+
+    json o2;
+    o2["c"] = 3;
+    o2["a"] = 1;
+    o2["b"] = 2;
+
+    BOOST_CHECK(o1 == o2);
+    BOOST_CHECK(o2 == o1);
+    BOOST_CHECK(!(o1 != o2));
+    BOOST_CHECK(!(o2 != o1));
 }
+
+BOOST_AUTO_TEST_CASE(test_object_equals_diff_vals)
+{
+    json o1;
+    o1["a"] = 1;
+    o1["b"] = 2;
+    o1["c"] = 3;
+
+    json o2;
+    o2["a"] = 1;
+    o2["b"] = 4;
+    o2["c"] = 3;
+
+    BOOST_CHECK(!(o1 == o2));
+    BOOST_CHECK(!(o2 == o1));
+    BOOST_CHECK(o1 != o2);
+    BOOST_CHECK(o2 != o1);
+}
+
+BOOST_AUTO_TEST_CASE(test_object_equals_diff_el_names)
+{
+    json o1;
+    o1["a"] = 1;
+    o1["b"] = 2;
+    o1["c"] = 3;
+
+    json o2;
+    o2["d"] = 1;
+    o2["e"] = 2;
+    o2["f"] = 3;
+
+    BOOST_CHECK(!(o1 == o2));
+    BOOST_CHECK(!(o2 == o1));
+    BOOST_CHECK(o1 != o2);
+    BOOST_CHECK(o2 != o1);
+}
+
+BOOST_AUTO_TEST_CASE(test_object_equals_diff_sizes)
+{
+    json o1;
+    o1["a"] = 1;
+    o1["b"] = 2;
+    o1["c"] = 3;
+
+    json o2;
+    o2["a"] = 1;
+    o2["b"] = 2;
+
+    BOOST_CHECK(!(o1 == o2));
+    BOOST_CHECK(!(o2 == o1));
+    BOOST_CHECK(o1 != o2);
+    BOOST_CHECK(o2 != o1);
+}
+
+BOOST_AUTO_TEST_CASE(test_object_equals_subtle_offsets)
+{
+    json o1;
+    o1["a"] = 1;
+    o1["b"] = 1;
+
+    json o2;
+    o2["b"] = 1;
+    o2["c"] = 1;
+
+    BOOST_CHECK(!(o1 == o2));
+    BOOST_CHECK(!(o2 == o1));
+    BOOST_CHECK(o1 != o2);
+    BOOST_CHECK(o2 != o1);
+}
+
 


### PR DESCRIPTION
#26 fixed one bug with operator== on json objects, but created another, because I didn't think through the behaviour of std::lower_bound properly.

This pull also includes an unrelated commit that makes the test suite build (did you fail to commit json_parser.hpp?)