### PR TITLE
Fixed the noexcept specification for Visual Studio 2015

### DIFF
--- a/src/jsoncons/jsoncons_config.hpp
+++ b/src/jsoncons/jsoncons_config.hpp
@@ -35,7 +35,7 @@ namespace jsoncons {
 #elif defined(__GNUC__)
 #   define JSONCONS_NOEXCEPT _GLIBCXX_USE_NOEXCEPT
 #elif defined(_MSC_VER)
-#   if _MSC_VER >= 1700
+#   if _MSC_VER >= 1900
 #       define JSONCONS_NOEXCEPT noexcept
 #   else
 #       define JSONCONS_NOEXCEPT

--- a/src/jsoncons/jsoncons_config.hpp
+++ b/src/jsoncons/jsoncons_config.hpp
@@ -34,6 +34,12 @@ namespace jsoncons {
 #   endif
 #elif defined(__GNUC__)
 #   define JSONCONS_NOEXCEPT _GLIBCXX_USE_NOEXCEPT
+#elif defined(_MSC_VER)
+#   if _MSC_VER >= 1700
+#       define JSONCONS_NOEXCEPT noexcept
+#   else
+#       define JSONCONS_NOEXCEPT
+#   endif
 #else
 #   define JSONCONS_NOEXCEPT
 #endif


### PR DESCRIPTION
Visual Studio 2015 added proper noexcept support, as a result the noexcept specification needs to be updated for jsoncons to build without error.