### PR TITLE
carify copy and move semantics of const_val_proxy

### DIFF
--- a/src/jsoncons/json1.hpp
+++ b/src/jsoncons/json1.hpp
@@ -1128,6 +1128,14 @@ public:
     private:
         const_val_proxy(); // no op
         const_val_proxy& operator = (const const_val_proxy& other); // noop
+        const_val_proxy(const const_val_proxy& other)
+          : val2_(other.val2_), val_((&other.val2_ == &other.val_) ? val2_ : other.val_)
+        {
+        }
+        const_val_proxy(const_val_proxy&& other)
+          : val2_(std::move(other.val2_)), val_((&other.val2_ == &other.val_) ? val2_ : other.val_)
+        {
+        }
 
         const_val_proxy(const basic_json<Char,Alloc>& val)
             : val_(val)


### PR DESCRIPTION
related to #49

this is a pretty ugly "solution" but the semantics of `const_val_proxy` are pretty confusing to me.

Didn't run the test-suite on this one, so that the least that should be done.

There's probably a better solution than this but I'm not really familiar with the code-base and so the purpose of this struct sort of eludes me at the moment.