### PR TITLE
GCC 4.8 workaround

### DIFF
--- a/src/jsoncons/json_structures.hpp
+++ b/src/jsoncons/json_structures.hpp
@@ -153,6 +153,20 @@ public:
         elements_.insert(it, std::move(value));
     }
 
+#if defined(__GNUC__) && __GNUC__ == 4 && __GNUC_MINOR__ < 9
+    // work around https://gcc.gnu.org/bugzilla/show_bug.cgi?id=54577
+    iterator add(const_iterator pos, const JsonT& value)
+    {
+        iterator it = elements_.begin() + (pos - elements_.begin());
+        return elements_.insert(it, value);
+    }
+
+    iterator add(const_iterator pos, JsonT&& value)
+    {
+        iterator it = elements_.begin() + (pos - elements_.begin());
+        return elements_.insert(it, std::move(value));
+    }
+#else
     iterator add(const_iterator pos, const JsonT& value)
     {
         return elements_.insert(pos, value);
@@ -162,6 +176,7 @@ public:
     {
         return elements_.insert(pos, std::move(value));
     }
+#endif
 
     iterator begin() {return elements_.begin();}
 


### PR DESCRIPTION
This is a workaround for a [C++11 issue in GCC 4.8](https://gcc.gnu.org/bugzilla/show_bug.cgi?id=54577) (NB: GCC 4.8 is shipped with Ubuntu 14.04 LTS, which is likely to be used by a lot of companies for a little while yet).