### PR TITLE
Allow for broken regex with GCC 4.8 in unit tests

### DIFF
--- a/test_suite/src/jsonpath/jsonpath_filter_tests.cpp
+++ b/test_suite/src/jsonpath/jsonpath_filter_tests.cpp
@@ -164,6 +164,10 @@ BOOST_AUTO_TEST_CASE(test_jsonpath_filter_uni)
     BOOST_CHECK_EQUAL(json(0),result1);
 }
 
+#if defined(__GNUC__) && (__GNUC__ == 4 && __GNUC_MINOR__ < 9)
+// GCC 4.8 has broken regex support: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=53631
+BOOST_AUTO_TEST_CASE_EXPECTED_FAILURES(test_jsonpath_filter_regex, 2)
+#endif
 BOOST_AUTO_TEST_CASE(test_jsonpath_filter_regex)
 {
     size_t line = 1;

--- a/test_suite/src/jsonpath/jsonpath_tests.cpp
+++ b/test_suite/src/jsonpath/jsonpath_tests.cpp
@@ -522,6 +522,10 @@ BOOST_AUTO_TEST_CASE(test_jsonpath_store_book_tests2)
     BOOST_CHECK_EQUAL(expected6,result6);
 }
 
+#if defined(__GNUC__) && (__GNUC__ == 4 && __GNUC_MINOR__ < 9)
+// GCC 4.8 has broken regex support: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=53631
+BOOST_AUTO_TEST_CASE_EXPECTED_FAILURES(test_jsonpath_store_book_regex, 3)
+#endif
 BOOST_AUTO_TEST_CASE(test_jsonpath_store_book_regex)
 {
     json root = json::parse(jsonpath_fixture::store_text());


### PR DESCRIPTION
The tests that depend on <regex> support are marked as expected failures when compiling with GCC 4.8.

This is the "ignore it" approach for #72.