### PR TITLE
Fix compilation errors and warnings by GCC and Clang

### DIFF
--- a/src/jsoncons/json_filter.hpp
+++ b/src/jsoncons/json_filter.hpp
@@ -121,7 +121,7 @@ private:
 
         char do_current_char() const override { return '\0'; }
     };
-    const null_parsing_context default_context_;
+    const null_parsing_context default_context_ = null_parsing_context();
 
     basic_null_json_input_handler<CharT> null_input_handler_;
     basic_json_input_output_adapter<CharT> default_input_output_adapter_;

--- a/src/jsoncons/osequencestream.hpp
+++ b/src/jsoncons/osequencestream.hpp
@@ -212,12 +212,12 @@ private:
 
 public:
     basic_osequencestream() JSONCONS_NOEXCEPT
-        : buf_(),
-          std::basic_ostream<CharT, Traits>( (std::basic_streambuf<CharT, Traits>*)(&buf_))
+        : std::basic_ostream<CharT, Traits>( (std::basic_streambuf<CharT, Traits>*)(&buf_)),
+          buf_()
     {}
     basic_osequencestream(std::size_t length) JSONCONS_NOEXCEPT
-        : buf_(length),
-          std::basic_ostream<CharT, Traits>( (std::basic_streambuf<CharT, Traits>*)(&buf_))
+        : std::basic_ostream<CharT, Traits>( (std::basic_streambuf<CharT, Traits>*)(&buf_)),
+          buf_(length)
     {}
 
     virtual ~basic_osequencestream() JSONCONS_NOEXCEPT 

--- a/src/jsoncons/osequencestream.hpp
+++ b/src/jsoncons/osequencestream.hpp
@@ -73,7 +73,7 @@ public:
         return this->pptr() - this->pbase();
     }
 
-    virtual int sync()
+    virtual int sync() override
     {
         return EOF;
     }

--- a/test_suite/src/json_extensibility_tests.cpp
+++ b/test_suite/src/json_extensibility_tests.cpp
@@ -115,7 +115,7 @@ namespace jsoncons
 
         static Json to_json(const boost::numeric::ublas::matrix<T>& val)
         {
-            Json a = Json::make_array<2>(val.size1(), val.size2(), T());
+            Json a = Json::template make_array<2>(val.size1(), val.size2(), T());
             for (size_t i = 0; i < val.size1(); ++i)
             {
                 for (size_t j = 0; j < val.size1(); ++j)

--- a/test_suite/src/json_type_traits_container_tests.cpp
+++ b/test_suite/src/json_type_traits_container_tests.cpp
@@ -17,6 +17,7 @@
 #include <deque>
 #include <forward_list>
 #include <list>
+#include <array>
 
 using namespace jsoncons;
 using boost::numeric::ublas::matrix;


### PR DESCRIPTION
This allows tests to build without warnings or errors on GCC 6 and Clang 3.8.