### PR TITLE
Add Travis configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,26 @@
+dist: trusty
+sudo: required
+addons:
+  apt:
+    sources:
+      - ubuntu-toolchain-r-test
+    packages:
+      - g++-6
+      - clang-3.8
+      - libc++-dev
+      - cmake
+      - libboost-all-dev
+before_install:
+  - curl -L http://llvm.org/apt/llvm-snapshot.gpg.key | sudo apt-key add -
+  - echo 'deb http://llvm.org/apt/trusty/ llvm-toolchain-trusty-3.8 main' | sudo tee /etc/apt/sources.list
+env:
+  - CC=gcc-6 CXX=g++-6
+  - CC=clang-3.8 CXX=clang++-3.8
+matrix:
+  allow_failures:
+    - env: CC=clang-3.8 CXX=clang++-3.8
+script:
+  - cd test_suite/build/cmake
+  - cmake .
+  - make -j2
+  - ./run_tests.sh


### PR DESCRIPTION
This adds Travis CI configuration. If you wish, you can register on https://travis-ci.org/ and enable CI for this project. It will test if tests compile and run on GCC 6. Clang 3.8 is not finished because Boost on Travis is compiled against `libstdc++`, not `libc++`, so we cannot link tests properly. I've added it nevertheless, but marked it as "allow to fail" -- this way you can still open the build job and see if Clang has any new warnings or errors.