### PR TITLE
Fix std::array to_json() method

### DIFF
--- a/src/jsoncons/json_type_traits.hpp
+++ b/src/jsoncons/json_type_traits.hpp
@@ -639,7 +639,7 @@ struct json_type_traits<Json, std::array<E, N>>
 
     static Json to_json(const std::array<E, N>& value)
     {
-        return J(value.begin(), value.end());
+        return Json(value.begin(), value.end());
     }
 };
 


### PR DESCRIPTION
I've accidentially cherry-picked old broken version of the commit for earlier PR, sorry. This passes tests now: https://travis-ci.org/abbradar/jsoncons