### PR TITLE
Filter objects extension

### DIFF
--- a/src/jsoncons_ext/jsonpath/json_query.hpp
+++ b/src/jsoncons_ext/jsonpath/json_query.hpp
@@ -193,6 +193,13 @@ private:
                     }
                 }
             }
+            else if (context.is_object())
+            {
+                if (result_.exists(context))
+                {
+                    nodes.push_back(std::addressof(context));
+                }
+            }
         }
     };
 


### PR DESCRIPTION
Allows to apply filter expression over a single object. A single object might be considered as one-element array.

For example:
{
    "header": {
        "type": "A"
    }
}

The json-path expression "$.header[?(@.type == 'A')] allows to filter headers of type "A".