### PR TITLE
Fix broken JSONCONS_NO_DEPRECATED

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,12 +15,13 @@ before_install:
   - echo 'deb http://llvm.org/apt/trusty/ llvm-toolchain-trusty-3.8 main' | sudo tee /etc/apt/sources.list
 env:
   - CC=gcc-6 CXX=g++-6
+  - CC=gcc-6 CXX=g++-6 CMAKEFLAGS=-DNO_DEPRECATED=YES
   - CC=clang-3.8 CXX=clang++-3.8
 matrix:
   allow_failures:
     - env: CC=clang-3.8 CXX=clang++-3.8
 script:
   - cd test_suite/build/cmake
-  - cmake .
+  - cmake $CMAKEFLAGS .
   - make -j2
   - ./run_tests.sh

--- a/src/jsoncons/json.hpp
+++ b/src/jsoncons/json.hpp
@@ -2443,8 +2443,6 @@ public:
         dump(serializer);
     }
 
-#if !defined(JSONCONS_NO_DEPRECATED)
-
     string_type to_string(const char_allocator_type& allocator=char_allocator_type()) const JSONCONS_NOEXCEPT
     {
         string_type s(allocator);
@@ -2469,6 +2467,8 @@ public:
         }
         return os.str();
     }
+
+#if !defined(JSONCONS_NO_DEPRECATED)
 
     void write_body(basic_json_output_handler<char_type>& handler) const
     {

--- a/src/jsoncons/unicode_traits.hpp
+++ b/src/jsoncons/unicode_traits.hpp
@@ -236,14 +236,18 @@ is_legal_utf8(Iterator first, size_t length)
     uint8_t a;
     Iterator srcptr = first+length;
     switch (length) {
-    default: return conv_errc::over_long_utf8_sequence;
-        /* Everything else falls through when "true"... */
-    case 4: if (((a = (*--srcptr))& 0xC0) != 0x80) 
-        return conv_errc::expected_continuation_byte;
-    case 3: if (((a = (*--srcptr))& 0xC0) != 0x80) 
-        return conv_errc::expected_continuation_byte;
-    case 2: if (((a = (*--srcptr))& 0xC0) != 0x80) 
-        return conv_errc::expected_continuation_byte;
+    default:
+        return conv_errc::over_long_utf8_sequence;
+    /* Everything else falls through when "true"... */
+    case 4:
+        if (((a = (*--srcptr))& 0xC0) != 0x80)
+            return conv_errc::expected_continuation_byte;
+    case 3:
+        if (((a = (*--srcptr))& 0xC0) != 0x80)
+            return conv_errc::expected_continuation_byte;
+    case 2:
+        if (((a = (*--srcptr))& 0xC0) != 0x80)
+            return conv_errc::expected_continuation_byte;
 
         switch (static_cast<uint8_t>(*first)) 
         {
@@ -255,8 +259,9 @@ is_legal_utf8(Iterator first, size_t length)
             default:   if (a < 0x80) return conv_errc::source_illegal;
         }
 
-    case 1: if (static_cast<uint8_t>(*first) >= 0x80 && static_cast<uint8_t>(*first) < 0xC2) 
-        return conv_errc::source_illegal;
+    case 1:
+        if (static_cast<uint8_t>(*first) >= 0x80 && static_cast<uint8_t>(*first) < 0xC2)
+            return conv_errc::source_illegal;
     }
     if (static_cast<uint8_t>(*first) > 0xF4) 
         return conv_errc::source_illegal;

--- a/test_suite/build/cmake/CMakeLists.txt
+++ b/test_suite/build/cmake/CMakeLists.txt
@@ -37,6 +37,10 @@ elseif()
 target_compile_definitions (jsoncons_tests PUBLIC BOOST_ALL_DYN_LINK)
 endif()
 
+if (NO_DEPRECATED)
+add_definitions(-DJSONCONS_NO_DEPRECATED)
+endif()
+
 target_include_directories (jsoncons_tests PUBLIC ${Boost_INCLUDE_DIRS}
                                            PUBLIC ../../../src
                                            PRIVATE ../../src)


### PR DESCRIPTION
Also enable tests on Travis for this mode so this won't go unnoticed again, and fix style warnings of new GCC (about misleading identation).