### PR TITLE
Fix GCC 7 warnings

### DIFF
--- a/src/jsoncons/json.hpp
+++ b/src/jsoncons/json.hpp
@@ -2317,6 +2317,7 @@ public:
         {
         case value_type::empty_object_t: 
             create_object_implicitly();
+            // FALLTHRU
         case value_type::object_t:
             return json_proxy<json_type>(*this, key_storage_type(name.begin(),name.end(),char_allocator_type(object_value().get_allocator())));
             break;
@@ -3207,6 +3208,7 @@ public:
         {
         case value_type::empty_object_t:
             create_object_implicitly();
+            // FALLTHRU
         case value_type::object_t:
             object_value().set(name, std::forward<T&&>(value));
             break;
@@ -3224,6 +3226,7 @@ public:
         {
         case value_type::empty_object_t:
             create_object_implicitly();
+            // FALLTHRU
         case value_type::object_t:
             object_value().set_(std::forward<key_storage_type&&>(name), std::forward<T&&>(value));
             break;
@@ -3757,6 +3760,7 @@ public:
         {
         case value_type::empty_object_t:
             create_object_implicitly();
+            // FALLTHRU
         case value_type::object_t:
             return var_.object_data_cast()->value();
         default:
@@ -3771,6 +3775,7 @@ public:
         {
         case value_type::empty_object_t:
             const_cast<json_type*>(this)->create_object_implicitly(); // HERE
+            // FALLTHRU
         case value_type::object_t:
             return var_.object_data_cast()->value();
         default:

--- a/src/jsoncons/json_parser.hpp
+++ b/src/jsoncons/json_parser.hpp
@@ -168,12 +168,12 @@ class basic_json_parser : private basic_parsing_context<CharT>
 
     int max_depth_;
     string_to_double<CharT> str_to_double_;
+    uint8_t precision_;
+    size_t literal_index_;
     const CharT* begin_input_;
     const CharT* end_input_;
     const CharT* p_;
     std::pair<const CharT*,size_t> literal_;
-    uint8_t precision_;
-    size_t literal_index_;
 
     // Noncopyable and nonmoveable
     basic_json_parser(const basic_json_parser&) = delete;

--- a/src/jsoncons/unicode_traits.hpp
+++ b/src/jsoncons/unicode_traits.hpp
@@ -238,13 +238,14 @@ is_legal_utf8(Iterator first, size_t length)
     switch (length) {
     default:
         return conv_errc::over_long_utf8_sequence;
-    /* Everything else falls through when "true"... */
     case 4:
         if (((a = (*--srcptr))& 0xC0) != 0x80)
             return conv_errc::expected_continuation_byte;
+        // FALLTHRU
     case 3:
         if (((a = (*--srcptr))& 0xC0) != 0x80)
             return conv_errc::expected_continuation_byte;
+        // FALLTHRU
     case 2:
         if (((a = (*--srcptr))& 0xC0) != 0x80)
             return conv_errc::expected_continuation_byte;
@@ -259,9 +260,11 @@ is_legal_utf8(Iterator first, size_t length)
             default:   if (a < 0x80) return conv_errc::source_illegal;
         }
 
+        // FALLTHRU
     case 1:
         if (static_cast<uint8_t>(*first) >= 0x80 && static_cast<uint8_t>(*first) < 0xC2)
             return conv_errc::source_illegal;
+        // FALLTHRU
     }
     if (static_cast<uint8_t>(*first) > 0xF4) 
         return conv_errc::source_illegal;
@@ -711,11 +714,18 @@ convert(InputIt first, InputIt last,
         uint8_t byte3 = 0;
         uint8_t byte4 = 0;
 
-        switch (bytes_to_write) { // note: everything falls through
-        case 4: byte4 = (uint8_t)((ch | byteMark) & byteMask); ch >>= 6;
-        case 3: byte3 = (uint8_t)((ch | byteMark) & byteMask); ch >>= 6;
-        case 2: byte2 = (uint8_t)((ch | byteMark) & byteMask); ch >>= 6;
-        case 1: byte1 = (uint8_t) (ch | first_byte_mark[bytes_to_write]);
+        switch (bytes_to_write) {
+        case 4:
+            byte4 = (uint8_t)((ch | byteMark) & byteMask); ch >>= 6;
+            // FALLTHRU
+        case 3:
+            byte3 = (uint8_t)((ch | byteMark) & byteMask); ch >>= 6;
+            // FALLTHRU
+        case 2:
+            byte2 = (uint8_t)((ch | byteMark) & byteMask); ch >>= 6;
+            // FALLTHRU
+        case 1:
+            byte1 = (uint8_t) (ch | first_byte_mark[bytes_to_write]);
         }
 
         switch (bytes_to_write) 
@@ -945,10 +955,17 @@ public:
         default:
             return replacement_char;
             break;
-        case 4: ch += static_cast<uint8_t>(*it++); ch <<= 6;
-        case 3: ch += static_cast<uint8_t>(*it++); ch <<= 6;
-        case 2: ch += static_cast<uint8_t>(*it++); ch <<= 6;
-        case 1: ch += static_cast<uint8_t>(*it++);
+        case 4:
+            ch += static_cast<uint8_t>(*it++); ch <<= 6;
+            // FALLTHRU
+        case 3:
+            ch += static_cast<uint8_t>(*it++); ch <<= 6;
+            // FALLTHRU
+        case 2:
+            ch += static_cast<uint8_t>(*it++); ch <<= 6;
+            // FALLTHRU
+        case 1:
+            ch += static_cast<uint8_t>(*it++);
             ch -= offsets_from_utf8[length_ - 1];
             break;
         }


### PR DESCRIPTION
GCC 7 now warns if case fallthru is used without a marker (either C++17 attribute or a comment).