### PR TITLE
Fix equality check of strings

### DIFF
--- a/src/jsoncons/json.hpp
+++ b/src/jsoncons/json.hpp
@@ -923,7 +923,10 @@ public:
                 break;
             case value_type::small_string_t:
             case value_type::string_t:
-                return as_string_view() == rhs.as_string_view();
+                if (rhs_id == value_type::small_string_t || rhs_id == value_type::string_t)
+                {
+                    return as_string_view() == rhs.as_string_view();
+                }
                 break;
             default:
                 break;

--- a/test_suite/src/json_equals_tests.cpp
+++ b/test_suite/src/json_equals_tests.cpp
@@ -141,6 +141,15 @@ BOOST_AUTO_TEST_CASE(test_empty_object_equal)
     BOOST_CHECK(json(json::object()) == json());
 }
 
+BOOST_AUTO_TEST_CASE(test_string_not_equals_empty_object)
+{
+    json o1("42");
+    json o2;
+
+    BOOST_CHECK(o1 != o2);
+    BOOST_CHECK(o2 != o1);
+}
+
 BOOST_AUTO_TEST_SUITE_END()
 
 


### PR DESCRIPTION
In case one compares a string against something else for equality, the right
hand side was unconditionally converted to a string_view.

This change ensures that the right hand side is a string.