### PR TITLE
avoid clash with std::minus in VS2017

### DIFF
--- a/include/jsoncons/json_parser.hpp
+++ b/include/jsoncons/json_parser.hpp
@@ -1475,7 +1475,7 @@ public:
         switch (state_)
         {
             case parse_state::minus:
-                goto minus;
+                goto minus_sign;
             case parse_state::positive_zero:
                 goto positive_zero;
             case parse_state::negative_zero:
@@ -1497,7 +1497,7 @@ public:
             default:
                 JSONCONS_UNREACHABLE();               
         }
-minus:
+minus_sign:
         if (JSONCONS_UNLIKELY(p_ >= local_end_input)) // Buffer exhausted               
         {
             state_ = parse_state::minus;


### PR DESCRIPTION
while it works without any problem on gcc or clang, I have many problems with the "minus" label (json_parser.hpp) in Visual Studio, causing a name clash with std::minus (without ever using the std namespace)
If you know any better workaround, please let me know

