### PR TITLE
Fix compile error from using custom allocator

### DIFF
--- a/include/jsoncons/json.hpp
+++ b/include/jsoncons/json.hpp
@@ -118,12 +118,12 @@ public:
 #else
     typedef std::basic_string_view<char_type,char_traits_type> string_view_type;
 #endif
-    // string_type is for interface only, not storage 
-    typedef std::basic_string<CharT,char_traits_type> string_type;
-
     typedef typename std::allocator_traits<allocator_type>:: template rebind_alloc<char_type> char_allocator_type;
     using string_storage_type = typename implementation_policy::template string_storage<CharT,char_traits_type,char_allocator_type>;
     using key_storage_type = typename implementation_policy::template key_storage<CharT,char_traits_type,char_allocator_type>;
+
+	// string_type is for interface only, not storage 
+	typedef std::basic_string<CharT,char_traits_type,char_allocator_type> string_type;
 
     typedef basic_json<CharT,ImplementationPolicy,Allocator> value_type;
     typedef value_type& reference;

--- a/include/jsoncons/json.hpp
+++ b/include/jsoncons/json.hpp
@@ -122,8 +122,8 @@ public:
     using string_storage_type = typename implementation_policy::template string_storage<CharT,char_traits_type,char_allocator_type>;
     using key_storage_type = typename implementation_policy::template key_storage<CharT,char_traits_type,char_allocator_type>;
 
-	// string_type is for interface only, not storage 
-	typedef std::basic_string<CharT,char_traits_type,char_allocator_type> string_type;
+    // string_type is for interface only, not storage 
+    typedef std::basic_string<CharT,char_traits_type,char_allocator_type> string_type;
 
     typedef basic_json<CharT,ImplementationPolicy,Allocator> value_type;
     typedef value_type& reference;


### PR DESCRIPTION
json_decoder fails to compile when using a custom allocator, because it tries to copy string types which use mismatching allocators.

Now that could be fixed differently if the json output is really meant to offer std::allocator only, but that is probably not desired, because a user naturally expects the out values with the specified allocator.