### PR TITLE
Ignore blank lines in csv files

### DIFF
--- a/include/jsoncons_ext/csv/csv_parser.hpp
+++ b/include/jsoncons_ext/csv/csv_parser.hpp
@@ -71,8 +71,8 @@ class basic_csv_parser : private parsing_context
     size_t index_;
     unsigned long column_;
     unsigned long line_;
-    int curr_char_;
-    int prev_char_;
+    CharT curr_char_;
+    CharT prev_char_;
     std::basic_string<CharT> value_buffer_;
     int depth_;
     basic_csv_parameters<CharT> parameters_;
@@ -335,6 +335,10 @@ all_csv_states:
                 {
                     state_ = csv_state_type::comment;
                 }
+				else if (curr_char_ == '\r' || curr_char_ == '\n')
+				{
+					// do nothing yet: could be a blank line
+				}
                 else
                 {
                     state_ = csv_state_type::unquoted_string;

--- a/include/jsoncons_ext/csv/csv_parser.hpp
+++ b/include/jsoncons_ext/csv/csv_parser.hpp
@@ -335,10 +335,10 @@ all_csv_states:
                 {
                     state_ = csv_state_type::comment;
                 }
-				else if (curr_char_ == '\r' || curr_char_ == '\n')
-				{
-					// do nothing yet: could be a blank line
-				}
+                else if (curr_char_ == '\r' || curr_char_ == '\n')
+                {
+                    // do nothing yet: could be a blank line
+                }
                 else
                 {
                     state_ = csv_state_type::unquoted_string;


### PR DESCRIPTION
Blank lines, e.g. a blank line at file end, create an empty object in the json array, which is most likely not desired. Could be a csv option in the future.