### PR TITLE
Fix compile error from using JSONCONS_HAS_STRING_VIEW

### DIFF
--- a/include/jsoncons_ext/csv/csv_parser.hpp
+++ b/include/jsoncons_ext/csv/csv_parser.hpp
@@ -784,7 +784,7 @@ private:
             {
             case csv_column_type::integer_t:
                 {
-                    std::istringstream iss(value);
+                    std::istringstream iss(value.data());
                     int64_t val;
                     iss >> val;
                     if (!iss.fail())
@@ -808,7 +808,7 @@ private:
                 break;
             case csv_column_type::float_t:
                 {
-                    std::istringstream iss(value);
+                    std::istringstream iss(value.data());
                     double val;
                     iss >> val;
                     if (!iss.fail())

--- a/include/jsoncons_ext/csv/csv_parser.hpp
+++ b/include/jsoncons_ext/csv/csv_parser.hpp
@@ -784,7 +784,8 @@ private:
             {
             case csv_column_type::integer_t:
                 {
-                    std::istringstream iss(value.data());
+                    std::string str(value.data(), value.size());
+                    std::istringstream iss(str);
                     int64_t val;
                     iss >> val;
                     if (!iss.fail())
@@ -808,7 +809,8 @@ private:
                 break;
             case csv_column_type::float_t:
                 {
-                    std::istringstream iss(value.data());
+                    std::string str(value.data(), value.size());
+                    std::istringstream iss(str);
                     double val;
                     iss >> val;
                     if (!iss.fail())


### PR DESCRIPTION
std::istringstream does not take a std::string_view (vs 2017)