### PR TITLE
Fix mismatching allocator types

### DIFF
--- a/include/jsoncons/json_decoder.hpp
+++ b/include/jsoncons/json_decoder.hpp
@@ -18,7 +18,7 @@
 
 namespace jsoncons {
 
-template <class Json,class Allocator=std::allocator<typename Json::char_type>>
+template <class Json,template <class Type> class Allocator=std::allocator>
 class json_decoder : public basic_json_input_handler<typename Json::char_type>
 {
 public:
@@ -49,8 +49,11 @@ public:
         key_storage_type name_;
         Json value_;
     };
-    std::vector<stack_item,Allocator> stack_;
-    std::vector<size_t,Allocator> stack_offsets_;
+    typedef Allocator<stack_item> stack_item_allocator;
+    typedef Allocator<size_t> size_t_allocator;
+
+    std::vector<stack_item,stack_item_allocator> stack_;
+    std::vector<size_t,size_t_allocator> stack_offsets_;
     bool is_valid_;
 
 public:

--- a/include/jsoncons/json_parser.hpp
+++ b/include/jsoncons/json_parser.hpp
@@ -81,11 +81,15 @@ enum class parse_state : uint8_t
     done
 };
 
-template <class CharT, class Allocator = std::allocator<char>>
+template <class CharT, template <typename Type> class Allocator = std::allocator>
 class basic_json_parser : private parsing_context
 {
     static const int default_initial_stack_capacity_ = 100;
     typedef typename basic_json_input_handler<CharT>::string_view_type string_view_type;
+    typedef Allocator<CharT> char_t_allocator;
+    typedef Allocator<char> char_allocator;
+    typedef std::basic_string<CharT,std::char_traits<CharT>,char_t_allocator> string_t;
+    typedef std::basic_string<char,std::char_traits<char>,char_allocator> string;
 
     basic_null_json_input_handler<CharT> default_input_handler_;
     default_parse_error_handler default_err_handler_;
@@ -94,8 +98,8 @@ class basic_json_parser : private parsing_context
     parse_error_handler& err_handler_;
     uint32_t cp_;
     uint32_t cp2_;
-    std::basic_string<CharT,std::char_traits<CharT>,Allocator> string_buffer_;
-    std::basic_string<char,std::char_traits<char>,Allocator> number_buffer_;
+    string_t string_buffer_;
+    string number_buffer_;
 
     bool is_negative_;
     uint8_t precision_;
@@ -112,7 +116,10 @@ class basic_json_parser : private parsing_context
     const CharT* p_;
 
     parse_state state_;
-    std::vector<parse_state,Allocator> state_stack_;
+    typedef Allocator<parse_state> state_allocator;
+    typedef std::vector<parse_state,state_allocator> parse_state_vector;
+
+    parse_state_vector state_stack_;
 
     // Noncopyable and nonmoveable
     basic_json_parser(const basic_json_parser&) = delete;

--- a/include/jsoncons/json_reader.hpp
+++ b/include/jsoncons/json_reader.hpp
@@ -136,15 +136,16 @@ private:
     }
 };
 
-template<class CharT,class Allocator=std::allocator<char>>
+template<class CharT,template <class Type> class Allocator=std::allocator>
 class basic_json_reader 
 {
+    typedef Allocator<CharT> char_t_allocator;
     static const size_t default_max_buffer_length = 16384;
 
     basic_json_parser<CharT,Allocator> parser_;
     std::basic_istream<CharT>& is_;
     bool eof_;
-    std::vector<CharT,Allocator> buffer_;
+    std::vector<CharT,char_t_allocator> buffer_;
     size_t buffer_length_;
     bool begin_;
 

--- a/include/jsoncons_ext/csv/csv_parser.hpp
+++ b/include/jsoncons_ext/csv/csv_parser.hpp
@@ -52,19 +52,22 @@ enum class csv_state_type
     done
 };
 
-template<class CharT,class Allocator=std::allocator<CharT>>
+template<class CharT,template <class Type> class Allocator=std::allocator>
 class basic_csv_parser : private parsing_context
 {
     typedef basic_string_view_ext<CharT> string_view_type;
-
-    typedef std::basic_string<CharT,std::char_traits<CharT>,Allocator> string_type;
+    typedef Allocator<CharT> char_t_allocator;
+    typedef std::basic_string<CharT,std::char_traits<CharT>,char_t_allocator> string_type;
+    typedef Allocator<string_type> string_allocator;
+    typedef Allocator<std::vector<string_type, string_allocator>> string_vector_allocator;
+    typedef Allocator<detail::csv_type_info> csv_type_info_allocator;
 
     static const int default_depth = 3;
 
     default_parse_error_handler default_err_handler_;
     csv_state_type state_;
     int top_;
-    std::vector<csv_mode_type,Allocator> stack_;
+    std::vector<csv_mode_type,Allocator<csv_mode_type>> stack_;
     basic_json_input_handler<CharT>& handler_;
     parse_error_handler& err_handler_;
     size_t index_;
@@ -75,10 +78,10 @@ class basic_csv_parser : private parsing_context
     string_type value_buffer_;
     int depth_;
     basic_csv_parameters<CharT,Allocator> parameters_;
-    std::vector<string_type,Allocator> column_names_;
-    std::vector<std::vector<string_type,Allocator>,Allocator> column_values_;
-    std::vector<detail::csv_type_info,Allocator> column_types_;
-    std::vector<string_type,Allocator> column_defaults_;
+    std::vector<string_type,string_allocator> column_names_;
+    std::vector<std::vector<string_type,string_allocator>,string_vector_allocator> column_values_;
+    std::vector<detail::csv_type_info,csv_type_info_allocator> column_types_;
+    std::vector<string_type,string_allocator> column_defaults_;
     size_t column_index_;
     basic_json_fragment_filter<CharT> filter_;
     size_t level_;

--- a/include/jsoncons_ext/csv/csv_reader.hpp
+++ b/include/jsoncons_ext/csv/csv_reader.hpp
@@ -25,9 +25,11 @@
 
 namespace jsoncons { namespace csv {
 
-template<class CharT,class Allocator=std::allocator<char>>
+template<class CharT,template <class Type> class Allocator=std::allocator>
 class basic_csv_reader 
 {
+    typedef Allocator<CharT> char_t_allocator;
+
     struct stack_item
     {
         stack_item()
@@ -42,7 +44,7 @@ class basic_csv_reader
 
     basic_csv_parser<CharT,Allocator> parser_;
     std::basic_istream<CharT>& is_;
-    std::vector<CharT,Allocator> buffer_;
+    std::vector<CharT,char_t_allocator> buffer_;
     size_t buffer_length_;
     size_t buffer_position_;
     bool eof_;
@@ -191,7 +193,7 @@ Json decode_csv(typename Json::string_view_type s)
     return decoder.get_result();
 }
 
-template <class Json,class Allocator>
+template <class Json,template <class Type> class Allocator=std::allocator>
 Json decode_csv(typename Json::string_view_type s, const basic_csv_parameters<typename Json::char_type,Allocator>& params)
 {
     json_decoder<Json,Allocator> decoder;
@@ -213,7 +215,7 @@ Json decode_csv(std::basic_istream<typename Json::char_type>& is)
     return decoder.get_result();
 }
 
-template <class Json,class Allocator>
+template <class Json,template <class Type> class Allocator=std::allocator>
 Json decode_csv(std::basic_istream<typename Json::char_type>& is, const basic_csv_parameters<typename Json::char_type,Allocator>& params)
 {
     json_decoder<Json,Allocator> decoder;


### PR DESCRIPTION
New master branch does not compile on MSVC c++17

The allocator types are mismatching. I fixed all errors I could find, but there might be more, as I might not have all templates in my compile unit. I suggest to pass allocators as templated templates. Then it is easier to use them for various types.