### PR TITLE
Use string as inferred type for overflow integers

### DIFF
--- a/include/jsoncons_ext/csv/csv_parser.hpp
+++ b/include/jsoncons_ext/csv/csv_parser.hpp
@@ -1256,8 +1256,7 @@ private:
                     }
                     else
                     {
-                        double d = to_double_(buffer.data(), buffer.length());
-                        handler.double_value(d, number_format(format), *this);
+                        handler.string_value(value, *this);
                     }
                 }
                 else
@@ -1269,8 +1268,7 @@ private:
                     }
                     else
                     {
-                        double d = to_double_(buffer.data(), buffer.length());
-                        handler.double_value(d, number_format(format), *this);
+                        handler.string_value(value, *this);
                     }
                 }
                 break;


### PR DESCRIPTION
Hello Daniel, thanks for an awesome project.

I have an issue with the new type inference mechanism. In a csv file I have long hexadecimal strings which might not contain chars from 'a' to 'f', e.g. `4000001600010001000000000300000000000008000000010100`.
Since there are only digits in the field, the csv parser interprets these values as an integer, gets an overflow and falls back to double, which in turn leads to the information loss due to the double's finite precision, e.g. you might get back something like `4000001600010000762621119870936895770498791553105920.000000`.

I propose to fall back to string type by default.