### PR TITLE
Use double type for 1st argument to ldexp()

### DIFF
--- a/include/jsoncons/binary/binary_utilities.hpp
+++ b/include/jsoncons/binary/binary_utilities.hpp
@@ -180,11 +180,11 @@ double decode_half(uint16_t half)
     double val;
     if (exp == 0) 
     {
-        val = ldexp(mant, -24);
+        val = ldexp((double)mant, -24);
     }
     else if (exp != 31) 
     {
-        val = ldexp(mant + 1024, exp - 25);
+        val = ldexp(mant + 1024.0, exp - 25);
     } 
     else
     {


### PR DESCRIPTION
Spotted by Prof Brian Ripley <ripley@stats.ox.ac.uk>