### PR TITLE
Fix infinite recursion with bignums and misc. undefined behavior

### DIFF
--- a/include/jsoncons/bignum.hpp
+++ b/include/jsoncons/bignum.hpp
@@ -233,6 +233,7 @@ public:
 
     basic_bignum(unsigned short u)
     {
+        neg_ = false;
         initialize_from_integer( u );
     }
 
@@ -245,6 +246,7 @@ public:
 
     basic_bignum(unsigned int u)
     {
+        neg_ = false;
         initialize_from_integer( u );
     }
 
@@ -257,6 +259,7 @@ public:
 
     basic_bignum(unsigned long u)
     {
+        neg_ = false;
         initialize_from_integer( u );
     }
 
@@ -269,6 +272,7 @@ public:
 
     basic_bignum(unsigned long long u)
     {
+        neg_ = false;
         initialize_from_integer( u );
     }
 
@@ -335,7 +339,7 @@ public:
     {
         if ( dynamic_ )
         {
-            delete[] data_;
+            allocator().deallocate(data_, capacity_);
         }
     }
 
@@ -1455,4 +1459,3 @@ typedef basic_bignum<std::allocator<uint8_t>> bignum;
 }
 
 #endif
-

--- a/include/jsoncons/json.hpp
+++ b/include/jsoncons/json.hpp
@@ -3141,6 +3141,11 @@ public:
         {
         case data_type_tag::short_string_tag:
         case data_type_tag::long_string_tag:
+            if (var_.semantic_type() == semantic_type_tag::bignum_tag)
+            {
+                return static_cast<bool>(var_.as_bignum());
+            }
+
             try
             {
                 basic_json j = basic_json::parse(as_string_view());
@@ -3170,6 +3175,11 @@ public:
         {
         case data_type_tag::short_string_tag:
         case data_type_tag::long_string_tag:
+            if (var_.semantic_type() == semantic_type_tag::bignum_tag)
+            {
+                return static_cast<int64_t>(var_.as_bignum());
+            }
+
             try
             {
                 basic_json j = basic_json::parse(as_string_view());
@@ -3199,6 +3209,11 @@ public:
         {
         case data_type_tag::short_string_tag:
         case data_type_tag::long_string_tag:
+            if (var_.semantic_type() == semantic_type_tag::bignum_tag)
+            {
+                return static_cast<uint64_t>(var_.as_bignum());
+            }
+
             try
             {
                 basic_json j = basic_json::parse(as_string_view());
@@ -3250,6 +3265,11 @@ public:
         {
         case data_type_tag::short_string_tag:
         case data_type_tag::long_string_tag:
+            if (var_.semantic_type() == semantic_type_tag::bignum_tag)
+            {
+                return static_cast<double>(var_.as_bignum());
+            }
+
             try
             {
                 basic_json j = basic_json::parse(as_string_view());


### PR DESCRIPTION
Hi,
I discovered this project due to its inclusion in [miloyip/nativejson-benchmark](https://github.com/miloyip/nativejson-benchmark).  I locally updated its submodule for jsoncons from commit 88194db to the latest master.  After adjusting the tests to the current API, the benchmark segfaulted due to a stack overflow during the conformance testing.

Long story short, with the help of gdb, I found a case where conversion of `basic_json` values backed by bignums to primitive types entered an infinite recursion -- for example, `as_double()` parses the string representation of the value, expecting it to convert to a double, but its data type remains a string because it is semantically a bignum and too big to fit in a double.  I fixed this by using `as_bignum()` and a conversion operator if the semantic type matched `bignum_tag`.

I found undefined behavior with ubsan and msan along the way -- `neg_` was sometimes not initialized, and `data_` is allocated with `std::allocator::allocate()` and deallocated with `delete[]`, even though [`allocate()` uses `::operator new()`](https://en.cppreference.com/w/cpp/memory/allocator/allocate) (without the brackets) internally.  I changed it to `deallocate()` for the sake of consistency.