### PR TITLE
__FILE__ and __LINE__ macroses removed from release version

### DIFF
--- a/include/jsoncons/json_exception.hpp
+++ b/include/jsoncons/json_exception.hpp
@@ -103,7 +103,8 @@ private:
             JSONCONS_STR(__LINE__)); }
 #else
 #define JSONCONS_ASSERT(x) if (!(x)) { \
-    throw jsoncons::json_exception_impl<std::runtime_error>("assertion '" #x "' failed "); }
+    throw jsoncons::json_exception_impl<std::runtime_error>("assertion '" #x "' failed at  <> :" \
+            JSONCONS_STR( 0 )); }
 #endif // _DEBUG
 
 #define JSONCONS_THROW(x) throw (x)

--- a/include/jsoncons/json_exception.hpp
+++ b/include/jsoncons/json_exception.hpp
@@ -97,9 +97,14 @@ private:
 #define JSONCONS_STR2(x)  #x
 #define JSONCONS_STR(x)  JSONCONS_STR2(x)
 
+#ifdef _DEBUG
 #define JSONCONS_ASSERT(x) if (!(x)) { \
     throw jsoncons::json_exception_impl<std::runtime_error>("assertion '" #x "' failed at " __FILE__ ":" \
             JSONCONS_STR(__LINE__)); }
+#else
+#define JSONCONS_ASSERT(x) if (!(x)) { \
+    throw jsoncons::json_exception_impl<std::runtime_error>("assertion '" #x "' failed "); }
+#endif // _DEBUG
 
 #define JSONCONS_THROW(x) throw (x)
 

--- a/third_party/catch/catch.hpp
+++ b/third_party/catch/catch.hpp
@@ -353,7 +353,8 @@ namespace Catch {
 #define CATCH_INTERNAL_LINEINFO \
     ::Catch::SourceLineInfo( __FILE__, static_cast<std::size_t>( __LINE__ ) )
 #else
-#define CATCH_INTERNAL_LINEINFO
+#define CATCH_INTERNAL_LINEINFO \
+    ::Catch::SourceLineInfo( __FILE__, static_cast<std::size_t>( 0 ) )
 #endif // _DEBUG
 
 // end catch_common.h

--- a/third_party/catch/catch.hpp
+++ b/third_party/catch/catch.hpp
@@ -349,8 +349,12 @@ namespace Catch {
     }
 }
 
+#ifdef _DEBUG
 #define CATCH_INTERNAL_LINEINFO \
     ::Catch::SourceLineInfo( __FILE__, static_cast<std::size_t>( __LINE__ ) )
+#else
+#define CATCH_INTERNAL_LINEINFO
+#endif // _DEBUG
 
 // end catch_common.h
 namespace Catch {


### PR DESCRIPTION
these macroses are generates a literal constants that contains full file names and after that the release exe file contains these literal constants with my local directories structure.

so it should be removed from release build and looks  the JSONCONS_ASSERT macros also may be fully removed from release but I don't sure.

let me know if You have any question

thanks for this cool library.
