### PR TITLE
added `sum()` and `mult()` functions.

### DIFF
--- a/doc/ref/jsonpath/jsonpath.md
+++ b/doc/ref/jsonpath/jsonpath.md
@@ -19,11 +19,11 @@ Stefan Goessner's javascript implemention returns `false` in case of no match, b
 
 Unlike XML, the root of a JSON text is usually an anonymous object or array, so JSONPath identifies the outermost level of the text with the symbol $.
 
-JSONPath expressions can use the dot–notation
+JSONPath expressions can use the dot-notation
 
     $.store.book.0.title
 
-or the bracket–notation 
+or the bracket-notation 
 
 
     $[store][book][0][title]
@@ -94,12 +94,15 @@ Precedence|Operator|Associativity
 
 #### Aggregate Functions
 
-Functions can be called inside filter expressions. The input to an aggregate function is the value of a JSONPath expression.
+Functions can be called __*only inside filter expressions*__. The input to an aggregate function is the value of a JSONPath expression.
+There are not much use cases for aggregation functions like `mult()` inside filter expressions but still they could be used, here are examples:
 
 Function|Description|Result|Example
 ----------|--------|-------|---
-min()|Provides the minimum value of an array of numbers|double|$.store.book[?(@.price < max($.store.book[*].price))].title
-max()|Provides the maximum value of an array of numbers|double|$.store.book[?(@.price > min($.store.book[*].price))].title
+`min(...)`|Provides the minimum value of an array of numbers|`double`|`$.store.book[?(@.price < max($.store.book[*].price))].title`
+`max(...)`|Provides the maximum value of an array of numbers|`double`|`$.store.book[?(@.price > min($.store.book[*].price))].title`
+`sum(...)`|Provides the sum value of an array of numbers|`double`|`$.store.book[?(@.price > sum($.store.book[*].price) / 4)].title`
+`mult(...)`|Provides the multiplication value of an array of numbers|`double`|`$.store.book[?(479373 < mult($..price) && mult($..price) < 479374)].title`
 
 ### Examples
 

--- a/include/jsoncons_ext/jsonpath/jsonpath_filter.hpp
+++ b/include/jsoncons_ext/jsonpath/jsonpath_filter.hpp
@@ -35,6 +35,8 @@ JSONCONS_DEFINE_LITERAL(ampamp_literal,"&&")
 JSONCONS_DEFINE_LITERAL(pipepipe_literal,"||")
 JSONCONS_DEFINE_LITERAL(max_literal,"max")
 JSONCONS_DEFINE_LITERAL(min_literal,"min")
+JSONCONS_DEFINE_LITERAL(sum_literal,"sum")
+JSONCONS_DEFINE_LITERAL(mult_literal,"mult")
 
 template<class Json>
 struct PathConstructor
@@ -1098,6 +1100,38 @@ class jsonpath_filter_parser
                               {
                                   v = x;
                               }
+                          }
+                          return v;
+                      }
+                }
+            },
+            {
+                sum_literal<char_type>(),{1,true,true,[](const term<Json>& term)
+                      {
+                          Json a = term.evaluate_single_node();
+
+                          double v = 0.0;
+                          for (const auto& elem : a.array_range())
+                          {
+                              v += elem.template as<double>();
+                          }
+                          return v;
+                      }
+                }
+            },
+            {
+                mult_literal<char_type>(),{1,true,true,[](const term<Json>& term)
+                      {
+                          Json a = term.evaluate_single_node();
+
+                          double v = 0.0;
+                          for (const auto& elem : a.array_range())
+                          {
+                              double x = elem.template as<double>();
+                              v == 0.0 && x != 0.0
+                              ? (v = x)
+                              : (v *= x);
+
                           }
                           return v;
                       }

--- a/tests/src/jsonpath/jsonpath_tests.cpp
+++ b/tests/src/jsonpath/jsonpath_tests.cpp
@@ -1162,6 +1162,30 @@ TEST_CASE("test_min")
     CHECK(result == expected);
 }
 
+TEST_CASE("test_sum_filter_func")
+{
+    std::string path = "$.store.book[?(@.price > sum($.store.book[*].price) / 4)].title"; // unexpected exception if '$.store.book.length' instead '4'
+
+    json expected = json::parse(R"(
+["The Lord of the Rings"]
+    )");
+
+    json result = json_query(store,path);
+    CHECK(result == expected);
+}
+
+TEST_CASE("test_mult_func")
+{
+    std::string path = "$.store.bicycle[?(479373 < mult($..price) && mult($..price) < 479374)].color";
+
+    json expected = json::parse(R"(
+["red"]
+    )");
+
+    json result = json_query(store,path);
+    CHECK(result == expected);
+}
+
 TEST_CASE("test_ws1")
 {
     json result = json_query(store,"$..book[ ?(( @.price > 8 ) && (@.price < 12)) ].author");


### PR DESCRIPTION
Hi, 

I want to further create functions (especially simple sum() would be helpful) which will work NOT ONLY inside filter. 
Could you point out where to start with and are there some gotchas.
I want to do simply `$sum($..someArrayOfDoubleValues)` to get a number or, to get an array (as you always get here) with size of 1 and `arr[0]` equal to what was calculated.

BTW. 
In one of the test I wrote this 
`std::string path = "$.store.book[?(@.price > sum($.store.book[*].price) / $.store.book.length)].title"; // unexpected exception if '$.store.book.length'.`
Is it expected?