### PR TITLE
Include jsoncons_ext directory into installation script

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,6 +49,7 @@ export(EXPORT ${PROJECT_NAME}-targets
        FILE "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Targets.cmake")
 
 install(DIRECTORY ${JSONCONS_INCLUDE_DIR}/jsoncons
+                  ${JSONCONS_INCLUDE_DIR}/jsoncons_ext
         DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
 
 # GNUInstallDirs "DATADIR" wrong here; CMake search path wants "share".


### PR DESCRIPTION
Currently only `include/jsoncons` directory is being copied to installation place.
Add `include/jsoncons_ext` as well.