### PR TITLE
removed a multi-line comment

### DIFF
--- a/include/jsoncons/json_type_traits.hpp
+++ b/include/jsoncons/json_type_traits.hpp
@@ -1148,7 +1148,7 @@ namespace jsoncons \
             return j; \
         } \
     }; \
-} // jsoncons \
+} // jsoncons 
 
 
 #define JSONCONS_TYPE_TRAITS_DECL(ValueType,...) \


### PR DESCRIPTION
The multi-line comment at 1151 is not necessary and causes builds that treat warnings as errors to fail.