### PR TITLE
Fix compiler (gcc 9.2) warning "accessible non-virtual destructor"

### DIFF
--- a/include/jsoncons/json_exception.hpp
+++ b/include/jsoncons/json_exception.hpp
@@ -20,6 +20,7 @@ namespace jsoncons {
 class json_exception 
 {
 public:
+    virtual ~json_exception() = default;
     virtual const char* what() const noexcept = 0;
 };
 


### PR DESCRIPTION
GCC 9.2 produces warning: `‘class jsoncons::json_exception’ has virtual functions and accessible non-virtual destructor`