### PR TITLE
Fix incorrect default mapping with headers in docs.

### DIFF
--- a/doc/ref/csv/basic_csv_options.md
+++ b/doc/ref/csv/basic_csv_options.md
@@ -41,7 +41,7 @@ unquoted_empty_value_is_null|Replace empty field with json null value. Default i
 infer_types|Infer null, true, false, integers and floating point values in the CSV source. Default is `true`.|
 lossless_number|If set to `true`, parse numbers with exponents and fractional parts as strings with semantic tagging `semantic_tag::bigdec`. Default is `false`.|
 comment_starter|Character to comment out a line, must be at column 1. Default is no comments.|
-mapping|Indicates what [mapping kind](mapping_kind.md) to use when parsing a CSV file into a `basic_json`. If assume_header is true or column_names is not empty, defaults to `mapping_kind::n_rows`, otherwise `mapping_kind::n_objects`.|
+mapping|Indicates what [mapping kind](mapping_kind.md) to use when parsing a CSV file into a `basic_json`. If assume_header is true or column_names is not empty, defaults to `mapping_kind::n_objects`, otherwise `mapping_kind::n_rows`.|
 max_lines|Maximum number of lines to read. Default is unlimited.|
 column_types|A comma separated list of data types corresponding to the columns in the file. The following data types are supported: string, integer, float and boolean. Example: "bool,float,string"}|
 column_defaults|A comma separated list of strings containing default json values corresponding to the columns in the file. Example: "false,0.0,"\"\""|

--- a/doc/ref/csv/basic_csv_options.md
+++ b/doc/ref/csv/basic_csv_options.md
@@ -41,7 +41,7 @@ unquoted_empty_value_is_null|Replace empty field with json null value. Default i
 infer_types|Infer null, true, false, integers and floating point values in the CSV source. Default is `true`.|
 lossless_number|If set to `true`, parse numbers with exponents and fractional parts as strings with semantic tagging `semantic_tag::bigdec`. Default is `false`.|
 comment_starter|Character to comment out a line, must be at column 1. Default is no comments.|
-mapping|Indicates what [mapping kind](mapping_kind.md) to use when parsing a CSV file into a `basic_json`. If assume_header is true or column_names is not empty, defaults to `mapping_kind::n_rows`, otherwise `mapping_kind::n_columns`.|
+mapping|Indicates what [mapping kind](mapping_kind.md) to use when parsing a CSV file into a `basic_json`. If assume_header is true or column_names is not empty, defaults to `mapping_kind::n_rows`, otherwise `mapping_kind::n_objects`.|
 max_lines|Maximum number of lines to read. Default is unlimited.|
 column_types|A comma separated list of data types corresponding to the columns in the file. The following data types are supported: string, integer, float and boolean. Example: "bool,float,string"}|
 column_defaults|A comma separated list of strings containing default json values corresponding to the columns in the file. Example: "false,0.0,"\"\""|


### PR DESCRIPTION
The mapping `n_columns` does not exist.