### PR TITLE
Don't define JSONCONS_HAS_STRTOLD_L for ANDROID_API < 21

### DIFF
--- a/include/jsoncons/config/compiler_support.hpp
+++ b/include/jsoncons/config/compiler_support.hpp
@@ -88,8 +88,8 @@
 #endif
 
 #if defined(ANDROID) || defined(__ANDROID__)
-#define JSONCONS_HAS_STRTOLD_L
 #if __ANDROID_API__ >= 21
+#define JSONCONS_HAS_STRTOLD_L
 #else
 #define JSONCONS_NO_LOCALECONV
 #endif


### PR DESCRIPTION
strtolod_l/wcstold_l are only supported when building for Android SDK level 21 and above. Bulding for min SDK less than 21 results in a compile error in parse_number.hpp.