### PR TITLE
Fix compilation error with gcc 11

### DIFF
--- a/include/jsoncons/json_reader.hpp
+++ b/include/jsoncons/json_reader.hpp
@@ -34,7 +34,7 @@ private:
     //std::function<bool(json_errc,const ser_context&)> err_handler_;
 
     // noncopyable and nonmoveable
-    json_utf8_to_other_visitor_adaptor<CharT>(const json_utf8_to_other_visitor_adaptor<CharT>&) = delete;
+    json_utf8_to_other_visitor_adaptor(const json_utf8_to_other_visitor_adaptor<CharT>&) = delete;
     json_utf8_to_other_visitor_adaptor<CharT>& operator=(const json_utf8_to_other_visitor_adaptor<CharT>&) = delete;
 
 public:


### PR DESCRIPTION
Hello,
Fixing this compilation issue. gcc 11 does not accept this wrong constructor declaration anymore.
```
In file included from BUILD/jsoncons-0.157.2/include/jsoncons/basic_json.hpp:35,                                                                                                                                           from BUILD/jsoncons-0.157.2/include/jsoncons/json.hpp:10,
                 from BUILD/jsoncons-0.157.2/tests/src/JSONTestSuite_tests.cpp:13:
BUILD/jsoncons-0.157.2/include/jsoncons/json_reader.hpp:37:47: error: expected unqualified-id before 'const'
   37 |     json_utf8_to_other_visitor_adaptor<CharT>(const json_utf8_to_other_visitor_adaptor<CharT>&) = delete;
      |                                               ^~~~~
BUILD/jsoncons-0.157.2/include/jsoncons/json_reader.hpp:37:47: error: expected ')' before 'const'                                                                                                            37 |     json_utf8_to_other_visitor_adaptor<CharT>(const json_utf8_to_other_visitor_adaptor<CharT>&) = delete;
      |                                              ~^~~~~
      |                                               )
```
Regards,
Stac