### PR TITLE
variant of json_query() that returns pointers

### DIFF
--- a/doc/ref/jsonpath/json_replace.md
+++ b/doc/ref/jsonpath/json_replace.md
@@ -7,9 +7,15 @@ template<class Json, class T>
 void json_replace(Json& root, 
                   const typename Json::string_view_type& path, 
                   T&& new_value)
+
+template<class Json, class Op>
+void json_replace(Json& root, 
+                  const typename Json::string_view_type& path, 
+                  T Op)
 ```
 
-Searches for all values that match a JSONPath expression and replaces them with the specified value
+(1) Searches for all values that match a JSONPath expression and replaces them with the specified value
+(2) Searches for all values that match a JSONPath expression and replaces them with the result of the given function
 
 #### Parameters
 
@@ -23,8 +29,12 @@ Searches for all values that match a JSONPath expression and replaces them with 
     <td>JSONPath expression string</td> 
   </tr>
   <tr>
-    <td>new_value</td>
+    <td>(1) new_value</td>
     <td>The value to use as replacement</td> 
+  </tr>
+  <tr>
+    <td>(2) op</td>
+    <td>Callback function to rewrite values that matched the expression</td> 
   </tr>
 </table>
 
@@ -104,6 +114,83 @@ Output:
                 "price": 10.0,
                 "title": "Moby Dick"
             }
+        ]
+    }
+}
+```
+
+#### Change the prices of all books
+
+Input JSON file `booklist.json`:
+
+```json
+{ "store": {
+    "book": [ 
+      { "category": "reference",
+        "author": "Nigel Rees",
+        "title": "Sayings of the Century",
+        "price": 8.95
+      },
+      { "category": "fiction",
+        "author": "Evelyn Waugh",
+        "title": "Sword of Honour",
+        "price": 12.99
+      },
+      { "category": "fiction",
+        "author": "Herman Melville",
+        "title": "Moby Dick",
+        "isbn": "0-553-21311-3",
+        "price": 8.99
+      }
+    ]
+  }
+}
+```
+```c++
+#include <jsoncons/json.hpp>
+#include <jsoncons_ext/jsonpath/jsonpath.hpp>
+#include <cmath>
+
+using namespace jsoncons;
+using namespace jsoncons::jsonpath;
+
+int main()
+{
+    std::ifstream is("input/booklist.json");
+    json booklist;
+    is >> booklist;
+
+    // make a discount on all books
+	jsonpath::json_replace(booklist, "$.store.book[*].price",
+			[](const json& price) { return std::round(price.as<double>() - 1.0); });
+    std::cout << pretty_print(booklist) << std::endl;
+
+}
+```
+Output:
+```json
+{
+    "store": {
+        "book": [
+            {
+                "author": "Nigel Rees", 
+                "category": "reference", 
+                "price": 8.0, 
+                "title": "Sayings of the Century"
+            }, 
+            {
+                "author": "Evelyn Waugh", 
+                "category": "fiction", 
+                "price": 12.0, 
+                "title": "Sword of Honour"
+            }, 
+            {
+                "author": "Herman Melville", 
+                "category": "fiction", 
+                "isbn": "0-553-21311-3", 
+                "price": 8.0, 
+                "title": "Moby Dick"
+            } 
         ]
     }
 }

--- a/examples/src/jsonpath_examples.cpp
+++ b/examples/src/jsonpath_examples.cpp
@@ -3,6 +3,7 @@
 
 #include <string>
 #include <fstream>
+#include <cmath>
 #include <cassert>
 #include <jsoncons/json.hpp>
 #include <jsoncons_ext/jsonpath/jsonpath.hpp>
@@ -110,6 +111,18 @@ namespace {
 
         std::cout << ("2\n") << pretty_print(j) << "\n";
     }
+
+    void json_replace_example3()
+    {
+        std::ifstream is("./input/booklist.json");
+        json booklist = json::parse(is);
+
+        // make a discount on all books
+        jsonpath::json_replace(booklist, "$.store.book[*].price",
+                [](const json& price) { return std::round(price.as<double>() - 1.0); });
+        std::cout << pretty_print(booklist);
+    }
+
 
     void jsonpath_complex_examples()
     {
@@ -276,6 +289,7 @@ void jsonpath_examples()
     std::cout << "\nJsonPath examples\n\n";
     json_replace_example1();
     json_replace_example2();
+    json_replace_example3();
     jsonpath_complex_examples();
     jsonpath_union();
     json_query_examples();

--- a/include/jsoncons/detail/more_type_traits.hpp
+++ b/include/jsoncons/detail/more_type_traits.hpp
@@ -669,6 +669,17 @@ namespace impl {
     template<class T>
     using
     is_constructible_from_string = is_detected<construct_from_string_t,T>;
+
+    // is_function_object
+
+    template<class FunctionObject, class Arg>
+        using
+        function_object_t = decltype(std::declval<FunctionObject>()(std::declval<Arg>()));
+
+    template<class FunctionObject, class Arg>
+        using
+        is_function_object = jsoncons::detail::is_detected<function_object_t, FunctionObject, Arg>;
+
 } // detail
 } // jsoncons
 


### PR DESCRIPTION
This makes it possible to change values depending on their previous values.
With json_replace() it is possible to replace a matched value with a new predefined value but it is not possible to rewrite the value depending on the previous value.
Getting the pointers of the matched values allows us to run search-and-replace rules on the old value to generate the new value.