### PR TITLE
add missing copy/move assignment operators to json_object

### DIFF
--- a/include/jsoncons/allocator_holder.hpp
+++ b/include/jsoncons/allocator_holder.hpp
@@ -22,7 +22,7 @@ public:
     allocator_holder(allocator_holder&&)  = default;
     allocator_holder& operator=(const allocator_holder&)  = default;
     allocator_holder& operator=(allocator_holder&&)  = default;
-    allocator_holder(const allocator_type&)
+    allocator_holder(const allocator_type& alloc)
         : alloc_(alloc)
         {}
     ~allocator_holder() = default;

--- a/include/jsoncons/allocator_holder.hpp
+++ b/include/jsoncons/allocator_holder.hpp
@@ -18,10 +18,13 @@ private:
     allocator_type alloc_;
 public:
     allocator_holder() = default;
-    allocator_holder(const allocator_type&)  = default;
-    allocator_holder(allocator_type&&)  = default;
-    allocator_holder& operator=(const allocator_type&)  = default;
-    allocator_holder& operator=(allocator_type&&)  = default;
+    allocator_holder(const allocator_holder&)  = default;
+    allocator_holder(allocator_holder&&)  = default;
+    allocator_holder& operator=(const allocator_holder&)  = default;
+    allocator_holder& operator=(allocator_holder&&)  = default;
+    allocator_holder(const allocator_type&)
+        : alloc_(alloc)
+        {}
     ~allocator_holder() = default;
     
     allocator_type get_allocator() const

--- a/include/jsoncons/allocator_holder.hpp
+++ b/include/jsoncons/allocator_holder.hpp
@@ -17,15 +17,13 @@ public:
 private:
     allocator_type alloc_;
 public:
-    allocator_holder()
-        : alloc_()
-    {
-    }
-    allocator_holder(const allocator_type& alloc)
-        : alloc_(alloc)
-    {
-    }
-
+    allocator_holder() = default;
+    allocator_holder(const allocator_type&)  = default;
+    allocator_holder(allocator_type&&)  = default;
+    allocator_holder& operator=(const allocator_type&)  = default;
+    allocator_holder& operator=(allocator_type&&)  = default;
+    ~allocator_holder() = default;
+    
     allocator_type get_allocator() const
     {
         return alloc_;

--- a/include/jsoncons/json_container_types.hpp
+++ b/include/jsoncons/json_container_types.hpp
@@ -565,10 +565,21 @@ namespace jsoncons {
         {
         }
 
+        json_object& operator=(const json_object& val)
+        {
+            allocator_holder<allocator_type>::operator=(val.get_allocator());
+            members_ = val.members_;
+        }
+
         json_object(json_object&& val)
             : allocator_holder<allocator_type>(val.get_allocator()), 
               members_(std::move(val.members_))
         {
+        }
+
+        json_object& operator=(json_object&& val)
+        {
+            val.swap(*this);
         }
 
         json_object(const json_object& val, const allocator_type& alloc) 
@@ -1203,8 +1214,6 @@ namespace jsoncons {
                 }
             }
         }
-
-        json_object& operator=(const json_object&) = delete;
     };
 
     // Preserve order
@@ -1251,11 +1260,23 @@ namespace jsoncons {
         {
         }
 
+        json_object& operator=(const json_object& val)
+        {
+            allocator_holder<allocator_type>::operator=(val.get_allocator());
+            members_ = val.members_;
+            index_ = val.index_;
+        }
+
         json_object(json_object&& val)
             : allocator_holder<allocator_type>(val.get_allocator()), 
               members_(std::move(val.members_)),
               index_(std::move(val.index_))
         {
+        }
+
+        json_object& operator=(json_object&& val)
+        {
+            val.swap(*this);
         }
 
         json_object(const json_object& val, const allocator_type& alloc) 
@@ -1977,8 +1998,6 @@ namespace jsoncons {
             std::stable_sort(index_.begin(),index_.end(),
                              [&](std::size_t a, std::size_t b) -> bool {return members_.at(a).key().compare(members_.at(b).key()) < 0;});
         }
-
-        json_object& operator=(const json_object&) = delete;
     };
 
 } // namespace jsoncons

--- a/tests/src/json_object_tests.cpp
+++ b/tests/src/json_object_tests.cpp
@@ -237,7 +237,20 @@ TEST_CASE("test_empty_object_copy")
     CHECK(b.is_object());
 }
 
-TEST_CASE("test_empty_object_assignment")
+TEST_CASE("test_empty_object_move")
+{
+    json a;
+    CHECK(a.size() == 0);
+    CHECK(a.is_object());
+    CHECK(a.is_object());
+
+    json b = std::move(a);
+    CHECK(b.size() == 0);
+    CHECK(b.is_object());
+    CHECK(b.is_object());
+}
+
+TEST_CASE("test_empty_object_copy_assignment")
 {
     json a;
     CHECK(a.size() == 0);
@@ -260,6 +273,35 @@ TEST_CASE("test_empty_object_assignment")
     CHECK(c.is_object());
     CHECK(c.is_object());
     c = a;
+    CHECK(c.size() == 0);
+    CHECK(c.is_object());
+    CHECK(c.is_object());
+}
+
+TEST_CASE("test_empty_object_move_assignment")
+{
+    json a;
+    CHECK(a.size() == 0);
+    CHECK(a.is_object());
+    CHECK(a.is_object());
+
+    json b = json::make_array(10);
+    CHECK(b.size() == 10);
+    CHECK(b.is_array());
+    CHECK(b.is_array());
+
+    b = std::move(a);
+    CHECK(b.size() == 0);
+    CHECK(b.is_object());
+    CHECK(b.is_object());
+
+    json c;
+    c["key"] = "value";
+    CHECK(c.size() == 1);
+    CHECK(c.is_object());
+    CHECK(c.is_object());
+
+    c = std::move(b);
     CHECK(c.size() == 0);
     CHECK(c.is_object());
     CHECK(c.is_object());


### PR DESCRIPTION
While trying to use this library I ran into this issue, the copy/move constructor are implemented however the `operator=` where not present or deleted in the top level object. They are however implemented throughout the code back such as:

https://github.com/danielaparker/jsoncons/blob/b9e95d6a0bcb2dc8a821d33f98a530f10cfe1bc0/include/jsoncons/json_container_types.hpp#L416
https://github.com/danielaparker/jsoncons/blob/b9e95d6a0bcb2dc8a821d33f98a530f10cfe1bc0/include/jsoncons/json_container_types.hpp#L426

Perhaps there is a reason but looking at the git blame there was no obvious reason why but feel free to enlighten me 🤓 

I also noticed they are missing from the `json_array` which might be something to considered in the future!