### PR TITLE
Fix incorrect custom-specializations.md docs

### DIFF
--- a/doc/ref/json_type_traits/custom-specializations.md
+++ b/doc/ref/json_type_traits/custom-specializations.md
@@ -158,7 +158,7 @@ To save typing and enhance readability, the jsoncons library defines macros,
 so you could also write
 
 ```c++
-JSONCONS_N_MEMBER_TRAITS(ns::book, author, title, price)
+JSONCONS_ALL_MEMBER_TRAITS(ns::book, author, title, price)
 ```
 
 which expands to the code above.


### PR DESCRIPTION
The current documentation [`Custom specialization`](https://github.com/danielaparker/jsoncons/blob/master/doc/ref/json_type_traits/custom-specializations.md#custom-specialization) is wrong and the example showing how to specialize a custom class to support `json_type_traits` fails to compile because the wrong macro is used.