### PR TITLE
Get rid of gcc warning -Wnon-virtual-dtor

### DIFF
--- a/include/jsoncons_ext/jsonpath/path_expression.hpp
+++ b/include/jsoncons_ext/jsonpath/path_expression.hpp
@@ -512,7 +512,11 @@ namespace detail {
         virtual JsonReference evaluate(dynamic_resources<Json,JsonReference>&,
                              JsonReference, 
                              JsonReference, 
+
                              std::error_code&) const = 0;
+
+    protected:
+        ~binary_operator() = default;
     };
 
     // Implementations


### PR DESCRIPTION
We get warnings when compiling the jsonpath extension:
`... has accessible non-virtual destructor [-Wnon-virtual-dtor]`

Simply defining a defaulted virtual destructor for the base class `binary_operator` removes the warning.