### PR TITLE
Fix memory leak in jsoncons::jsonpath::node_set

### DIFF
--- a/include/jsoncons_ext/jsonpath/path_expression.hpp
+++ b/include/jsoncons_ext/jsonpath/path_expression.hpp
@@ -2472,6 +2472,9 @@ namespace detail {
                 case node_set_tag::multi:
                     nodes.~vector();
                     break;
+                case node_set_tag::single:
+                    node.~path_node_type();
+                    break;
                 default:
                     break;
             }


### PR DESCRIPTION
There is a memory leak in node_set when it holds only one node.