### PR TITLE
Make implementation_type public in container types

### DIFF
--- a/include/jsoncons/json_container_types.hpp
+++ b/include/jsoncons/json_container_types.hpp
@@ -32,8 +32,8 @@ namespace jsoncons {
     public:
         using allocator_type = typename Json::allocator_type;
         using value_type = Json;
-    private:
         using implementation_policy = typename Json::implementation_policy;
+    private:
         using value_allocator_type = typename std::allocator_traits<allocator_type>:: template rebind_alloc<value_type>;                   
         using value_container_type = typename implementation_policy::template sequence_container_type<value_type,value_allocator_type>;
         value_container_type elements_;
@@ -537,8 +537,8 @@ namespace jsoncons {
         using key_value_type = key_value<KeyT,Json>;
         using char_type = typename Json::char_type;
         using string_view_type = typename Json::string_view_type;
-    private:
         using implementation_policy = typename Json::implementation_policy;
+    private:
         using key_value_allocator_type = typename std::allocator_traits<allocator_type>:: template rebind_alloc<key_value_type>;                       
         using key_value_container_type = typename implementation_policy::template sequence_container_type<key_value_type,key_value_allocator_type>;
 
@@ -1235,8 +1235,8 @@ namespace jsoncons {
         //using mapped_type = Json;
         using string_view_type = typename Json::string_view_type;
         using key_value_type = key_value<KeyT,Json>;
-    private:
         using implementation_policy = typename Json::implementation_policy;
+    private:
         using key_value_allocator_type = typename std::allocator_traits<allocator_type>:: template rebind_alloc<key_value_type>;                       
         using key_value_container_type = typename implementation_policy::template sequence_container_type<key_value_type,key_value_allocator_type>;
         typedef typename std::allocator_traits<allocator_type>:: template rebind_alloc<std::size_t> index_allocator_type;


### PR DESCRIPTION
This is used by jsoncons::type_traits::detail::basic_json_t in certain
circumstances, and ICC does not like that it is not publicly accessible.

Fixes compilation errors like:

```
jsoncons/basic_json.hpp(49): error #525: type "jsoncons::json_object<KeyT, Json, std::enable_if<std::is_same<Json::implementation_policy::key_order, jsoncons::sort_key_order>::value, void>::type>::implementation_policy [with KeyT=std::basic_string<char, std::char_traits<char>, std::allocator<char>>, Json=jsoncons::basic_json<char, jsoncons::sorted_policy, std::allocator<char>>]" (declared at line 541 of "jsoncons/json_container_types.hpp") is an inaccessible type (allowed for cfront compatibility)
basic_json_t = basic_json<typename T::char_type,typename T::implementation_policy,typename T::allocator_type>;
detected during:
    instantiation of type "jsoncons::type_traits::detail::basic_json_t<jsoncons::json_object<std::basic_string<char, std::char_traits<char>, std::allocator<char>>, jsoncons::basic_json<char, jsoncons::sorted_policy, std::allocator<char>>, void>>" at line 182 of "jsoncons/more_type_traits.hpp"
```