### PR TITLE
Fix shadowed variables in constructors for ICC 18.0 on Windows

### DIFF
--- a/include/jsoncons/detail/parse_number.hpp
+++ b/include/jsoncons/detail/parse_number.hpp
@@ -78,12 +78,12 @@ struct to_integer_result
 {
     const CharT* ptr;
     to_integer_errc ec;
-    constexpr to_integer_result(const CharT* ptr)
-        : ptr(ptr), ec(to_integer_errc())
+    constexpr to_integer_result(const CharT* ptr_)
+        : ptr(ptr_), ec(to_integer_errc())
     {
     }
-    constexpr to_integer_result(const CharT* ptr, to_integer_errc ec)
-        : ptr(ptr), ec(ec)
+    constexpr to_integer_result(const CharT* ptr_, to_integer_errc ec_)
+        : ptr(ptr_), ec(ec_)
     {
     }
 

--- a/include/jsoncons_ext/bson/bson_parser.hpp
+++ b/include/jsoncons_ext/bson/bson_parser.hpp
@@ -33,8 +33,8 @@ struct parse_state
     uint8_t type;
     std::size_t index;
 
-    parse_state(parse_mode mode, std::size_t length, std::size_t pos, uint8_t type = 0) noexcept
-        : mode(mode), length(length), pos(pos), type(type), index(0)
+    parse_state(parse_mode mode_, std::size_t length_, std::size_t pos_, uint8_t type_ = 0) noexcept
+        : mode(mode_), length(length_), pos(pos_), type(type_), index(0)
     {
     }
 


### PR DESCRIPTION
Fixes ICC compilation messages like:

jsoncons/detail/parse_number.hpp(85): message #3280: declaration hides member "jsoncons::detail::to_integer_result<T, CharT>::ptr [with T=uint64_t={unsigned __int64}, CharT=__wchar_t]" (declared at line 79) [C:\gitlab-runner\builds\sE-ja_c6\0\ofan\ont_core_cpp\msvc-build\test\ont_core_cpp_tests.vcxproj]
        constexpr to_integer_result(const CharT* ptr, to_integer_errc ec)
                                                 ^
            detected during:
              instantiation of "jsoncons::detail::to_integer_result<T, CharT>::to_integer_result(const CharT *, jsoncons::detail::to_integer_errc) [with T=uint64_t={unsigned __int64}, CharT=__wchar_t]" at line 552
              instantiation of "std::enable_if<<expression>, jsoncons::detail::to_integer_result<T, CharT>>::type jsoncons::detail::to_integer_unchecked(const CharT *, size_t={unsigned __int64}, T &) [with T=uint64_t={unsigned __int64}, CharT=__wchar_t]" at line 2660 of "C:\gitlab-runner\builds\sE-ja_c6\0\ofan\ont_core_cpp\bass\third_party\include\jsoncons/json_parser.hpp"
              instantiation of "void jsoncons::basic_json_parser<CharT, TempAllocator>::end_positive_value(jsoncons::basic_json_visitor<CharT> &, std::error_code &) [with CharT=__wchar_t, TempAllocator=std::allocator<char>]" at line 2638 of "C:\gitlab-runner\builds\sE-ja_c6\0\ofan\ont_core_cpp\bass\third_party\include\jsoncons/json_parser.hpp"
              instantiation of "void jsoncons::basic_json_parser<CharT, TempAllocator>::end_integer_value(jsoncons::basic_json_visitor<CharT> &, std::error_code &) [with CharT=__wchar_t, TempAllocator=std::allocator<char>]" at line 578 of "C:\gitlab-runner\builds\sE-ja_c6\0\ofan\ont_core_cpp\bass\third_party\include\jsoncons/json_parser.hpp"
              instantiation of "void jsoncons::basic_json_parser<CharT, TempAllocator>::parse_some_(jsoncons::basic_json_visitor<CharT> &, std::error_code &) [with CharT=__wchar_t, TempAllocator=std::allocator<char>]" at line 539 of "C:\gitlab-runner\builds\sE-ja_c6\0\ofan\ont_core_cpp\bass\third_party\include\jsoncons/json_parser.hpp"
              instantiation of "void jsoncons::basic_json_parser<CharT, TempAllocator>::parse_some(jsoncons::basic_json_visitor<CharT> &, std::error_code &) [with CharT=__wchar_t, TempAllocator=std::allocator<char>]" at line 530 of "C:\gitlab-runner\builds\sE-ja_c6\0\ofan\ont_core_cpp\bass\third_party\include\jsoncons/json_parser.hpp"
              instantiation of "void jsoncons::basic_json_parser<CharT, TempAllocator>::parse_some(jsoncons::basic_json_visitor<CharT> &) [with CharT=__wchar_t, TempAllocator=std::allocator<char>]" at line 2704 of "C:\gitlab-runner\builds\sE-ja_c6\0\ofan\ont_core_cpp\bass\third_party\include\jsoncons/basic_json.hpp"
              instantiation of "std::enable_if<jsoncons::type_traits::is_sequence_of<Source, jsoncons::basic_json<CharT, ImplementationPolicy, Allocator>::char_type, void>::value, jsoncons::basic_json<CharT, ImplementationPolicy, Allocator>>::type jsoncons::basic_json<CharT, ImplementationPolicy, Allocator>::parse(const Source &, const jsoncons::basic_json_decode_options<jsoncons::basic_json<CharT, ImplementationPolicy, Allocator>::char_type> &, std::function<bool (jsoncons::json_errc, const
                        jsoncons::ser_context &)>) [with CharT=__wchar_t, ImplementationPolicy=jsoncons::sorted_policy, Allocator=std::allocator<char>, Source=jsoncons::detail::basic_string_view<__wchar_t, std::char_traits<__wchar_t>>]" at line 5799 of "C:\gitlab-runner\builds\sE-ja_c6\0\ofan\ont_core_cpp\bass\third_party\include\jsoncons/basic_json.hpp"

                        jsoncons/detail/parse_number.hpp(85): message #3280: declaration hides member "jsoncons::detail::to_integer_result<T, CharT>::ptr [with T=uint64_t={unsigned __int64}, CharT=__wchar_t]" (declared at line 79) [C:\gitlab-runner\builds\sE-ja_c6\0\ofan\ont_core_cpp\msvc-build\test\ont_core_cpp_tests.vcxproj]
        constexpr to_integer_result(const CharT* ptr, to_integer_errc ec)
                                                 ^
            detected during:
              instantiation of "jsoncons::detail::to_integer_result<T, CharT>::to_integer_result(const CharT *, jsoncons::detail::to_integer_errc) [with T=uint64_t={unsigned __int64}, CharT=__wchar_t]" at line 552
              instantiation of "std::enable_if<<expression>, jsoncons::detail::to_integer_result<T, CharT>>::type jsoncons::detail::to_integer_unchecked(const CharT *, size_t={unsigned __int64}, T &) [with T=uint64_t={unsigned __int64}, CharT=__wchar_t]" at line 2660 of "C:\gitlab-runner\builds\sE-ja_c6\0\ofan\ont_core_cpp\bass\third_party\include\jsoncons/json_parser.hpp"
              instantiation of "void jsoncons::basic_json_parser<CharT, TempAllocator>::end_positive_value(jsoncons::basic_json_visitor<CharT> &, std::error_code &) [with CharT=__wchar_t, TempAllocator=std::allocator<char>]" at line 2638 of "C:\gitlab-runner\builds\sE-ja_c6\0\ofan\ont_core_cpp\bass\third_party\include\jsoncons/json_parser.hpp"
              instantiation of "void jsoncons::basic_json_parser<CharT, TempAllocator>::end_integer_value(jsoncons::basic_json_visitor<CharT> &, std::error_code &) [with CharT=__wchar_t, TempAllocator=std::allocator<char>]" at line 578 of "C:\gitlab-runner\builds\sE-ja_c6\0\ofan\ont_core_cpp\bass\third_party\include\jsoncons/json_parser.hpp"
              instantiation of "void jsoncons::basic_json_parser<CharT, TempAllocator>::parse_some_(jsoncons::basic_json_visitor<CharT> &, std::error_code &) [with CharT=__wchar_t, TempAllocator=std::allocator<char>]" at line 539 of "C:\gitlab-runner\builds\sE-ja_c6\0\ofan\ont_core_cpp\bass\third_party\include\jsoncons/json_parser.hpp"
              instantiation of "void jsoncons::basic_json_parser<CharT, TempAllocator>::parse_some(jsoncons::basic_json_visitor<CharT> &, std::error_code &) [with CharT=__wchar_t, TempAllocator=std::allocator<char>]" at line 530 of "C:\gitlab-runner\builds\sE-ja_c6\0\ofan\ont_core_cpp\bass\third_party\include\jsoncons/json_parser.hpp"
              instantiation of "void jsoncons::basic_json_parser<CharT, TempAllocator>::parse_some(jsoncons::basic_json_visitor<CharT> &) [with CharT=__wchar_t, TempAllocator=std::allocator<char>]" at line 2704 of "C:\gitlab-runner\builds\sE-ja_c6\0\ofan\ont_core_cpp\bass\third_party\include\jsoncons/basic_json.hpp"
              instantiation of "std::enable_if<jsoncons::type_traits::is_sequence_of<Source, jsoncons::basic_json<CharT, ImplementationPolicy, Allocator>::char_type, void>::value, jsoncons::basic_json<CharT, ImplementationPolicy, Allocator>>::type jsoncons::basic_json<CharT, ImplementationPolicy, Allocator>::parse(const Source &, const jsoncons::basic_json_decode_options<jsoncons::basic_json<CharT, ImplementationPolicy, Allocator>::char_type> &, std::function<bool (jsoncons::json_errc, const
                        jsoncons::ser_context &)>) [with CharT=__wchar_t, ImplementationPolicy=jsoncons::sorted_policy, Allocator=std::allocator<char>, Source=jsoncons::detail::basic_string_view<__wchar_t, std::char_traits<__wchar_t>>]" at line 5799 of "C:\gitlab-runner\builds\sE-ja_c6\0\ofan\ont_core_cpp\bass\third_party\include\jsoncons/basic_json.hpp"

and

jsoncons_ext/bson/bson_parser.hpp(36): message #3280: declaration hides member "jsoncons::bson::parse_state::mode" (declared at line 30) [C:\gitlab-runner\builds\sE-ja_c6\0\ofan\ont_core_cpp\msvc-build\guppy\model_convert\model_convert.vcxproj]
        parse_state(parse_mode mode, std::size_t length, std::size_t pos, uint8_t type = 0) noexcept