### PR TITLE
chore: Set permissions for GitHub actions

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -9,9 +9,16 @@ on:
   schedule:
     - cron: '0 19 * * 1'
 
+permissions:
+  contents: read
+
 jobs:
   CodeQL-Build:
 
+    permissions:
+      actions: read  # for github/codeql-action/init to get workflow details
+      contents: read  # for actions/checkout to fetch code
+      security-events: write  # for github/codeql-action/autobuild to send a status report
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -2,6 +2,9 @@ name: macOS
 
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   build:
 

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -2,6 +2,9 @@ name: Ubuntu
 
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   gcc_build:
     runs-on: ubuntu-latest

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -10,9 +10,6 @@ on:
       - 'README.md'
       - 'doc/**'
 
-permissions:
-  contents: read
-
 jobs:
   vs2022:
     strategy:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -10,6 +10,9 @@ on:
       - 'README.md'
       - 'doc/**'
 
+permissions:
+  contents: read
+
 jobs:
   vs2022:
     strategy:

--- a/.github/workflows/windows.yml.bak
+++ b/.github/workflows/windows.yml.bak
@@ -2,6 +2,9 @@ name: Windows
 
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   msvc2019:
     runs-on: windows-latest


### PR DESCRIPTION
 Restrict the GitHub token permissions only to the required ones; this way, even if the attackers will succeed in compromising your workflow, they won’t be able to do much.

- Included permissions for the action. https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions

https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions

https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs

[Keeping your GitHub Actions and workflows secure Part 1: Preventing pwn requests](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)

Signed-off-by: naveen <172697+naveensrinivasan@users.noreply.github.com>
