### PR TITLE
Feature383: Resettable parser/cursor/encoder for BSON,UBJSON,CSV

### DIFF
--- a/include/jsoncons_ext/bson/bson_cursor.hpp
+++ b/include/jsoncons_ext/bson/bson_cursor.hpp
@@ -87,10 +87,56 @@ public:
                       Sourceable&& source,
                       const bson_decode_options& options,
                       std::error_code& ec)
-       : parser_(std::forward<Sourceable>(source), alloc, options), 
+       : parser_(std::forward<Sourceable>(source), options, alloc),
          cursor_visitor_(accept_all),
          eof_(false)
     {
+        if (!done())
+        {
+            next(ec);
+        }
+    }
+
+    void reset()
+    {
+        parser_.reset();
+        cursor_visitor_.reset();
+        eof_ = false;
+        if (!done())
+        {
+            next();
+        }
+    }
+
+    template <class Sourceable>
+    void reset(Sourceable&& source)
+    {
+        parser_.reset(std::forward<Sourceable>(source));
+        cursor_visitor_.reset();
+        eof_ = false;
+        if (!done())
+        {
+            next();
+        }
+    }
+
+    void reset(std::error_code& ec)
+    {
+        parser_.reset();
+        cursor_visitor_.reset();
+        eof_ = false;
+        if (!done())
+        {
+            next(ec);
+        }
+    }
+
+    template <class Sourceable>
+    void reset(Sourceable&& source, std::error_code& ec)
+    {
+        parser_.reset(std::forward<Sourceable>(source));
+        cursor_visitor_.reset();
+        eof_ = false;
         if (!done())
         {
             next(ec);

--- a/include/jsoncons_ext/bson/bson_encoder.hpp
+++ b/include/jsoncons_ext/bson/bson_encoder.hpp
@@ -114,6 +114,19 @@ public:
         sink_.flush();
     }
 
+    void reset()
+    {
+        stack_.clear();
+        buffer_.clear();
+        nesting_depth_ = 0;
+    }
+
+    void reset(Sink&& sink)
+    {
+        sink_ = std::move(sink);
+        reset();
+    }
+
 private:
     // Implementing methods
 

--- a/include/jsoncons_ext/bson/bson_parser.hpp
+++ b/include/jsoncons_ext/bson/bson_parser.hpp
@@ -83,10 +83,19 @@ public:
 
     void reset()
     {
-        state_stack_.clear();
-        state_stack_.emplace_back(parse_mode::root,0,0);
         more_ = true;
         done_ = false;
+        bytes_buffer_.clear();
+        text_buffer_.clear();
+        state_stack_.clear();
+        state_stack_.emplace_back(parse_mode::root,0,0);
+    }
+
+    template <class Sourceable>
+    void reset(Sourceable&& source)
+    {
+        source_ = std::forward<Sourceable>(source);
+        reset();
     }
 
     bool done() const

--- a/include/jsoncons_ext/csv/csv_encoder.hpp
+++ b/include/jsoncons_ext/csv/csv_encoder.hpp
@@ -134,6 +134,22 @@ public:
         }
     }
 
+    void reset()
+    {
+        stack_.clear();
+        strings_buffer_.clear();
+        buffered_line_.clear();
+        name_.clear();
+        column_index_ = 0;
+        row_counts_.clear();
+    }
+
+    void reset(Sink&& sink)
+    {
+        sink_ = std::move(sink);
+        reset();
+    }
+
 private:
 
     template<class AnyWriter>
@@ -713,7 +729,7 @@ private:
     }
 
     template <class AnyWriter>
-    bool string_value(const CharT* s, std::size_t length, AnyWriter& sink)
+    bool do_string_value(const CharT* s, std::size_t length, AnyWriter& sink)
     {
         bool quote = false;
         if (options_.quote_style() == quote_style_kind::all || options_.quote_style() == quote_style_kind::nonnumeric ||
@@ -736,7 +752,7 @@ private:
     void write_string_value(const string_view_type& value, AnyWriter& sink)
     {
         begin_value(sink);
-        string_value(value.data(),value.length(),sink);
+        do_string_value(value.data(),value.length(),sink);
         end_value();
     }
 

--- a/include/jsoncons_ext/ubjson/ubjson_cursor.hpp
+++ b/include/jsoncons_ext/ubjson/ubjson_cursor.hpp
@@ -96,6 +96,52 @@ public:
         }
     }
 
+    void reset()
+    {
+        parser_.reset();
+        cursor_visitor_.reset();
+        eof_ = false;
+        if (!done())
+        {
+            next();
+        }
+    }
+
+    template <class Sourceable>
+    void reset(Sourceable&& source)
+    {
+        parser_.reset(std::forward<Sourceable>(source));
+        cursor_visitor_.reset();
+        eof_ = false;
+        if (!done())
+        {
+            next();
+        }
+    }
+
+    void reset(std::error_code& ec)
+    {
+        parser_.reset();
+        cursor_visitor_.reset();
+        eof_ = false;
+        if (!done())
+        {
+            next(ec);
+        }
+    }
+
+    template <class Sourceable>
+    void reset(Sourceable&& source, std::error_code& ec)
+    {
+        parser_.reset(std::forward<Sourceable>(source));
+        cursor_visitor_.reset();
+        eof_ = false;
+        if (!done())
+        {
+            next(ec);
+        }
+    }
+
     bool done() const override
     {
         return parser_.done();

--- a/include/jsoncons_ext/ubjson/ubjson_encoder.hpp
+++ b/include/jsoncons_ext/ubjson/ubjson_encoder.hpp
@@ -96,6 +96,18 @@ public:
     {
     }
 
+    void reset()
+    {
+        stack_.clear();
+        nesting_depth_ = 0;
+    }
+
+    void reset(Sink&& sink)
+    {
+        sink_ = std::move(sink);
+        reset();
+    }
+
     ~basic_ubjson_encoder() noexcept
     {
         JSONCONS_TRY

--- a/include/jsoncons_ext/ubjson/ubjson_parser.hpp
+++ b/include/jsoncons_ext/ubjson/ubjson_parser.hpp
@@ -78,10 +78,19 @@ public:
 
     void reset()
     {
-        state_stack_.clear();
-        state_stack_.emplace_back(parse_mode::root,0);
         more_ = true;
         done_ = false;
+        text_buffer_.clear();
+        state_stack_.clear();
+        state_stack_.emplace_back(parse_mode::root,0,0);
+        int nesting_depth_ = 0;
+    }
+
+    template <class Sourceable>
+    void reset(Sourceable&& source)
+    {
+        source_ = std::forward<Sourceable>(source);
+        reset();
     }
 
     bool done() const

--- a/include/jsoncons_ext/ubjson/ubjson_parser.hpp
+++ b/include/jsoncons_ext/ubjson/ubjson_parser.hpp
@@ -83,7 +83,7 @@ public:
         text_buffer_.clear();
         state_stack_.clear();
         state_stack_.emplace_back(parse_mode::root,0,0);
-        int nesting_depth_ = 0;
+        nesting_depth_ = 0;
     }
 
     template <class Sourceable>

--- a/test/bson/src/bson_cursor_tests.cpp
+++ b/test/bson/src/bson_cursor_tests.cpp
@@ -77,3 +77,230 @@ TEST_CASE("bson_cursor reputon test")
     }
 }
 
+TEST_CASE("bson_parser reset")
+{
+    std::vector<uint8_t> input1 = {
+        0x0C, 0x00, 0x00, 0x00, // Document: 12 bytes
+            0x10, // int32 field type
+                0x61, 0x00, // "a" field name
+                0x01, 0x00, 0x00, 0x00, // int32(1) field value
+        0x00, // end of object
+        0x0C, 0x00, 0x00, 0x00, // Document: 12 bytes
+            0x10, // int32 field type
+                0x62, 0x00, // "b" field name
+                0x02, 0x00, 0x00, 0x00, // int32(2) field value
+        0x00 // end of object
+    };
+
+
+    std::vector<uint8_t> input2 = {
+        0x0C, 0x00, 0x00, 0x00, // Document: 12 bytes
+            0x10, // int32 field type
+                0x63, 0x00, // "c" field name
+                0x03, 0x00, 0x00, 0x00, // int32(3) field value
+        0x00 // end of object
+    };
+
+    json expected1 = json::parse(R"({"a":1})");
+    json expected2 = json::parse(R"({"b":2})");
+    json expected3 = json::parse(R"({"c":3})");
+
+    json_decoder<json> destination;
+    bson::basic_bson_parser<bytes_source> parser{ input1 };
+    std::error_code ec;
+
+    SECTION("keeping same source")
+    {
+        parser.parse(destination, ec);
+        REQUIRE_FALSE(ec);
+        CHECK(destination.get_result() == expected1);
+
+        destination.reset();
+        parser.reset();
+        parser.parse(destination, ec);
+        CHECK_FALSE(ec);
+        CHECK(parser.stopped());
+        // TODO: This fails: CHECK(parser.done());
+        CHECK(destination.get_result() == expected2);
+    }
+
+    SECTION("with different source")
+    {
+        parser.parse(destination, ec);
+        REQUIRE_FALSE(ec);
+        CHECK(destination.get_result() == expected1);
+
+        destination.reset();
+        parser.reset(input2);
+        parser.parse(destination, ec);
+        CHECK_FALSE(ec);
+        CHECK(parser.stopped());
+        // TODO: This fails: CHECK(parser.done());
+        CHECK(destination.get_result() == expected3);
+    }
+}
+
+struct bson_bytes_cursor_reset_test_traits
+{
+    using cursor_type = bson::bson_bytes_cursor;
+    using input_type = std::vector<uint8_t>;
+
+    static void set_input(input_type& input, input_type bytes) {input = bytes;}
+};
+
+struct bson_stream_cursor_reset_test_traits
+{
+    using cursor_type = bson::bson_stream_cursor;
+
+    // binary_stream_source::char_type is actually char, not uint8_t
+    using input_type = std::istringstream;
+
+    static void set_input(input_type& input, std::vector<uint8_t> bytes)
+    {
+        auto data = reinterpret_cast<const char*>(bytes.data());
+        std::string s(data, bytes.size());
+        input.str(s);
+    }
+};
+
+template <typename CursorType>
+void check_bson_cursor_document(std::string info, CursorType& cursor,
+                                std::string expectedKey, int expectedValue)
+{
+    using event_type = staj_event_type;
+    INFO(info);
+
+    REQUIRE_FALSE(cursor.done());
+    CHECK(cursor.current().event_type() == event_type::begin_object);
+    CHECK(cursor.current().tag() == semantic_tag::none);
+
+    REQUIRE_FALSE(cursor.done());
+    cursor.next();
+    CHECK(cursor.current().event_type() == event_type::key);
+    CHECK(cursor.current().tag() == semantic_tag::none);
+    CHECK(cursor.current().template get<std::string>() == expectedKey);
+    CHECK(cursor.current().template get<jsoncons::string_view>() == expectedKey);
+
+    REQUIRE_FALSE(cursor.done());
+    cursor.next();
+    CHECK(cursor.current().event_type() == event_type::int64_value);
+    CHECK(cursor.current().tag() == semantic_tag::none);
+    CHECK(cursor.current().template get<int>() == expectedValue);
+
+    REQUIRE_FALSE(cursor.done());
+    cursor.next();
+    CHECK(cursor.current().event_type() == event_type::end_object);
+    CHECK(cursor.current().tag() == semantic_tag::none);
+
+    // Extra next() required to pop out of document state
+    CHECK_FALSE(cursor.done());
+    cursor.next();
+    CHECK(cursor.done());
+}
+
+TEMPLATE_TEST_CASE("bson_cursor reset test", "",
+                   bson_bytes_cursor_reset_test_traits,
+                   bson_stream_cursor_reset_test_traits)
+{
+    using traits = TestType;
+    using input_type = typename traits::input_type;
+    using cursor_type = typename traits::cursor_type;
+    using source_type = typename cursor_type::source_type;
+    using event_type = staj_event_type;
+
+    SECTION("keeping same source")
+    {
+        std::error_code ec;
+        input_type input;
+        traits::set_input(input, {
+            0x0C, 0x00, 0x00, 0x00, // Document: 12 bytes
+                0x10, // int32 field type
+                    0x61, 0x00, // "a" field name
+                    0x01, 0x00, 0x00, 0x00, // int32(1) field value
+            0x00, // end of object
+            0x0C, 0x00, 0x00, 0x00, // Document: 12 bytes
+                0x10, // int32 field type
+                    0x62, 0x00, // "b" field name
+                    0x02, 0x00, 0x00, 0x00, // int32(2) field value
+            0x00, // end of object
+            0x0C, 0x00, 0x00, 0x00, // Document: 12 bytes
+                0x10, // int32 field type
+                    0x63, 0x00, // "c" field name
+                    0x03, 0x00, 0x00, 0x00, // int32(3) field value
+            0x00 // end of object
+        });
+        source_type source(input);
+        cursor_type cursor(std::move(source));
+        check_bson_cursor_document("first document", cursor, "a", 1);
+        cursor.reset();
+        check_bson_cursor_document("second document", cursor, "b", 2);
+        cursor.reset(ec);
+        check_bson_cursor_document("third document", cursor, "c", 3);
+    }
+
+    SECTION("with another source")
+    {
+        std::error_code ec;
+        input_type input0;
+        input_type input1;
+        input_type input2;
+        input_type input3;
+        traits::set_input(input0, {});
+        traits::set_input(input1, {
+            0x0C, 0x00, 0x00, 0x00, // Document: 12 bytes
+                0x10, // int32 field type
+                    0x61, 0x00, // "a" field name
+                    0x01, 0x00, 0x00, 0x00, // int32(1) field value
+            0x00, // end of object
+        });
+        traits::set_input(input2, {
+            0x09, 0x00, 0x00, 0x00, // Document: 9 bytes
+                0x20, // invalid field type
+                    0x62, 0x00, // "b" field name
+                    0x00, // bogus field value
+            0x00, // end of object
+        });
+        traits::set_input(input3, {
+            0x0C, 0x00, 0x00, 0x00, // Document: 12 bytes
+                0x10, // int32 field type
+                    0x63, 0x00, // "c" field name
+                    0x03, 0x00, 0x00, 0x00, // int32(3) field value
+            0x00, // end of object
+        });
+
+        // Constructing cursor with blank input results in unexpected_eof
+        // error because it eagerly parses the next event upon construction.
+        cursor_type cursor(input0, ec);
+        CHECK(ec == bson::bson_errc::unexpected_eof);
+        CHECK_FALSE(cursor.done());
+
+        // Reset to valid input1
+        cursor.reset(input1);
+        check_bson_cursor_document("first document", cursor, "a", 1);
+
+        // Reset to invalid input2
+        ec = bson::bson_errc::success;
+        cursor.reset(input2, ec);
+        REQUIRE_FALSE(ec);
+        REQUIRE_FALSE(cursor.done());
+        CHECK(cursor.current().event_type() == event_type::begin_object);
+        CHECK(cursor.current().tag() == semantic_tag::none);
+        REQUIRE_FALSE(cursor.done());
+        cursor.next(ec);
+        REQUIRE_FALSE(ec);
+        REQUIRE_FALSE(cursor.done());
+        CHECK(cursor.current().event_type() == event_type::key);
+        CHECK(cursor.current().tag() == semantic_tag::none);
+        CHECK(cursor.current().template get<std::string>() == std::string("b"));
+        CHECK(cursor.current().template get<jsoncons::string_view>() ==
+              jsoncons::string_view("b"));
+        cursor.next(ec);
+        CHECK(ec == bson::bson_errc::unknown_type);
+        CHECK_FALSE(cursor.done());
+
+        // Reset to valid input3
+        ec = bson::bson_errc::success;
+        cursor.reset(input3, ec);
+        check_bson_cursor_document("third document", cursor, "c", 3);
+    }
+}

--- a/test/cbor/src/cbor_cursor_tests.cpp
+++ b/test/cbor/src/cbor_cursor_tests.cpp
@@ -367,6 +367,7 @@ TEMPLATE_TEST_CASE("cbor_cursor reset test", "",
         CHECK(cursor.done());
 
         // Reset to invalid input2
+        ec = cbor::cbor_errc::success;
         cursor.reset(input2, ec);
         CHECK(ec == cbor::cbor_errc::unknown_type);
         CHECK_FALSE(cursor.done());

--- a/test/msgpack/src/msgpack_cursor_tests.cpp
+++ b/test/msgpack/src/msgpack_cursor_tests.cpp
@@ -369,6 +369,7 @@ TEMPLATE_TEST_CASE("msgpack_cursor reset test", "",
         CHECK(cursor.done());
 
         // Reset to invalid input2
+        ec = msgpack::msgpack_errc::success;
         cursor.reset(input2, ec);
         CHECK(ec == msgpack::msgpack_errc::unknown_type);
         CHECK_FALSE(cursor.done());

--- a/test/src/json_parser_tests.cpp
+++ b/test/src/json_parser_tests.cpp
@@ -283,6 +283,7 @@ TEST_CASE("test_parser_reinitialization")
     parser.update("false true", 10);
     parser.finish_parse(decoder);
     CHECK(parser.done());
+    CHECK_FALSE(parser.source_exhausted());
     json j1 = decoder.get_result();
     REQUIRE(j1.is_bool());
     CHECK_FALSE(j1.as<bool>());
@@ -291,6 +292,7 @@ TEST_CASE("test_parser_reinitialization")
     parser.update("-42", 3);
     parser.finish_parse(decoder);
     CHECK(parser.done());
+    CHECK(parser.source_exhausted());
     json j2 = decoder.get_result();
     REQUIRE(j2.is_int64());
     CHECK(j2.as<int64_t>() == -42);

--- a/test/ubjson/src/ubjson_cursor_tests.cpp
+++ b/test/ubjson/src/ubjson_cursor_tests.cpp
@@ -214,3 +214,175 @@ TEST_CASE("ubjson_cursor with filter tests")
     CHECK(filtered_c.done());
 }
 
+TEST_CASE("ubjson_parser reset", "")
+{
+    std::vector<uint8_t> input1 = {
+        '[','U',0x01,'U',0x02,']', // array, uint8(1), uint8(2), end array
+        '{','U',0x01,'c','U',0x04,'}' // map, "c", uint(4), end map
+    };
+
+    std::vector<uint8_t> input2 = {
+        '{','U',0x01,'e','U',0x06,'}' // map, "e", uint(6), end map
+    };
+
+    json expected1 = json::parse(R"([1,2])");
+    json expected2 = json::parse(R"({"c":4})");
+    json expected3 = json::parse(R"({"e":6})");
+
+    json_decoder<json> destination;
+    ubjson::basic_ubjson_parser<bytes_source> parser{ input1 };
+    std::error_code ec;
+
+    SECTION("keeping same source")
+    {
+        parser.parse(destination, ec);
+        REQUIRE_FALSE(ec);
+        CHECK(destination.get_result() == expected1);
+
+        destination.reset();
+        parser.reset();
+        parser.parse(destination, ec);
+        CHECK_FALSE(ec);
+        CHECK(parser.stopped());
+        // TODO: This fails: CHECK(parser.done());
+        CHECK(destination.get_result() == expected2);
+    }
+
+    SECTION("with different source")
+    {
+        parser.parse(destination, ec);
+        REQUIRE_FALSE(ec);
+        CHECK(destination.get_result() == expected1);
+
+        destination.reset();
+        parser.reset(input2);
+        parser.parse(destination, ec);
+        CHECK_FALSE(ec);
+        CHECK(parser.stopped());
+        // TODO: This fails: CHECK(parser.done());
+        CHECK(destination.get_result() == expected3);
+    }
+}
+
+struct ubjson_bytes_cursor_reset_test_traits
+{
+    using cursor_type = ubjson::ubjson_bytes_cursor;
+    using input_type = std::vector<uint8_t>;
+
+    static void set_input(input_type& input, input_type bytes) {input = bytes;}
+};
+
+struct ubjson_stream_cursor_reset_test_traits
+{
+    using cursor_type = ubjson::ubjson_stream_cursor;
+
+    // binary_stream_source::char_type is actually char, not uint8_t
+    using input_type = std::istringstream;
+
+    static void set_input(input_type& input, std::vector<uint8_t> bytes)
+    {
+        auto data = reinterpret_cast<const char*>(bytes.data());
+        std::string s(data, bytes.size());
+        input.str(s);
+    }
+};
+
+TEMPLATE_TEST_CASE("ubjson_cursor reset test", "",
+                   ubjson_bytes_cursor_reset_test_traits,
+                   ubjson_stream_cursor_reset_test_traits)
+{
+    using traits = TestType;
+    using input_type = typename traits::input_type;
+    using cursor_type = typename traits::cursor_type;
+    using source_type = typename cursor_type::source_type;
+    using event_type = staj_event_type;
+
+    SECTION("keeping same source")
+    {
+        std::error_code ec;
+        input_type input;
+        traits::set_input(input, {
+            'S', 'U', 3, 'T', 'o', 'm', // string(3) "Tom"
+            'i', 0x9c, // int8(-100)
+            'Z' // null
+        });
+        source_type source(input);
+        cursor_type cursor(std::move(source));
+
+        REQUIRE_FALSE(cursor.done());
+        CHECK(cursor.current().event_type() == event_type::string_value);
+        CHECK(cursor.current().tag() == semantic_tag::none);
+        CHECK(cursor.current().template get<std::string>() == std::string("Tom"));
+        CHECK(cursor.current().template get<jsoncons::string_view>() ==
+              jsoncons::string_view("Tom"));
+        cursor.next();
+        CHECK(cursor.done());
+
+        cursor.reset();
+        REQUIRE_FALSE(cursor.done());
+        CHECK(cursor.current().event_type() == event_type::int64_value);
+        CHECK(cursor.current().tag() == semantic_tag::none);
+        CHECK(cursor.current().template get<int>() == -100);
+        cursor.next();
+        CHECK(cursor.done());
+
+        cursor.reset(ec);
+        REQUIRE_FALSE(ec);
+        REQUIRE_FALSE(cursor.done());
+        CHECK(cursor.current().event_type() == event_type::null_value);
+        CHECK(cursor.current().tag() == semantic_tag::none);
+        cursor.next(ec);
+        REQUIRE_FALSE(ec);
+        CHECK(cursor.done());
+    }
+
+    SECTION("with another source")
+    {
+        std::error_code ec;
+        input_type input0;
+        input_type input1;
+        input_type input2;
+        input_type input3;
+        traits::set_input(input0, {});
+        traits::set_input(input1, {'S', 'U', 3, 'T', 'o', 'm'}); // string(3) "Tom"
+        traits::set_input(input2, {'A'}); // invalid type
+        traits::set_input(input3, {'i', 0x9c}); // int8(-100)
+
+        // Constructing cursor with blank input results in unexpected_eof
+        // error because it eagerly parses the next event upon construction.
+        cursor_type cursor(input0, ec);
+        CHECK(ec == ubjson::ubjson_errc::unexpected_eof);
+        CHECK_FALSE(cursor.done());
+
+        // Reset to valid input1
+        cursor.reset(input1);
+        CHECK(cursor.current().event_type() == event_type::string_value);
+        CHECK(cursor.current().tag() == semantic_tag::none);
+        CHECK(cursor.current().template get<std::string>() == std::string("Tom"));
+        CHECK(cursor.current().template get<jsoncons::string_view>() ==
+              jsoncons::string_view("Tom"));
+        ec = ubjson::ubjson_errc::success;
+        REQUIRE_FALSE(cursor.done());
+        cursor.next(ec);
+        CHECK_FALSE(ec);
+        CHECK(cursor.done());
+
+        // Reset to invalid input2
+        ec = ubjson::ubjson_errc::success;
+        cursor.reset(input2, ec);
+        CHECK(ec == ubjson::ubjson_errc::unknown_type);
+        CHECK_FALSE(cursor.done());
+
+        // Reset to valid input3
+        ec = ubjson::ubjson_errc::success;
+        cursor.reset(input3, ec);
+        REQUIRE_FALSE(ec);
+        CHECK(cursor.current().event_type() == event_type::int64_value);
+        CHECK(cursor.current().tag() == semantic_tag::none);
+        CHECK(cursor.current().template get<int>() == -100);
+        REQUIRE_FALSE(cursor.done());
+        cursor.next(ec);
+        CHECK_FALSE(ec);
+        CHECK(cursor.done());
+    }
+}

--- a/test/ubjson/src/ubjson_encoder_tests.cpp
+++ b/test/ubjson/src/ubjson_encoder_tests.cpp
@@ -146,3 +146,81 @@ TEST_CASE("serialize big array to ubjson")
     CHECK(val2 == val);
 }
 
+struct ubjson_bytes_encoder_reset_test_fixture
+{
+    std::vector<uint8_t> output1;
+    std::vector<uint8_t> output2;
+    ubjson::ubjson_bytes_encoder encoder;
+
+    ubjson_bytes_encoder_reset_test_fixture() : encoder(output1) {}
+    std::vector<uint8_t> bytes1() const {return output1;}
+    std::vector<uint8_t> bytes2() const {return output2;}
+};
+
+struct ubjson_stream_encoder_reset_test_fixture
+{
+    std::ostringstream output1;
+    std::ostringstream output2;
+    ubjson::ubjson_stream_encoder encoder;
+
+    ubjson_stream_encoder_reset_test_fixture() : encoder(output1) {}
+    std::vector<uint8_t> bytes1() const {return bytes_of(output1);}
+    std::vector<uint8_t> bytes2() const {return bytes_of(output2);}
+
+private:
+    static std::vector<uint8_t> bytes_of(const std::ostringstream& os)
+    {
+        auto str = os.str();
+        auto data = reinterpret_cast<const uint8_t*>(str.data());
+        std::vector<uint8_t> bytes(data, data + str.size());
+        return bytes;
+    }
+};
+
+TEMPLATE_TEST_CASE("test_ubjson_encoder_reset", "",
+                   ubjson_bytes_encoder_reset_test_fixture,
+                   ubjson_stream_encoder_reset_test_fixture)
+{
+    using fixture_type = TestType;
+    fixture_type f;
+
+    std::vector<uint8_t> expected_partial =
+        {
+            '[', '#', 'U', 2, // begin array, 2 elements
+                'S', 'U', 3, 'f', 'o', 'o' // string(3) "foo"
+                // second element missing
+        };
+
+    std::vector<uint8_t> expected_full =
+        {
+            '[', '#', 'U', 2, // begin array, 2 elements
+                'S', 'U', 3, 'f', 'o', 'o', // string(3) "foo"
+                'U', 42 // int8(42)
+        };
+
+    std::vector<uint8_t> expected_partial_then_full(expected_partial);
+    expected_partial_then_full.insert(expected_partial_then_full.end(),
+                                      expected_full.begin(), expected_full.end());
+
+    // Parially encode, reset, then fully encode to same sink
+    f.encoder.begin_array(2);
+    f.encoder.string_value("foo");
+    f.encoder.flush();
+    CHECK(f.bytes1() == expected_partial);
+    f.encoder.reset();
+    f.encoder.begin_array(2);
+    f.encoder.string_value("foo");
+    f.encoder.uint64_value(42);
+    f.encoder.end_array();
+    f.encoder.flush();
+    CHECK(f.bytes1() == expected_partial_then_full);
+
+    // Reset and encode to different sink
+    f.encoder.reset(f.output2);
+    f.encoder.begin_array(2);
+    f.encoder.string_value("foo");
+    f.encoder.uint64_value(42);
+    f.encoder.end_array();
+    f.encoder.flush();
+    CHECK(f.bytes2() == expected_full);
+}


### PR DESCRIPTION
I've omitted parser/cursor reset to same source for CSV because it doesn't seem workable for that particular format. Other than the `max_lines` option, there's doesn't seem to be way for the parser to know it's done parsing a complete "entity" the same way as can be done with JSON, CBOR, etc.