### PR TITLE
Fix and enhance basic_json_diagnostics_visitor

### DIFF
--- a/test/src/json_parser_tests.cpp
+++ b/test/src/json_parser_tests.cpp
@@ -297,3 +297,44 @@ TEST_CASE("test_parser_reinitialization")
     REQUIRE(j2.is_int64());
     CHECK(j2.as<int64_t>() == -42);
 }
+
+TEST_CASE("test_diagnostics_visitor", "")
+{
+    SECTION("narrow char")
+    {
+        std::ostringstream os;
+        json_diagnostics_visitor visitor(os, "  ");
+        json_parser parser;
+        std::string input(R"({"foo":[42,null]})");
+        parser.update(input.data(), input.size());
+        parser.finish_parse(visitor);
+        std::ostringstream expected;
+        expected << "visit_begin_object"  << std::endl
+                 << "  visit_key:foo"     << std::endl
+                 << "  visit_begin_array" << std::endl
+                 << "    visit_uint64:42" << std::endl
+                 << "    visit_null"      << std::endl
+                 << "  visit_end_array"   << std::endl
+                 << "visit_end_object"    << std::endl;
+        CHECK(os.str() == expected.str());
+    }
+
+    SECTION("wide char")
+    {
+        std::wostringstream os;
+        wjson_diagnostics_visitor visitor(os, L"  ");
+        wjson_parser parser;
+        std::wstring input(LR"({"foo":[42,null]})");
+        parser.update(input.data(), input.size());
+        parser.finish_parse(visitor);
+        std::wostringstream expected;
+        expected << L"visit_begin_object"  << std::endl
+                 << L"  visit_key:foo"     << std::endl
+                 << L"  visit_begin_array" << std::endl
+                 << L"    visit_uint64:42" << std::endl
+                 << L"    visit_null"      << std::endl
+                 << L"  visit_end_array"   << std::endl
+                 << L"visit_end_object"    << std::endl;
+        CHECK(os.str() == expected.str());
+    }
+}

--- a/test/ubjson/src/ubjson_cursor_tests.cpp
+++ b/test/ubjson/src/ubjson_cursor_tests.cpp
@@ -264,6 +264,34 @@ TEST_CASE("ubjson_parser reset", "")
     }
 }
 
+TEST_CASE("ubjson_parser with json_diagnostics_visitor", "")
+{
+    std::ostringstream os;
+    json_diagnostics_visitor visitor(os, "  ");
+    std::vector<uint8_t> input{
+        '{',
+            'U',3,'f','o','o',
+            '[',
+                'U',42,
+                'Z',
+            ']',
+        '}'
+    };
+    ubjson::basic_ubjson_parser<bytes_source> parser(input);
+    std::error_code ec;
+    parser.parse(visitor, ec);
+    CHECK_FALSE(ec);
+    std::ostringstream expected;
+    expected << "visit_begin_object"  << std::endl
+             << "  visit_key:foo"     << std::endl
+             << "  visit_begin_array" << std::endl
+             << "    visit_uint64:42" << std::endl
+             << "    visit_null"      << std::endl
+             << "  visit_end_array"   << std::endl
+             << "visit_end_object"    << std::endl;
+    CHECK(os.str() == expected.str());
+}
+
 struct ubjson_bytes_cursor_reset_test_traits
 {
     using cursor_type = ubjson::ubjson_bytes_cursor;


### PR DESCRIPTION
Fixes #385. I took the liberty of enhancing `basic_json_diagnostics_visitor` as follows:
- Optional indentation according to the nesting level of the visited items
- Ability to specify which output stream to write diagnostic information. By default, it writes to `std::cout` (as before) if `CharT` is `char`.
- Added `:` separator between names and values to avoid confusing output like `visit_uint64123`.

If I went too far with the liberties in enhancing `basic_json_diagnostics_visitor`, then I apologize. Please let me know if that's the case, and I'll roll back the undesired changes.

The test case with UBJSON is to verify that a `basic_json_diagnostics_visitor<char>` works with a parser taking a `bytes_source`. The reason why I picked UBJSON is that it's easy to figure out the input bytes by hand compared to other binary formats.