### PR TITLE
Fix boost interprocess example

### DIFF
--- a/doc/Tutorials/Custom Allocators.md
+++ b/doc/Tutorials/Custom Allocators.md
@@ -30,17 +30,17 @@ typedef boost::interprocess::allocator<char,
 
 struct boost_sorted_policy : public sorted_policy
 {
-    template <class T, class Allocator>
-    using sequence_container_type = boost::interprocess::vector<T,Allocator>;
+    template <class KeyT,class Json>
+    using object = sorted_json_object<KeyT,Json,boost::interprocess::vector>;
+
+    template <class Json>
+    using array = json_array<Json,boost::interprocess::vector>;
 
     template <class CharT, class CharTraits, class Allocator>
-    using key_storage = boost::interprocess::basic_string<CharT, CharTraits, Allocator>;
-
-    template <class CharT, class CharTraits, class Allocator>
-    using string_storage = boost::interprocess::basic_string<CharT, CharTraits, Allocator>;
+    using string = boost::interprocess::basic_string<CharT, CharTraits, Allocator>;
 };
 
-using my_json = basic_json<char,boost_sorted_policy,shmem_allocator>;
+using shm_json = basic_json<char,boost_sorted_policy,shmem_allocator>;
 
 int main(int argc, char *argv[])
 {

--- a/doc/ref/basic_json.md
+++ b/doc/ref/basic_json.md
@@ -42,7 +42,7 @@ Member type                         |Definition
 `pointer`|`basic_json*`
 `const_pointer`|`const basic_json*`
 `string_view_type`|`basic_string_view<char_type>`
-`key_type`|std::basic_string<char_type,char_traits_type,char_allocator_type>
+`key_type`|A [ContiguousContainer](https://en.cppreference.com/w/cpp/named_req/ContiguousContainer) to `char_type`
 `key_value_type`|`key_value<key_type,basic_json>`
 `object_iterator`|A [RandomAccessIterator](http://en.cppreference.com/w/cpp/concept/RandomAccessIterator) to [key_value_type](json/key_value.md)
 `const_object_iterator`|A const [RandomAccessIterator](http://en.cppreference.com/w/cpp/concept/RandomAccessIterator) to const [key_value_type](json/key_value.md)

--- a/examples_boost/interprocess_allocator/shared_memory.cpp
+++ b/examples_boost/interprocess_allocator/shared_memory.cpp
@@ -12,14 +12,14 @@ typedef boost::interprocess::allocator<char,
 
 struct boost_sorted_policy : public sorted_policy
 {
-    template <class T, class Allocator>
-    using sequence_container_type = boost::interprocess::vector<T,Allocator>;
+    template <class KeyT,class Json>
+    using object = sorted_json_object<KeyT,Json,boost::interprocess::vector>;
+
+    template <class Json>
+    using array = json_array<Json,boost::interprocess::vector>;
 
     template <class CharT, class CharTraits, class Allocator>
-    using key_storage = boost::interprocess::basic_string<CharT, CharTraits, Allocator>;
-
-    template <class CharT, class CharTraits, class Allocator>
-    using string_storage = boost::interprocess::basic_string<CharT, CharTraits, Allocator>;
+    using string = boost::interprocess::basic_string<CharT, CharTraits, Allocator>;
 };
 
 using my_json = basic_json<char,boost_sorted_policy,shmem_allocator>;

--- a/examples_boost/interprocess_allocator2/shared_memory.cpp
+++ b/examples_boost/interprocess_allocator2/shared_memory.cpp
@@ -12,14 +12,14 @@ typedef boost::interprocess::allocator<int,
 
 struct boost_sorted_policy : public sorted_policy
 {
-    template <class T, class Allocator>
-    using sequence_container_type = boost::interprocess::vector<T,Allocator>;
+    template <class KeyT,class Json>
+    using object = sorted_json_object<KeyT,Json,boost::interprocess::vector>;
+
+    template <class Json>
+    using array = json_array<Json,boost::interprocess::vector>;
 
     template <class CharT, class CharTraits, class Allocator>
-    using key_storage = boost::interprocess::basic_string<CharT, CharTraits, Allocator>;
-
-    template <class CharT, class CharTraits, class Allocator>
-    using string_storage = boost::interprocess::basic_string<CharT, CharTraits, Allocator>;
+    using string = boost::interprocess::basic_string<CharT, CharTraits, Allocator>;
 };
 
 using shm_json = basic_json<char,boost_sorted_policy,shmem_allocator>;
@@ -48,7 +48,7 @@ int main(int argc, char *argv[])
       shm_json* j = segment.construct<shm_json>("my json")(shm_json::array(allocator));
       j->push_back(10);
 
-      shm_json o(allocator);
+      shm_json o(json_object_arg, semantic_tag::none, allocator);
       //o.try_emplace("category", "reference",allocator);
       //o.try_emplace("author", "Nigel Rees",allocator);
       //o.try_emplace("title", "Sayings of the Century",allocator);

--- a/include/jsoncons/basic_json.hpp
+++ b/include/jsoncons/basic_json.hpp
@@ -247,6 +247,9 @@ namespace jsoncons {
         using array = json_array<Json,std::vector>;
 
         using parse_error_handler_type = default_json_parsing;
+        
+        template <class CharT, class CharTraits, class Allocator>
+        using string = std::basic_string<CharT, CharTraits, Allocator>;
     };
 
     struct order_preserving_policy
@@ -258,6 +261,9 @@ namespace jsoncons {
         using array = json_array<Json,std::vector>;
 
         using parse_error_handler_type = default_json_parsing;
+        
+        template <class CharT, class CharTraits, class Allocator>
+        using string = std::basic_string<CharT, CharTraits, Allocator>;
     };
 
     #if !defined(JSONCONS_NO_DEPRECATED)
@@ -352,7 +358,7 @@ namespace jsoncons {
 
         using char_allocator_type = typename std::allocator_traits<allocator_type>:: template rebind_alloc<char_type>;
 
-        using key_type = std::basic_string<char_type,char_traits_type,char_allocator_type>;
+        using key_type = typename ImplementationPolicy::template string<char_type,char_traits_type,char_allocator_type>;
 
 
         using reference = basic_json&;


### PR DESCRIPTION
Fixes #392.

All tests ran and passe with success.

Boost examples now compile and produce expected output.