### PR TITLE
Update compiler_support.hpp

### DIFF
--- a/include/jsoncons/config/compiler_support.hpp
+++ b/include/jsoncons/config/compiler_support.hpp
@@ -118,7 +118,9 @@
 #  if defined(__GNUC__)
 #   if (__GNUC__ >= 11)
 #    if (__cplusplus >= 201703)
-#     define JSONCONS_HAS_STD_FROM_CHARS 1
+#     if !defined(__MINGW32__)
+#      define JSONCONS_HAS_STD_FROM_CHARS 1
+#     endif // !defined(__MINGW32__)
 #    endif // (__cplusplus >= 201703)
 #   endif // (__GNUC__ >= 11)
 #  endif // defined(__GNUC__)


### PR DESCRIPTION
Don't use std::from_chars() if compiler is MinGW (GCC 11.2 on Windows), because it's not defined.