### PR TITLE
Multiple fixes for float parsing and boolean pretty print with wjson

### DIFF
--- a/include/jsoncons/config/compiler_support.hpp
+++ b/include/jsoncons/config/compiler_support.hpp
@@ -114,22 +114,6 @@
    #endif
 #endif
 
-#if !defined(JSONCONS_HAS_STD_FROM_CHARS)
-#  if defined(__GNUC__)
-#   if (__GNUC__ >= 11)
-#    if (__cplusplus >= 201703)
-#     if !defined(__MINGW32__)
-#      define JSONCONS_HAS_STD_FROM_CHARS 1
-#     endif // !defined(__MINGW32__)
-#    endif // (__cplusplus >= 201703)
-#   endif // (__GNUC__ >= 11)
-#  endif // defined(__GNUC__)
-#  if defined(_MSC_VER)
-#   if (_MSC_VER >= 1924 && _MSVC_LANG >= 201703)
-#    define JSONCONS_HAS_STD_FROM_CHARS 1
-#   endif // (_MSC_VER >= 1924 && MSVC_LANG >= 201703)
-#  endif // defined(_MSC_VER)
-#endif
 #if defined(JSONCONS_HAS_STD_FROM_CHARS) && JSONCONS_HAS_STD_FROM_CHARS
 #include <charconv>
 #endif

--- a/include/jsoncons/config/compiler_support.hpp
+++ b/include/jsoncons/config/compiler_support.hpp
@@ -130,7 +130,7 @@
 #   endif // (_MSC_VER >= 1924 && MSVC_LANG >= 201703)
 #  endif // defined(_MSC_VER)
 #endif
-#if defined(JSONCONS_HAS_STD_FROM_CHARS)
+#if defined(JSONCONS_HAS_STD_FROM_CHARS) && JSONCONS_HAS_STD_FROM_CHARS
 #include <charconv>
 #endif
 

--- a/include/jsoncons/config/jsoncons_config.hpp
+++ b/include/jsoncons/config/jsoncons_config.hpp
@@ -290,10 +290,11 @@ namespace jsoncons {
 
 #define JSONCONS_EXPAND(X) X    
 #define JSONCONS_QUOTE(Prefix, A) JSONCONS_EXPAND(Prefix ## #A)
+#define JSONCONS_WIDEN(A) JSONCONS_EXPAND(L ## A)
 
-#define JSONCONS_CSTRING_CONSTANT(CharT, Str) cstring_constant_of_type<CharT>(Str, JSONCONS_QUOTE(L, Str))
-#define JSONCONS_STRING_CONSTANT(CharT, Str) string_constant_of_type<CharT>(Str, JSONCONS_QUOTE(L, Str))
-#define JSONCONS_STRING_VIEW_CONSTANT(CharT, Str) string_view_constant_of_type<CharT>(Str, JSONCONS_QUOTE(L, Str))
+#define JSONCONS_CSTRING_CONSTANT(CharT, Str) cstring_constant_of_type<CharT>(Str, JSONCONS_WIDEN(Str))
+#define JSONCONS_STRING_CONSTANT(CharT, Str) string_constant_of_type<CharT>(Str, JSONCONS_WIDEN(Str))
+#define JSONCONS_STRING_VIEW_CONSTANT(CharT, Str) string_view_constant_of_type<CharT>(Str, JSONCONS_WIDEN(Str))
 
 #if defined(__clang__) 
 #define JSONCONS_HAS_STD_REGEX 1

--- a/include/jsoncons/detail/parse_number.hpp
+++ b/include/jsoncons/detail/parse_number.hpp
@@ -910,7 +910,7 @@ base16_to_integer(const CharT* s, std::size_t length, T& n)
 }
 
 
-#if defined(JSONCONS_HAS_STD_FROM_CHARS)
+#if defined(JSONCONS_HAS_STD_FROM_CHARS) && JSONCONS_HAS_STD_FROM_CHARS
 
 class chars_to
 {

--- a/include/jsoncons/json_options.hpp
+++ b/include/jsoncons/json_options.hpp
@@ -608,7 +608,7 @@ public:
     basic_json_options& inf_to_str(const string_type& value, bool enable_inverse = true)
     {
         this->enable_inf_to_str_ = true;
-        this->enable_inf_to_str_ = enable_inverse;
+        this->enable_str_to_inf_ = enable_inverse;
         this->inf_to_num_.clear();
         this->inf_to_str_ = value;
         return *this;
@@ -617,7 +617,7 @@ public:
     basic_json_options& neginf_to_str(const string_type& value, bool enable_inverse = true)
     {
         this->enable_neginf_to_str_ = true;
-        this->enable_neginf_to_str_ = enable_inverse;
+        this->enable_str_to_neginf_ = enable_inverse;
         this->neginf_to_num_.clear();
         this->neginf_to_str_ = value;
         return *this;

--- a/include/jsoncons_ext/csv/csv_parser.hpp
+++ b/include/jsoncons_ext/csv/csv_parser.hpp
@@ -1497,7 +1497,8 @@ private:
         }
         if (start != 0 || length != buffer_.size())
         {
-            buffer_ = buffer_.substr(start,length-start);
+            buffer_.resize(length);
+            buffer_.erase(0, start);
         }
     }
 

--- a/include/jsoncons_ext/csv/csv_parser.hpp
+++ b/include/jsoncons_ext/csv/csv_parser.hpp
@@ -1497,6 +1497,7 @@ private:
         }
         if (start != 0 || length != buffer_.size())
         {
+            // Do not use buffer_.substr(...), as this won't preserve the allocator state.
             buffer_.resize(length);
             buffer_.erase(0, start);
         }

--- a/test/corelib/src/json_options_tests.cpp
+++ b/test/corelib/src/json_options_tests.cpp
@@ -51,8 +51,8 @@ TEST_CASE("test_read_write_read_nan_replacement")
     j["field3"] = -1.79e308 * 1000;
 
     json_options options;
-    options.nan_to_str("NaN")
-           .inf_to_str("Inf");
+    options.nan_to_str("MyNaN")
+           .inf_to_str("MyInf");
 
     std::ostringstream os;
     os << pretty_print(j, options);

--- a/test/corelib/src/wjson_tests.cpp
+++ b/test/corelib/src/wjson_tests.cpp
@@ -52,6 +52,26 @@ TEST_CASE("wjson serialization tests")
     CHECK(testStr == L"{\"bar\":false,\"baz\":true,\"foo\":true}");
 }
 
+TEST_CASE("wjson pretty print tests")
+{
+    jsoncons::wjson testBlock;
+    testBlock[L"foo"] = true;
+    testBlock[L"bar"] = false;
+    testBlock[L"baz"] = true;
+    std::wostringstream actualStr;
+    actualStr << jsoncons::pretty_print(testBlock);
+
+    std::wostringstream expectedStr;
+    expectedStr << L"{" << std::endl;
+    expectedStr << L"    \"bar\": false, " << std::endl;
+    expectedStr << L"    \"baz\": true, " << std::endl;
+    expectedStr << L"    \"foo\": true" << std::endl;
+    expectedStr << L"}";
+
+    CHECK(actualStr.str().size() == expectedStr.str().size());
+    CHECK(actualStr.str() == expectedStr.str());
+}
+
 TEST_CASE("wjson test case")
 {
     std::wstring data = LR"(

--- a/test/csv/src/csv_tests.cpp
+++ b/test/csv/src/csv_tests.cpp
@@ -1497,6 +1497,7 @@ TEST_CASE("csv detect bom")
     }
 }
 
+#if !(defined(__GNUC__) && (__GNUC__ == 4) && __GNUC_MINOR__ < 9)
 TEST_CASE("csv_reader constructors")
 {
     const std::string input = R"(Date,1Y,2Y,3Y,5Y
@@ -1525,6 +1526,7 @@ TEST_CASE("csv_reader constructors")
         //std::cout << pretty_print(j) << "\n";
     }
 }
+#endif
 
 TEST_CASE("infinite loop")
 {

--- a/test/csv/src/csv_tests.cpp
+++ b/test/csv/src/csv_tests.cpp
@@ -1497,7 +1497,6 @@ TEST_CASE("csv detect bom")
     }
 }
 
-#if !(defined(__GNUC__) || (defined(_MSC_VER) && _MSC_VER == 1900))
 TEST_CASE("csv_reader constructors")
 {
     const std::string input = R"(Date,1Y,2Y,3Y,5Y
@@ -1526,7 +1525,6 @@ TEST_CASE("csv_reader constructors")
         //std::cout << pretty_print(j) << "\n";
     }
 }
-#endif
 
 TEST_CASE("infinite loop")
 {


### PR DESCRIPTION
Fixes #403 #404 #405.

> I changed the CSV parser code to no longer call `substr`; that allowed compilation and tests to pass.

Thanks. Interesting observation about `substr`.

Regarding the remaining failure, I wouldn't expect the test to work with gcc 4.8, as gcc 4.8 `basic_string` had issues with stateful allocators. It's probably enough to suppress the test if 
```
(defined(__GNUC__) && (__GNUC__ == 4) && __GNUC_MINOR__ < 9))
```