### PR TITLE
Remove fragment from URI

### DIFF
--- a/include/jsoncons_ext/jsonschema/schema_version.hpp
+++ b/include/jsoncons_ext/jsonschema/schema_version.hpp
@@ -17,7 +17,7 @@ namespace jsonschema {
     public:
         static bool contains(const string_view& url)
         {
-            if (url.find("json-schema.org/draft-07/schema#") != string_view::npos)
+            if (url.find("json-schema.org/draft-07/schema") != string_view::npos)
             {
                 return true;
             }


### PR DESCRIPTION
Hi,

I am trying to use jsoncons for json document validation, and I stumbled upon an odd behaviour around URI for schema.

It looks like [jsoncons/jsonschema](https://github.com/danielaparker/jsoncons/blame/master/include/jsoncons_ext/jsonschema/schema_version.hpp#L20) requires the schema URI to contain a fragment. 

When browsing [jsonschema examples](https://github.com/danielaparker/jsoncons/blob/master/examples/src/jsonschema_examples.cpp#L24) the `schema URI` is provided with an empty fragment. It is legal for URI to contain an empty fragment, but it is a bit unusual (and semantically redundant).

As far as I was able to find at [json-schema.org](https://json-schema.org/learn/miscellaneous-examples.html) it seems that the URI should/could be provided without any fragment, but current validation does not accept such URI.

I am wondering if the pound sign (#) is necessary for some reason, but if not, I would suggest to remove it from the schema_version validation.