### PR TITLE
Fix macOS build

### DIFF
--- a/include/jsoncons/config/compiler_support.hpp
+++ b/include/jsoncons/config/compiler_support.hpp
@@ -220,9 +220,9 @@
 
 #if !defined(JSONCONS_NO_EXCEPTIONS)
 
-#if defined(__GNUC__) && !__EXCEPTIONS
+#if defined(__GNUC__) && !defined(__EXCEPTIONS)
 # define JSONCONS_NO_EXCEPTIONS 1
-#elif _MSC_VER
+#elif defined(_MSC_VER)
 #if defined(_HAS_EXCEPTIONS) && _HAS_EXCEPTIONS == 0
 # define JSONCONS_NO_EXCEPTIONS 1
 #elif !defined(_CPPUNWIND)

--- a/include/jsoncons/staj_iterator.hpp
+++ b/include/jsoncons/staj_iterator.hpp
@@ -156,8 +156,6 @@ namespace jsoncons {
 
         void next(std::error_code& ec)
         {
-            using char_type = typename Json::char_type;
-
             if (!done())
             {
                 view_->cursor_->next(ec);
@@ -321,8 +319,6 @@ namespace jsoncons {
 
         void next(std::error_code& ec)
         {
-            using char_type = typename Json::char_type;
-
             view_->cursor_->next(ec);
             if (ec)
             {


### PR DESCRIPTION
- add `defined()` for `__EXCEPTIONS` and `_MSC_VER` in compiler_support.hpp (see https://github.com/peetonn/ROSBridge2Unreal/commit/cfe4a89451039a4f680fc41c722cf85afd62b131)
- remove shadowing of `using char_type = typename Json::char_type;` in stat_iterator.hpp