### PR TITLE
Compilation warning in win32 configuration due to down cast

### DIFF
--- a/include/jsoncons_ext/jsonpath/expression.hpp
+++ b/include/jsoncons_ext/jsonpath/expression.hpp
@@ -2379,12 +2379,12 @@ namespace detail {
 
         struct MyHash
         {
-            std::size_t operator()(string_type const& s) const noexcept
+            std::uintmax_t operator()(string_type const& s) const noexcept
             {
                 const int p = 31;
                 const int m = static_cast<int>(1e9) + 9;
-                long long hash_value = 0;
-                long long p_pow = 1;
+                std::uintmax_t hash_value = 0;
+                std::uintmax_t p_pow = 1;
                 for (char_type c : s) {
                     hash_value = (hash_value + (c - 'a' + 1) * p_pow) % m;
                     p_pow = (p_pow * p) % m;


### PR DESCRIPTION
This is to resolve issue #432 
- Switched hash struct to use std::uintmax_t instead of std::size_t and long long 