### PR TITLE
fix basic_json_decode_options constructor

### DIFF
--- a/include/jsoncons/json_options.hpp
+++ b/include/jsoncons/json_options.hpp
@@ -371,7 +371,7 @@ public:
     basic_json_decode_options(const basic_json_decode_options&) = default;
 
     basic_json_decode_options(basic_json_decode_options&& other)
-        : super_type(std::move(other)), lossless_number_(other.lossless_number_), err_handler_(other.default_json_parsing())
+        : super_type(std::move(other)), lossless_number_(other.lossless_number_), err_handler_(std::move(other.err_handler_))
     {
     }
 


### PR DESCRIPTION
I stumbled on this, while trying out jsoncons.  
I got the compile error:
```
/home/meierfra/devel/test/jsonconsTest/jsoncons/include/jsoncons/json_options.hpp: In instantiation of ‘jsoncons::basic_json_decode_options<CharT>::basic_json_decode_options(jsoncons::basic_json_decode_options<CharT>&&) [with CharT = char]’:
/home/meierfra/devel/test/jsonconsTest/main.cpp:31:65:   required from here
/home/meierfra/devel/test/jsonconsTest/jsoncons/include/jsoncons/json_options.hpp:374:102: error: ‘class jsoncons::basic_json_decode_options<char>’ has no member named ‘default_json_parsing’
  374 |         : super_type(std::move(other)), lossless_number_(other.lossless_number_), err_handler_(other.default_json_parsing())
      |                                                                                                ~~~~~~^~~~~~~~~~~~~~~~~~~~
```
other constructors use 'default_json_parsing' directly, so I think this is what you want.