### PR TITLE
Change signature of dump_pretty

### DIFF
--- a/include/jsoncons/basic_json.hpp
+++ b/include/jsoncons/basic_json.hpp
@@ -3859,11 +3859,10 @@ namespace jsoncons {
         template <class CharContainer>
         typename std::enable_if<extension_traits::is_back_insertable_char_container<CharContainer>::value>::type
         dump_pretty(CharContainer& cont,
-            const basic_json_encode_options<char_type>& options = basic_json_encode_options<CharT>(),
-            indenting indent = indenting::no_indent) const
+            const basic_json_encode_options<char_type>& options = basic_json_encode_options<CharT>()) const
         {
             std::error_code ec;
-            dump_pretty(cont, options, indent, ec);
+            dump_pretty(cont, options, ec);
             if (ec)
             {
                 JSONCONS_THROW(ser_error(ec));


### PR DESCRIPTION
After updating to 0.171.0, our code failed to compile with the following error:

`.../jsoncons/basic_json.hpp:3866:13: error: no matching member function for call to 'dump_pretty' dump_pretty(cont, options, indent, ec);`

The error occurs because on line 3866, dump_pretty is called with 4 parameters, but a dump_pretty function with the corresponding signature does not exists. After looking into the issue (and reading the doc https://github.com/danielaparker/jsoncons/blob/master/doc/ref/corelib/json/dump.md), I think that a dump_pretty function that takes an indent parameter should not exist at all.

I am not entirely sure how to fix this. The docs say that there should be a dump_pretty function that takes a CharContainer and options, with the options having a default parameter. My proposition changes the functions signature to fit the docs.
