### PR TITLE
Fix for shadowed path variable

### DIFF
--- a/include/jsoncons_ext/jsonpath/expression.hpp
+++ b/include/jsoncons_ext/jsonpath/expression.hpp
@@ -3077,9 +3077,9 @@ namespace detail {
 
             if ((options & result_options::path) == result_options::path)
             {
-                auto callback = [&result](const json_location_type& path, reference)
+                auto callback = [&result](const json_location_type& pathp, reference)
                 {
-                    result.emplace_back(path.to_string()); 
+                    result.emplace_back(pathp.to_string()); 
                 };
                 evaluate(resources, root, path, instance, callback, options);
             }


### PR DESCRIPTION
Fixes the warning about declaration shadows a local variable for path parameter.