### PR TITLE
Update json_encoder.hpp

### DIFF
--- a/include/jsoncons/json_encoder.hpp
+++ b/include/jsoncons/json_encoder.hpp
@@ -679,9 +679,10 @@ namespace detail {
                 	if (options_.bigint_format() == bigint_chars_format::number)
                 	{
 	                	write_bigint_value(sv);
-						break;
-					}
-				}	// fall through
+				break;
+			}
+			JSONCONS_FALLTHROUGH;
+		}
                 default:
                 {
                     sink_.push_back('\"');
@@ -1340,8 +1341,9 @@ namespace detail {
                 	{
 	                	write_bigint_value(sv);
                 		break;
-					}
-				}	// fall through
+			}
+			JSONCONS_FALLTHROUGH;
+		}
                 default:
                 {
                     sink_.push_back('\"');

--- a/include/jsoncons/json_encoder.hpp
+++ b/include/jsoncons/json_encoder.hpp
@@ -673,6 +673,15 @@ namespace detail {
                 case semantic_tag::bigint:
                     write_bigint_value(sv);
                     break;
+                case semantic_tag::bigdec:
+                {
+                	// output lossless number
+                	if (options_.bigint_format() == bigint_chars_format::number)
+                	{
+	                	write_bigint_value(sv);
+						break;
+					}
+				}	// fall through
                 default:
                 {
                     sink_.push_back('\"');
@@ -1324,6 +1333,15 @@ namespace detail {
                 case semantic_tag::bigint:
                     write_bigint_value(sv);
                     break;
+                case semantic_tag::bigdec:
+                {
+                	// output lossless number
+                	if (options_.bigint_format() == bigint_chars_format::number)
+                	{
+	                	write_bigint_value(sv);
+                		break;
+					}
+				}	// fall through
                 default:
                 {
                     sink_.push_back('\"');


### PR DESCRIPTION
Output semantic_tag::bigdec as number.
We like to use lossless_number when parsing and output these numbers back as numbers and not in quotes.