### PR TITLE
Update json_visitor.hpp

### DIFF
--- a/include/jsoncons/json_visitor.hpp
+++ b/include/jsoncons/json_visitor.hpp
@@ -1515,6 +1515,9 @@ namespace jsoncons {
         }
     };
 
+#if __cplusplus >= 201703L
+// not needed for C++17
+#else
     template <class C> constexpr C basic_json_diagnostics_visitor<C>::visit_begin_array_name[];
     template <class C> constexpr C basic_json_diagnostics_visitor<C>::visit_end_array_name[];
     template <class C> constexpr C basic_json_diagnostics_visitor<C>::visit_begin_object_name[];
@@ -1528,6 +1531,7 @@ namespace jsoncons {
     template <class C> constexpr C basic_json_diagnostics_visitor<C>::visit_int64_name[];
     template <class C> constexpr C basic_json_diagnostics_visitor<C>::visit_half_name[];
     template <class C> constexpr C basic_json_diagnostics_visitor<C>::visit_double_name[];
+#endif // C++17 check
 
     using json_visitor = basic_json_visitor<char>;
     using wjson_visitor = basic_json_visitor<wchar_t>;


### PR DESCRIPTION
Avoid the warning from clang:

out-of-line definition of constexpr static data member is redundant in C++17 and is deprecated