### PR TITLE
Update jsonpath_examples.cpp

### DIFF
--- a/examples/src/jsonpath_examples.cpp
+++ b/examples/src/jsonpath_examples.cpp
@@ -59,7 +59,7 @@ void json_query_examples()
     std::cout << "(9)\n" << pretty_print(result9) << "\n";
 
     // Intersection of book titles with category fiction and price < 15
-    json result10 = jsonpath::json_query(booklist, "$.store.book[?(@.category == 'fiction')][?(@.price < 15)].title");
+    json result10 = jsonpath::json_query(booklist, "$.store.book[?(@.category == 'fiction' && @.price < 15)].title"));
     std::cout << "(10)\n" << pretty_print(result10) << "\n";
 
     // Normalized path expressions


### PR DESCRIPTION
The original example returns empty result.
If you use &&, the result works.

Not sure if the [][] syntax should work and the library is wrong:

`"$.store.book[?(@.category == 'fiction')][?(@.price < 15)].title"`
vs.
`"$.store.book[?(@.category == 'fiction' && @.price < 15)].title"`

or the example wasn't updated!?