### PR TITLE
Update json_object.hpp

### DIFF
--- a/include/jsoncons/json_object.hpp
+++ b/include/jsoncons/json_object.hpp
@@ -38,8 +38,8 @@ namespace jsoncons {
         Json value;
 
         template <class... Args>
-        index_key_value(key_type&& name, int64_t index, Args&& ... args) 
-            : name(std::move(name)), index(index), value(std::forward<Args>(args)...)
+        index_key_value(key_type&& Name, int64_t Index, Args&& ... args) 
+            : name(std::move(Name)), index(Index), value(std::forward<Args>(args)...)
         {
         }
 


### PR DESCRIPTION
Shadowed name fix.

I got annoyed with all these messages about shadowed names here.

jsoncons/json_object.hpp:41:9: warning: declaration of 'name' shadows a member of 'jsoncons::index_key_value<jsoncons::basic_json<char, jsoncons::sorted_policy, std::allocator<char> > >' [-Wshadow]
         index_key_value(key_type&& name, int64_t index, Args&& ... args)
         ^~~~~~~~~~~~~~~
jsoncons/json_object.hpp:36:18: note: shadowed declaration is here
         key_type name;
     