### PR TITLE
Fix WORKING_DIRECTORY for unit tests

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -215,7 +215,7 @@ target_compile_options(unit_tests PRIVATE
 )
 endif()
 
-add_test(NAME unit_tests COMMAND unit_tests WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/test)
+add_test(NAME unit_tests COMMAND unit_tests WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 
 target_include_directories (unit_tests 
                             PUBLIC ${JSONCONS_INCLUDE_DIR} 


### PR DESCRIPTION
Hello

I ran into a path-related issue with `ctest` in a project that fetches `jsoncons`.

The issue can be reproduced with the following `CMakeLists.txt`:

```cmake
cmake_minimum_required(VERSION 3.25)

project(test_jsoncons)

include(FetchContent)

FetchContent_Declare(jsoncons
        GIT_REPOSITORY https://github.com/danielaparker/jsoncons.git
        GIT_TAG v0.176.0
)

FetchContent_MakeAvailable(jsoncons)

enable_testing()
```

Then we can run the following commands:

```shell
% cmake -S . -B build -G Ninja
% cd build
% ninja 
% ctest  
Test project /home/pierre/temp/test_jsoncons/build
    Start 1: unit_tests
Failed to change working directory to /home/pierre/temp/test_jsoncons/test : No such file or directory
1/1 Test #1: unit_tests .......................***Not Run   0.00 sec

0% tests passed, 1 tests failed out of 1

Total Test time (real) =   0.00 sec

The following tests FAILED:
          1 - unit_tests (Not Run)
Errors while running CTest
Output from these tests are in: /home/pierre/temp/test_jsoncons/build/Testing/Temporary/LastTest.log
Use "--rerun-failed --output-on-failure" to re-run the failed cases verbosely.
```

Just in case, my compiler is:

```shell
% gcc --version
gcc (Debian 12.2.0-14) 12.2.0
```

This PR fixes this issue.

`ctest` still runs properly when the commands above are executed from the root of the `jsoncons` repository.

Note that these commands don't work when they are executed from the `test` directory. The first lines seems to foresee this possibilities. However, `catch2` is not found when `ninja` runs: `fatal error: catch/catch.hpp: No such file or directory`. I've attempt to address this issue, which was present before my commit for this PR.

Best regards
Bktero 