### PR TITLE
uri::parse: Fix offset of query_

### DIFF
--- a/include/jsoncons/uri.hpp
+++ b/include/jsoncons/uri.hpp
@@ -680,7 +680,7 @@ namespace jsoncons {
                                 break;
                             case '#':
                                 path = std::make_pair(start,i);
-                                query = std::make_pair(start,start);
+                                query = std::make_pair(i,i);
                                 state = parse_state::expect_fragment;
                                 start = i+1;
                                 break;


### PR DESCRIPTION
This was showing up as a heap-buffer-overflow during `operator==`, after calling [this constructor](https://github.com/danielaparker/jsoncons/blob/232e16239fe930e1b5bb13cecd5510abbb6107d5/include/jsoncons/uri.hpp#L109-L113)