### PR TITLE
Avoid integer overflow UB in basic_json_parser

### DIFF
--- a/include/jsoncons/json_parser.hpp
+++ b/include/jsoncons/json_parser.hpp
@@ -177,7 +177,7 @@ public:
     {
         string_buffer_.reserve(initial_string_buffer_capacity);
 
-        std::size_t initial_stack_capacity = (options.max_nesting_depth()+2) <= default_initial_stack_capacity ? (options.max_nesting_depth()+2) : default_initial_stack_capacity;
+        std::size_t initial_stack_capacity = options.max_nesting_depth() <= (default_initial_stack_capacity-2) ? (options.max_nesting_depth()+2) : default_initial_stack_capacity;
         state_stack_.reserve(initial_stack_capacity );
         push_state(json_parse_state::root);
 


### PR DESCRIPTION
In Kvrocks we faced an integer overflow detected by UBSAN in basic_json_parser.

```
/home/runner/work/kvrocks/kvrocks/build/_deps/jsoncons-src/include/jsoncons/json_parser.hpp:180:74: runtime error: signed integer overflow: 2147483647 + 2 cannot be represented in type 'int'
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior /home/runner/work/kvrocks/kvrocks/build/_deps/jsoncons-src/include/jsoncons/json_parser.hpp:180:74 in 
```

The reason is that we set `max_nesting_depth` to `numeric_limits::max()`, so that `max_nesting_depth + 2` leads to overflow.

Here I use an equivalent form to eliminate the problem.