### PR TITLE
fixing the path for config files

### DIFF
--- a/examples/build/cmake/CMakeLists.txt
+++ b/examples/build/cmake/CMakeLists.txt
@@ -6,13 +6,13 @@
 cmake_minimum_required (VERSION 2.8)
 
 # load global config
-include (../../../build/cmake/config.cmake)
+include (../../build/cmake/Config.cmake)
 
 
 project (Examples CXX)
 
 # load per-platform configuration
-include (../../../build/cmake/${CMAKE_SYSTEM_NAME}.cmake)
+include (../../build/cmake/${CMAKE_SYSTEM_NAME}.cmake)
 
 include_directories (../../include
                      ../../../include)

--- a/examples/build/cmake/README.txt
+++ b/examples/build/cmake/README.txt
@@ -13,6 +13,7 @@ run_examples_vc140x64.cmd
 UNIX
 
 From the examples/build/cmake directory
+include Config.cmake and Linux.cmake as CMakeLists.txt expects it.
 
 mkdir -p debug
 cd debug


### PR DESCRIPTION
the path ../../../build/ was not accessible for the CMakeLists in examples, so making it to ../../build.
Suggested to add config files in examples/build/cmake/README as the cmake is expecting those files.