### PR TITLE
Fixing example files compilation

### DIFF
--- a/examples/build/cmake/CMakeLists.txt
+++ b/examples/build/cmake/CMakeLists.txt
@@ -19,9 +19,16 @@ include_directories (../../include
 
 file(GLOB_RECURSE Example_sources ../../src/*.cpp)
 
-add_executable (jsoncons_examples ${Example_sources})
+# Loop through each example file and create an executable for each
+foreach(example_file ${Example_sources})
+    # Extract the filename without path and extension
+    get_filename_component(example_name ${example_file} NAME_WE)
 
-if (${CMAKE_SYSTEM_NAME} STREQUAL "Linux" AND ${CMAKE_CXX_COMPILER_ID} STREQUAL "Clang")
-  # special link option on Linux because llvm stl rely on GNU stl
-  target_link_libraries (jsoncons_examples -Wl,-lstdc++)
-endif()
+    # Create an executable with the example name and file
+    add_executable(${example_name} ${example_file})
+
+    if (${CMAKE_SYSTEM_NAME} STREQUAL "Linux" AND ${CMAKE_CXX_COMPILER_ID} STREQUAL "Clang")
+      # special link option on Linux because llvm stl rely on GNU stl
+      target_link_libraries(${example_name} -Wl,-lstdc++)
+    endif()
+endforeach()

--- a/examples_boost/serialization_examples.cpp
+++ b/examples_boost/serialization_examples.cpp
@@ -5,8 +5,10 @@
 #include <jsoncons/json.hpp>
 #include <iomanip>
 #include <assert.h>
+#include <boost/multiprecision/cpp_int.hpp>
 
 using namespace jsoncons;
+namespace boost_mp = boost::multiprecision;
 
 void serialization_example1()
 {
@@ -409,7 +411,8 @@ void bignum_access_examples()
     // If your compiler supports extended integral types
 #if (defined(__GNUC__) || defined(__clang__)) && defined(JSONCONS_HAS_INT128)
     __int128 i = j.as<__int128>();
-    std::cout << "(4) " << i << "\n\n";
+    boost_mp::int128_t boost_i = static_cast<boost_mp::int128_t>(i);
+    std::cout << "(4) " << boost_i << "\n\n";
 #endif
 }
 
@@ -485,7 +488,9 @@ int main()
     decimal_precision_examples();
     bignum_access_examples(); 
     chinese_char();
-    chinese_uchar8_t();
+    #ifdef __cpp_char8_t
+        chinese_uchar8_t();
+    #endif
     std::cout << std::endl;
 }
 


### PR DESCRIPTION

- Changed serialization_examples.cpp to use boost to output type _int128, And run chinese_uchar8_t only when __cpp_char8_t is defined.
- Changed CmakeLists to create separate executables for each source file, as it is not possible to compile all the files into single executable because of conflict due to multiple main functions.

With this transaction the example sources except "json_traits_macros_examples.cpp" can be compiled without errors just following instructions in  "jsoncons/examples/build/cmake/README.txt".  

Will try to fix json_traits_macros_examples.cpp in future, but for now removing this file and doing cmake would give separate executables for all the examples.