### PR TITLE
Remove duplicate type definition(NFC).

### DIFF
--- a/include/jsoncons/text_source_adaptor.hpp
+++ b/include/jsoncons/text_source_adaptor.hpp
@@ -81,7 +81,6 @@ namespace jsoncons {
     {
     public:
         using value_type = typename Source::value_type;
-        using value_type = typename Source::value_type;
         using source_type = Source;
     private:
         source_type source_;


### PR DESCRIPTION
```
external/jsoncons~/include/jsoncons/text_source_adaptor.hpp:84:15: error: redefinition of 'value_type'
--
  | using value_type = typename Source::value_type;
  | ^
  | external/jsoncons~/include/jsoncons/text_source_adaptor.hpp:83:15: note: previous definition is here
  | using value_type = typename Source::value_type;
  | ^
  | 1 error generated.

```