### PR TITLE
fix various header issue(NFC)

### DIFF
--- a/include/jsoncons/utility/heap_string.hpp
+++ b/include/jsoncons/utility/heap_string.hpp
@@ -12,6 +12,8 @@
 #include <memory> // std::allocator
 
 #include <jsoncons/config/compiler_support.hpp>
+#include <jsoncons/config/jsoncons_config.hpp>
+#include <jsoncons/utility/extension_traits.hpp>
 
 namespace jsoncons {
 namespace utility {

--- a/include/jsoncons_ext/csv/csv_encoder.hpp
+++ b/include/jsoncons_ext/csv/csv_encoder.hpp
@@ -21,6 +21,7 @@
 #include <jsoncons/json_exception.hpp>
 #include <jsoncons/json_visitor.hpp>
 #include <jsoncons/sink.hpp>
+#include <jsoncons_ext/csv/csv_error.hpp>
 #include <jsoncons_ext/csv/csv_options.hpp>
 
 namespace jsoncons { namespace csv {

--- a/include/jsoncons_ext/ubjson/ubjson_parser.hpp
+++ b/include/jsoncons_ext/ubjson/ubjson_parser.hpp
@@ -16,6 +16,7 @@
 #include <utility> // std::move
 
 #include <jsoncons/config/jsoncons_config.hpp>
+#include <jsoncons/detail/parse_number.hpp>
 #include <jsoncons/json_visitor.hpp>
 #include <jsoncons/ser_context.hpp>
 #include <jsoncons/source.hpp>


### PR DESCRIPTION
```
jsoncons_ext/csv/csv_encoder.hpp:202:22: error: use of undeclared identifier
      'csv_errc'; did you mean 'conv_errc'?
  202 |                 ec = csv_errc::source_error;
      |                      ^~~~~~~~
      |                      conv_errc
```

```
external/jsoncons+/include/jsoncons_ext/ubjson/ubjson_parser.hpp:512:39: error: 'is_base10' is not a member of 'jsoncons::detail'
--
  | 512 \|                 if (jsoncons::detail::is_base10(text_buffer_.data(),text_buffer_.length()))
  | \|                                       ^~~~~~~~~
```

```
external/jsoncons~/include/jsoncons/utility/heap_string.hpp: In member function 'const char_type* jsoncons::utility::heap_string<CharT, Extra, Allocator>::c_str() const':
--
  | external/jsoncons~/include/jsoncons/utility/heap_string.hpp:73:49: error: 'extension_traits' has not been declared
  | 73 \|         const char_type* c_str() const { return extension_traits::to_plain_pointer(p_); }
  | \|                                                 ^~~~~~~~~~~~~~~~
  | external/jsoncons~/include/jsoncons/utility/heap_string.hpp: In member function 'const char_type* jsoncons::utility::heap_string<CharT, Extra, Allocator>::data() const':
  | external/jsoncons~/include/jsoncons/utility/heap_string.hpp:74:48: error: 'extension_traits' has not been declared
  | 74 \|         const char_type* data() const { return extension_traits::to_plain_pointer(p_); }
  | \|                                                ^~~~~~~~~~~~~~~~
  | external/jsoncons~/include/jsoncons/utility/heap_string.hpp: In static member function 'static jsoncons::utility::heap_string_factory<CharT, Extra, Allocator>::pointer jsoncons::utility::heap_string_factory<CharT, Extra, Allocator>::create(const char_type*, std::size_t, Extra, const Allocator&)':
  | external/jsoncons~/include/jsoncons/utility/heap_string.hpp:148:21: error: 'extension_traits' has not been declared
  | 148 \|                 q = extension_traits::to_plain_pointer(ptr);
  | \|                     ^~~~~~~~~~~~~~~~
  | external/jsoncons~/include/jsoncons/utility/heap_string.hpp:160:21: error: 'extension_traits' has not been declared
  | 160 \|                 q = extension_traits::to_plain_pointer(ptr);

```

Closes #578.