### PR TITLE
Fixed warning

### DIFF
--- a/include/jsoncons/utility/bigint.hpp
+++ b/include/jsoncons/utility/bigint.hpp
@@ -1315,7 +1315,7 @@ public:
         basic_bigint<Allocator> q;
 
         b <<= 1;
-        while ( b >>= 2, b > 0 )
+        while ( (void)(b >>= 2), b > 0 )
         {
             x >>= 1;
         }


### PR DESCRIPTION
Fixed a warning about possible misuse of comma in the while() with casting it to void.