### PR TITLE
Update CMake policy usage to 3.14

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.5...3.14)
 
 project(jsoncons CXX)
 
@@ -60,7 +60,7 @@ configure_package_config_file(cmake/Config.cmake
 
 # jsoncons is header-only and does not depend on the architecture.
 
-if (${CMAKE_VERSION} VERSION_LESS "3.14.0")
+if (CMAKE_VERSION VERSION_LESS "3.14.0")
    write_basic_package_version_file(${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}ConfigVersion.cmake
                                     VERSION ${${PROJECT_NAME}_VERSION}
                                     COMPATIBILITY AnyNewerVersion)

--- a/examples/build/cmake/CMakeLists.txt
+++ b/examples/build/cmake/CMakeLists.txt
@@ -3,7 +3,7 @@
 # jsoncons examples CMake file
 #
 
-cmake_minimum_required (VERSION 2.8)
+cmake_minimum_required(VERSION 3.5...3.14)
 
 # load global config
 include (../../build/cmake/Config.cmake)
@@ -27,7 +27,7 @@ foreach(example_file ${Example_sources})
     # Create an executable with the example name and file
     add_executable(${example_name} ${example_file})
 
-    if (${CMAKE_SYSTEM_NAME} STREQUAL "Linux" AND ${CMAKE_CXX_COMPILER_ID} STREQUAL "Clang")
+    if ((CMAKE_SYSTEM_NAME STREQUAL "Linux") AND (CMAKE_CXX_COMPILER_ID STREQUAL "Clang"))
       # special link option on Linux because llvm stl rely on GNU stl
       target_link_libraries(${example_name} -Wl,-lstdc++)
     endif()

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -50,7 +50,7 @@ set(JSONCONS_THIRD_PARTY_INCLUDE_DIR ${JSONCONS_TESTS_DIR}/thirdparty)
 set(CATCH_INCLUDE_DIR ${JSONCONS_THIRD_PARTY_INCLUDE_DIR}/catch)
 add_library(catch INTERFACE)
 
-if (${CMAKE_VERSION} VERSION_LESS "3.8.0")
+if (CMAKE_VERSION VERSION_LESS "3.8.0")
     target_compile_features(catch INTERFACE cxx_range_for)  # for C++11 - flags
 else()
     target_compile_features(catch INTERFACE cxx_std_11)
@@ -198,7 +198,7 @@ add_executable(unit_tests
                corelib/src/testmain.cpp
 )              
 
-if (${CMAKE_VERSION} VERSION_LESS "3.8.0")
+if (CMAKE_VERSION VERSION_LESS "3.8.0")
     target_compile_features(unit_tests INTERFACE cxx_range_for)  # for C++11 - flags
 else()
     target_compile_features(unit_tests INTERFACE cxx_std_11)


### PR DESCRIPTION
I've updated the usage of CMake policy to set policies up to CMake 3.14, and made a couple of tweaks to comply with future policies as well.
I didn't go any further than 3.14, as some MSVC-specific policies are included in 3.15, and  I do not have a Windows development environment on which to test them.
Additionally, I was not able to actually test the examples, as it seems the `CMakeLists.txt` tries to import some nonexistent CMake files, but I'm confident that my changes there are appropriate nonetheless.

Solves #609 