### PR TITLE
Fix make_array() call

### DIFF
--- a/include/jsoncons/basic_json.hpp
+++ b/include/jsoncons/basic_json.hpp
@@ -2435,6 +2435,12 @@ namespace jsoncons {
             construct<array_storage>(ptr, tag);
         }
 
+        basic_json(const array& val, semantic_tag tag, allocator_type alloc)
+        {
+            auto ptr = create_array(alloc, val);
+            construct<array_storage>(ptr, tag);
+        }
+
         basic_json(array&& val, semantic_tag tag = semantic_tag::none)
         {
             auto alloc = val.get_allocator();
@@ -2447,6 +2453,12 @@ namespace jsoncons {
             auto ptr = create_object(
                 std::allocator_traits<Allocator>::select_on_container_copy_construction(val.get_allocator()), 
                 val);
+            construct<object_storage>(ptr, tag);
+        }
+
+        basic_json(const object& val, semantic_tag tag, allocator_type alloc)
+        {
+            auto ptr = create_object(alloc, val);
             construct<object_storage>(ptr, tag);
         }
 


### PR DESCRIPTION
Add missing allocator-aware array and object constructors

The `make_array(array, allocator_type)` overload generated a compile error
when it was instantiated because there was no corresponding `basic_json`
constructor. This adds that missing constructor. A matching `object`
constructor is also added for completeness.