### PR TITLE
Better check for JSONCONS_HAS_STD_FROM_CHARS being defned

### DIFF
--- a/include/jsoncons/utility/read_number.hpp
+++ b/include/jsoncons/utility/read_number.hpp
@@ -745,7 +745,7 @@ hex_to_integer(const CharT* s, std::size_t length, T& n)
 
 // decstr_to_double
 
-#if defined(JSONCONS_HAS_STD_FROM_CHARS)
+#if defined(JSONCONS_HAS_STD_FROM_CHARS) && JSONCONS_HAS_STD_FROM_CHARS
 
     inline to_number_result<char> decstr_to_double(const char* s, std::size_t length, double& val) 
     {


### PR DESCRIPTION
Makes it work if JSONCONS_HAS_STD_FROM_CHARS is defined to 0.