### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -1,4 +1,6 @@
 name: Windows
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/danielaparker/jsoncons/security/code-scanning/5](https://github.com/danielaparker/jsoncons/security/code-scanning/5)

To fix this issue, we should set the `permissions` block at either the workflow (top/root) level or per job. Since both jobs only require minimal permissions, setting `permissions: contents: read` at the top level is best: all jobs will inherit it unless overridden. The change should be added right below the workflow's name (after line 1) and before the `on:` block. No other changes, imports, or definitions are needed for this fix.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
