### PR TITLE
Fixed "always false" typo in double comparison

### DIFF
--- a/include/jsoncons/basic_json.hpp
+++ b/include/jsoncons/basic_json.hpp
@@ -1765,7 +1765,7 @@ namespace jsoncons {
                                 {
                                     return -1;
                                 }
-                                if (val2 >= 0 && val2 < 0)
+                                if (val2 < 0 && val1 >= 0)
                                 {
                                     return 1;
                                 }


### PR DESCRIPTION
I hope I understood the intention behind this correctly. This still shouldn't impact a lot as it's a corner case mitigation.