### PR TITLE
Literal expression `\\` in jmespath expression

### DIFF
--- a/include/jsoncons_ext/jmespath/jmespath.hpp
+++ b/include/jsoncons_ext/jmespath/jmespath.hpp
@@ -4072,7 +4072,13 @@ namespace detail {
                         switch (*p_)
                         {
                             case '\'':
-                                buffer.push_back(*p_);
+                                buffer.push_back('\'');
+                                state_stack.pop_back();
+                                ++p_;
+                                ++column_;
+                                break;
+                            case '\\':
+                                buffer.push_back('\\');
                                 state_stack.pop_back();
                                 ++p_;
                                 ++column_;


### PR DESCRIPTION
the literal expression \`\\\\\` fails to produce the expected result:

expected:
search( ["1","2","3"], join(\`\\\\`, @) ) -> "1\2\3"

actual:
search( ["1","2","3"], join(\`\\\\`, @) ) -> jmespath expression fails to compile: syntax error