### PR TITLE
optimize semantic_tag::noesc write_string

### DIFF
--- a/include/jsoncons/json_encoder.hpp
+++ b/include/jsoncons/json_encoder.hpp
@@ -558,12 +558,7 @@ namespace jsoncons {
             {
                 //std::cout << "noesc\n";
                 sink_.push_back('\"');
-                const CharT* begin = sv.data();
-                const CharT* end = begin + sv.length();
-                for (const CharT* it = begin; it != end; ++it)
-                {
-                    sink_.push_back(*it);
-                }
+                sink_.append(sv.data(), sv.length());
                 sink_.push_back('\"');
                 column_ += (sv.length()+2);
             }
@@ -1270,12 +1265,7 @@ namespace jsoncons {
             {
                 //std::cout << "noesc\n";
                 sink_.push_back('\"');
-                const CharT* begin = sv.data();
-                const CharT* end = begin + sv.length();
-                for (const CharT* it = begin; it != end; ++it)
-                {
-                    sink_.push_back(*it);
-                }
+                sink_.append(sv.data(), sv.length());
                 sink_.push_back('\"');
             }
             else if (tag == semantic_tag::bigint)


### PR DESCRIPTION
This change replaces the per-character loop with a single bulk write: sink_.append(sv.data(), sv.length())

When encoding large JSON strings tagged as semantic_tag::noesc, json_encoder currently writes characters one-by-one via sink_.push_back(*it). This is a hot path for payloads dominated by large base64 fields and causes a noticeable regression versus previous versions.
This gives significant improvement on noesc-heavy DOM->string