### PR TITLE
jmespath: allow rhs_expression in a keyvalue - expression

### DIFF
--- a/include/jsoncons_ext/jmespath/jmespath.hpp
+++ b/include/jsoncons_ext/jmespath/jmespath.hpp
@@ -4431,8 +4431,8 @@ namespace detail {
                                     push_token(token<Json>(begin_multi_select_list_arg), resources, output_stack, ec);
                                     if (JSONCONS_UNLIKELY(ec)) {return jmespath_expression{};}
                                     state_stack.back() = expr_state::multi_select_list;
-                                    state_stack.push_back(expr_state::rhs_expression);                                
-                                    state_stack.push_back(expr_state::lhs_expression);                                
+                                    state_stack.push_back(expr_state::rhs_expression);
+                                    state_stack.push_back(expr_state::lhs_expression);
                                     context_stack.push_back(expression_context<Json>{});
                                 }
                                 break;
@@ -4490,7 +4490,8 @@ namespace detail {
                             case '-':case '0':case '1':case '2':case '3':case '4':case '5':case '6':case '7':case '8':case '9':
                                 break;
                             default:
-                                state_stack.back() = expr_state::key_val_expr;
+                                state_stack.back() = expr_state::expect_rbrace;
+                                state_stack.push_back(expr_state::key_val_expr);
                                 break;
                         }
                         break;
@@ -4906,16 +4907,7 @@ namespace detail {
                             case ',':
                                 push_token(token<Json>(separator_arg), resources, output_stack, ec);
                                 if (JSONCONS_UNLIKELY(ec)) {return jmespath_expression{};}
-                                state_stack.back() = expr_state::key_val_expr; 
-                                ++p_;
-                                ++column_;
-                                break;
-                            case '[':
-                            case '{':
-                                state_stack.push_back(expr_state::lhs_expression);
-                                break;
-                            case '.':
-                                state_stack.push_back(expr_state::sub_expression);
+                                state_stack.push_back(expr_state::key_val_expr); 
                                 ++p_;
                                 ++column_;
                                 break;
@@ -4942,8 +4934,9 @@ namespace detail {
                                 advance_past_space_character();
                                 break;
                             case ':':
-                                state_stack.back() = expr_state::expect_rbrace;
+                                state_stack.back() = expr_state::rhs_expression;
                                 state_stack.push_back(expr_state::lhs_expression);
+                                context_stack.push_back(expression_context<Json>{});
                                 ++p_;
                                 ++column_;
                                 break;

--- a/test/jmespath/input/test.json
+++ b/test/jmespath/input/test.json
@@ -1,3 +1,42 @@
 [
+  {
+    "given": {
+      "foo": {
+        "bar": "baz"
+      }
+    },
+    "cases": [
+      {
+        "comment": "Comparator expression evaluates to true boolean",
+        "expression": "foo.bar == 'baz'",
+        "result": true
+      },
+      {
+        "comment": "Comparator expression evaluates to false boolean",
+        "expression": "foo.bar == 'bar'",
+        "result": false
+      },
+      {
+        "comment": "Multi select list comparator value expression evaluates to true boolean",
+        "expression": "[foo.bar == 'baz']",
+        "result": [ true ]
+      },
+      {
+        "comment": "Multi select list comparator value expression evaluates to false boolean",
+        "expression": "[foo.bar == 'bar']",
+        "result": [ false ]
+      },
+      {
+        "comment": "Multi select hash comparator value expression evaluates to true boolean",
+        "expression": "{value: foo.bar == 'baz'}",
+        "result": { "value": true }
+      },
+      {
+        "comment": "Multi select hash comparator value expression evaluates to false boolean",
+        "expression": "{value: foo.bar == 'bar'}",
+        "result": { "value": false }
+      }
+    ]
+  }
 ]
 

--- a/test/jmespath/src/jmespath_tests.cpp
+++ b/test/jmespath/src/jmespath_tests.cpp
@@ -90,6 +90,10 @@ void jmespath_tests(const std::string& fpath)
 
 TEST_CASE("jmespath-tests")
 {
+    SECTION("Tests")
+    {
+        jmespath_tests("./jmespath/input/test.json");
+    }
     SECTION("Examples and tutorials")
     {
         jmespath_tests("./jmespath/input/examples/jmespath-examples.json"); 


### PR DESCRIPTION
I  tried the following jmespath expression and noticed that jsoncons_ext jmes_path could not compile the expression:

`{value: foo.bar == 'baz'}`

because it expected '}' or ',' after the lhs_expression value part of a "key: value" and found a comparator ==, i.e. the start of a rhs_expression.

The jmespath grammar allows any expression as value in a multi select hash, so also those consisting of lhs and rhs part.