### PR TITLE
JMESPath functions floor and ceil return integer

### DIFF
--- a/include/jsoncons_ext/jmespath/jmespath.hpp
+++ b/include/jsoncons_ext/jmespath/jmespath.hpp
@@ -1240,8 +1240,8 @@ namespace detail {
     template <typename Json>
     class jmespath_evaluator 
     {
-        static constexpr double max_double_to_int64 = 9223372036854775807.0;
-        static constexpr double min_double_to_int64 = -9223372036854775808.0;
+        static constexpr double max_double_to_int64 = static_cast<double>(uint64_t(1u) << std::numeric_limits<double>::digits); // 2^53
+        static constexpr double min_double_to_int64 = -static_cast<double>(uint64_t(1u) << std::numeric_limits<double>::digits); // -2^53
 
     public:
         typedef typename Json::char_type char_type;

--- a/test/jmespath/input/test.json
+++ b/test/jmespath/input/test.json
@@ -82,9 +82,24 @@
         "result": "-3"
       },
       {
-        "comment": "Ceil function applied to a large double not in int64_t range should return as double",
-        "expression": "ceil(`1e20`)",
-        "result": 1e20
+        "comment": "Value at 2^53 boundary (max safe integer)",
+        "expression": "ceil(`9007199254740992.0`)",
+        "result": 9007199254740992
+      },
+      {
+        "comment": "Negative value at -2^53 boundary",
+        "expression": "floor(`-9007199254740992.0`)",
+        "result": -9007199254740992
+      },
+      {
+        "comment": "Value beyond safe range remains as double (does not overflow to negative integer)",
+        "expression": "ceil(`9223372036854775807.2`)",
+        "result": 9.223372036854776e+18
+      },
+      {
+        "comment": "Negative value beyond safe range remains as double",
+        "expression": "floor(`-9223372036854775808.2`)",
+        "result": -9.223372036854776e+18
       }
     ]
   }


### PR DESCRIPTION
I added some edge case tests and noticed that my code in pull request [688](https://github.com/danielaparker/jsoncons/pull/688) did cause incorrect results due to overflow:

``ceil(`9223372036854775807`)`` returned -9223372036854775808 instead of +9223372036854775807

So I coded different bounds to check the cast from double to int64.

Sorry for the inconvenience.