### PR TITLE
Fix bad multiplier when writing some BSON datetimes

### DIFF
--- a/include/jsoncons_ext/bson/bson_encoder.hpp
+++ b/include/jsoncons_ext/bson/bson_encoder.hpp
@@ -42,7 +42,6 @@ class basic_bson_encoder final : public basic_json_visitor<char>
 {
     enum class decimal_parse_state { start, integer, exp1, exp2, fraction1 };
     static constexpr int64_t nanos_in_milli = 1000000;
-    static constexpr int64_t nanos_in_second = 1000000000;
     static constexpr int64_t millis_in_second = 1000;
 public:
     using allocator_type = Allocator;
@@ -523,7 +522,7 @@ private:
                 before_value(jsoncons::bson::bson_type::datetime_type);
                 if (val != 0)
                 {
-                    val /= nanos_in_second;
+                    val /= nanos_in_milli;
                 }
                 binary::native_to_little(static_cast<int64_t>(val),std::back_inserter(buffer_));
                 break;


### PR DESCRIPTION
Fix that `basic_bson_encoder::visit_uint64` converted `semantic_tag::epoch_nano`-tagged integers to seconds, not milliseconds, before serializing as a BSON datetime. The resulting datetime would be much closer to 1970-01-01 (the Unix epoch) than it should. This commit copies the correct behavior from `visit_int64` to `visit_uint64`.