### PR TITLE
Don't write extra value after some CBOR epoch timestamps

### DIFF
--- a/include/jsoncons_ext/cbor/cbor_encoder.hpp
+++ b/include/jsoncons_ext/cbor/cbor_encoder.hpp
@@ -1158,8 +1158,7 @@ private:
         {
             case semantic_tag::epoch_milli:
             case semantic_tag::epoch_nano:
-                visit_double(static_cast<double>(value), tag, context, ec);
-                break;
+                return visit_double(static_cast<double>(value), tag, context, ec);
             case semantic_tag::epoch_second:
                 write_tag(1);
                 break;
@@ -1180,8 +1179,7 @@ private:
         {
             case semantic_tag::epoch_milli:
             case semantic_tag::epoch_nano:
-                visit_double(static_cast<double>(value), tag, context, ec);
-                break;
+                return visit_double(static_cast<double>(value), tag, context, ec);
             case semantic_tag::epoch_second:
                 write_tag(1);
                 break;


### PR DESCRIPTION
Fix that `epoch_milli`- and `epoch_nano`-tagged integers serialized to too many values in CBOR:
1. a CBOR semantic tag of 1 (expected),
2. a float64 number of seconds since the epoch (expected), and then
3. the integer number of milliseconds or nanoseconds (bad).

Only the semantic tag and float64 should be written; the trailing integer could wrongly be interpreted as the next key in a map or value in an array.

Thanks for your work on the library and your quick response to my last pull request.