### PR TITLE
JMESPath - Merge function can't merge when receiving a json_const_ref

### DIFF
--- a/include/jsoncons_ext/jmespath/jmespath.hpp
+++ b/include/jsoncons_ext/jmespath/jmespath.hpp
@@ -2022,8 +2022,9 @@ namespace detail {
                     return arg0;
                 }
 
-                auto result = context.create_json(arg0);
-                for (std::size_t i = 1; i < args.size(); ++i)
+                auto result = context.create_json(json_object_arg);
+                result->reserve(arg0.size());
+                for (std::size_t i = 0; i < args.size(); ++i)
                 {
                     reference argi = args[i].value();
                     if (!argi.is_object())

--- a/test/jmespath/input/test.json
+++ b/test/jmespath/input/test.json
@@ -1,5 +1,20 @@
 [
   {
+    "given": {
+      "foz": "baz"
+    },
+    "cases": [
+      {
+        "comment": "Multi select hash used in merge function",
+        "expression": "{object:@}.merge(object, {foo:'bar'})",
+        "result": {
+          "foo": "bar",
+          "foz": "baz"
+        }
+      }
+    ]
+  },
+  {
     "given": [
       { "foo": "bar" },
       { "foo": "baz" }


### PR DESCRIPTION
Do a shallow copy of the first argument to the merge function: if it is a json_const_ref no modification of the referenced json is allowed.

PR for issue: #702 