### PR TITLE
JMESPath Support rhs expression in multi_select_list

### DIFF
--- a/include/jsoncons_ext/jmespath/jmespath.hpp
+++ b/include/jsoncons_ext/jmespath/jmespath.hpp
@@ -4904,6 +4904,7 @@ namespace detail {
                             case ',':
                                 push_token(token<Json>(separator_arg), resources, output_stack, ec);
                                 if (JSONCONS_UNLIKELY(ec)) {return jmespath_expression{};}
+                                state_stack.push_back(expr_state::rhs_expression);
                                 state_stack.push_back(expr_state::lhs_expression);
                                 ++p_;
                                 ++column_;

--- a/test/jmespath/input/test.json
+++ b/test/jmespath/input/test.json
@@ -10,13 +10,13 @@
     "cases": [
       {
         "comment": "Operator in multi-select list second element",
-        "expression": "sum([value, count_children && children.value || `0`])",
-        "result": 3
+        "expression": "[value, count_children && children.value || `0`]",
+        "result": [1, 2]
       },
       {
         "comment": "Operator in multi-select list first element",
-        "expression": "sum([count_children && children.value || `0`, value])",
-        "result": 3
+        "expression": "[count_children && children.value || `0`, value]",
+        "result": [2, 1]
       }
     ]
   },

--- a/test/jmespath/input/test.json
+++ b/test/jmespath/input/test.json
@@ -1,6 +1,27 @@
 [
   {
     "given": {
+      "value": 1,
+      "count_children": true,
+      "children": {
+        "value": 2
+      }
+    },
+    "cases": [
+      {
+        "comment": "Operator in multi-select list second element",
+        "expression": "sum([value, count_children && children.value || `0`])",
+        "result": 3
+      },
+      {
+        "comment": "Operator in multi-select list first element",
+        "expression": "sum([count_children && children.value || `0`, value])",
+        "result": 3
+      }
+    ]
+  },
+  {
+    "given": {
       "foz": "baz"
     },
     "cases": [


### PR DESCRIPTION
Using a rhs expression in a multi-select-list only works when it is the first element in the list, this fixes the case when it is the second or later element.