### PR TITLE
JMESPath - Sort and sort_by functions can't sort when receiving a json_const_ref

### DIFF
--- a/include/jsoncons_ext/jmespath/jmespath.hpp
+++ b/include/jsoncons_ext/jmespath/jmespath.hpp
@@ -2121,6 +2121,9 @@ namespace detail {
                     return context.null_value();
                 }
 
+                auto result = context.create_json(json_array_arg);
+                result->reserve(arg0.size());
+                result->push_back(arg0.at(0));
                 for (std::size_t i = 1; i < arg0.size(); ++i)
                 {
                     if (arg0.at(i).is_number() != is_number || arg0.at(i).is_string() != is_string)
@@ -2128,11 +2131,11 @@ namespace detail {
                         ec = jmespath_errc::invalid_type;
                         return context.null_value();
                     }
+                    result->push_back(arg0.at(i));
                 }
 
-                auto v = context.create_json(arg0);
-                std::stable_sort((v->array_range()).begin(), (v->array_range()).end());
-                return *v;
+                std::stable_sort((result->array_range()).begin(), (result->array_range()).end());
+                return *result;
             }
         };
 
@@ -2167,8 +2170,14 @@ namespace detail {
 
                 const auto& expr = args[1].expression();
 
-                auto v = context.create_json(arg0);
-                std::stable_sort((v->array_range()).begin(), (v->array_range()).end(),
+                auto result = context.create_json(json_array_arg);
+                result->reserve(arg0.size());
+                for (std::size_t i = 0; i < arg0.size(); ++i)
+                {
+                    result->push_back(arg0.at(i));
+                }
+
+                std::stable_sort((result->array_range()).begin(), (result->array_range()).end(),
                     [&expr,&context,&ec](reference lhs, reference rhs) -> bool
                 {
                     std::error_code ec2;
@@ -2188,7 +2197,7 @@ namespace detail {
                     
                     return key1 < key2;
                 });
-                return ec ? context.null_value() : *v;
+                return ec ? context.null_value() : *result;
             }
         };
 

--- a/test/jmespath/input/test.json
+++ b/test/jmespath/input/test.json
@@ -1,5 +1,23 @@
 [
   {
+    "given": [
+      [ 2, 1 ],
+      [ "foo", "bar" ]
+    ],
+    "cases": [
+      {
+        "comment": "Json const ref argument used in sort function",
+        "expression": "sort([*]|[0])",
+        "result": [ 1, 2 ]
+      },
+      {
+        "comment": "Json const ref argument used in sort_by function",
+        "expression": "sort_by([*]|[0],&@)",
+        "result": [ 1, 2 ]
+      }
+    ]
+  },
+  {
     "given": {
       "value": 1,
       "count_children": true,
@@ -11,12 +29,12 @@
       {
         "comment": "Operator in multi-select list second element",
         "expression": "[value, count_children && children.value || `0`]",
-        "result": [1, 2]
+        "result": [ 1, 2 ]
       },
       {
         "comment": "Operator in multi-select list first element",
         "expression": "[count_children && children.value || `0`, value]",
-        "result": [2, 1]
+        "result": [ 2, 1 ]
       }
     ]
   },
@@ -26,7 +44,7 @@
     },
     "cases": [
       {
-        "comment": "Multi select hash used in merge function",
+        "comment": "Json const ref argument used in merge function",
         "expression": "{object:@}.merge(object, {foo:'bar'})",
         "result": {
           "foo": "bar",


### PR DESCRIPTION
Do a shallow copy of the argument to the sort and sort_by function: if it is a json_const_ref no modification of the referenced json is allowed.

Same problem as #703 but then in the sort and sort_by functions