### PR TITLE
Fix staj_event::as_double silently returning 0 for non-numeric strings

### DIFF
--- a/include/jsoncons/staj_event.hpp
+++ b/include/jsoncons/staj_event.hpp
@@ -493,7 +493,11 @@ private:
             case staj_events::string_value:
             {
                 double val{0};
-                jsoncons::decstr_to_double(value_.string_data_, length_, val);
+                auto result = jsoncons::decstr_to_double(value_.string_data_, length_, val);
+                if (!result)
+                {
+                    ec = conv_errc::not_double;
+                }
                 return val;
             }
             case staj_events::double_value:

--- a/include/jsoncons/staj_event.hpp
+++ b/include/jsoncons/staj_event.hpp
@@ -493,6 +493,11 @@ private:
             case staj_events::string_value:
             {
                 double val{0};
+                if (length_ == 0)
+                {
+                    ec = conv_errc::not_double;
+                    return val;
+                }
                 auto result = jsoncons::decstr_to_double(value_.string_data_, length_, val);
                 if (!result)
                 {

--- a/test/csv/src/encode_decode_csv_tests.cpp
+++ b/test/csv/src/encode_decode_csv_tests.cpp
@@ -152,6 +152,35 @@ TEST_CASE("encode decode csv source")
     }
 }
 
+TEST_CASE("decode_csv non-numeric string into double reports error")
+{
+    // Regression test for staj_event::as_double silently returning 0.0
+    // when a string_value event is decoded into a floating-point type.
+    // Introduced in caacd258a ("Remove chars_to, replace with to_double"):
+    // the new to_double API's return code was not propagated to ec, so
+    // non-numeric and empty cells were coerced to 0.0 without error.
+    using cpp_type = std::vector<std::vector<double>>;
+    auto options = csv::csv_options{}
+        .mapping_kind(csv::csv_mapping_kind::n_rows)
+        .assume_header(false);
+
+    SECTION("non-numeric token")
+    {
+        std::string s = "hey\n";
+        auto result = csv::try_decode_csv<cpp_type>(s, options);
+        REQUIRE(!result); //-V521
+        REQUIRE_THROWS(csv::decode_csv<cpp_type>(s, options));
+    }
+
+    SECTION("empty trailing field")
+    {
+        std::string s = "0,\n";
+        auto result = csv::try_decode_csv<cpp_type>(s, options);
+        REQUIRE(!result); //-V521
+        REQUIRE_THROWS(csv::decode_csv<cpp_type>(s, options));
+    }
+}
+
 
 namespace
 {


### PR DESCRIPTION
## Summary

`basic_staj_event::as_double` silently returns `0.0` (with no error) when a
`string_value`/`key` event holds text that isn't a number. Any decoder that
asks a string event for a `double` — e.g.
`decode_csv<std::vector<std::vector<double>>>` over `infer_types(true)` output —
therefore coerces non-numeric and empty cells to `0.0` instead of reporting a
conversion error.

## Root cause

Regression introduced in caacd258a ("Remove chars_to, replace with to_double").

Before that commit, the string branch of `as_double` used the `chars_to`
functor, which **threw** `json_runtime_error<std::invalid_argument>` on invalid
input. The commit migrated to the new out-parameter API:

```diff
-                jsoncons::utility::chars_to f;
-                return f(value_.string_data_, length_);
+                double val{0};
+                jsoncons::utility::to_double(value_.string_data_, length_, val);
+                return val;
```

The new call reports failure through its **return value**, but this call site
discards it — so `val` keeps its default `0` and the caller's `std::error_code&`
is never set. (Later renames turned `to_double` into `decstr_to_double`; the
behavioral bug is unchanged.)

For comparison, `basic_csv_parser::end_value_with_numeric_check` uses the same
`decstr_to_double` call and *does* check `result.ec`.

## Fix

`include/jsoncons/staj_event.hpp`, `as_double`:

```cpp
double val{0};
auto result = jsoncons::decstr_to_double(value_.string_data_, length_, val);
if (!result)
{
    ec = conv_errc::not_double;
}
return val;
```

`to_number_result` has an `explicit operator bool()` that is false on error, so
`!result` covers both `std::errc::invalid_argument` (non-numeric / empty input)
and any other failure.

## Reproducer

```cpp
#include <jsoncons_ext/csv/csv.hpp>
#include <vector>
#include <string>

int main() {
    auto opt = jsoncons::csv::csv_options{}
        .mapping_kind(jsoncons::csv::csv_mapping_kind::n_rows)
        .assume_header(false);

    // Expected: an error. Actual (before this fix): silent {{0}}.
    auto r = jsoncons::csv::try_decode_csv<std::vector<std::vector<double>>>(
        std::string("hey\n"), opt);
    return r ? 1 : 0;   // returns 1 (success) before the fix
}
```

## Tests

Added `TEST_CASE("decode_csv non-numeric string into double reports error")`
to `test/csv/src/encode_decode_csv_tests.cpp`, covering a non-numeric token
(`"hey\n"`) and an empty trailing field (`"0,\n"`). Each section asserts both
`try_decode_csv` returns an error and `decode_csv` throws.

- The new test fails on current `master` (the `try_decode_csv` call silently
  succeeds).
- With the fix, the new test passes and the full unit-test suite is green
  (883 test cases, 20,639 assertions).
