### PR TITLE
fix bigdec mantissa and exponent parsing

### DIFF
--- a/include/jsoncons_ext/cbor/cbor_encoder.hpp
+++ b/include/jsoncons_ext/cbor/cbor_encoder.hpp
@@ -612,6 +612,12 @@ private:
                             s.push_back(c);
                             state = decimal_parse_state::integer;
                             break;
+                        case '+':
+                            state = decimal_parse_state::integer;
+                            break;
+                        case '.':
+                            state = decimal_parse_state::fraction1;
+                            break;
                         default:
                         {
                             ec = cbor_errc::invalid_decimal_fraction;
@@ -684,6 +690,9 @@ private:
                             s.push_back(c);
                             --scale;
                             break;
+                        case 'e': case 'E':
+                            state = decimal_parse_state::exp1;
+                            break;
                         default:
                         {
                             ec = cbor_errc::invalid_decimal_fraction;
@@ -701,7 +710,7 @@ private:
         if (exponent.length() > 0)
         {
             int64_t val{};
-            auto r = jsoncons::to_integer(exponent.data(), exponent.length(), val);
+            auto r = jsoncons::dec_to_integer(exponent.data(), exponent.length(), val);
             if (!r)
             {
                 ec = r.error_code();
@@ -713,7 +722,7 @@ private:
         if (JSONCONS_UNLIKELY(ec)) {return;}
 
         int64_t val{ 0 };
-        auto r = jsoncons::to_integer(s.data(),s.length(), val);
+        auto r = jsoncons::dec_to_integer(s.data(),s.length(), val);
         if (r)
         {
             visit_int64(val, semantic_tag::none, context, ec);


### PR DESCRIPTION
this fixes various CBOR bigdec cases where a 0 would lead to unintended throwing or octal interpretation e.g. "0.8" would throw, "0.215" would be misparsed as "0.141"

also adds support for +, leading dot and fraction followed by exponent, e.g. "+2.5" or ".6" or "-1.5e6"
