### PR TITLE
fix misplaced #endif

### DIFF
--- a/include/jsoncons/basic_json.hpp
+++ b/include/jsoncons/basic_json.hpp
@@ -4992,8 +4992,8 @@ namespace jsoncons {
                     return other;
             }
         }
-    };
 #endif
+    };
 
     // operator==
 


### PR DESCRIPTION
1.8.0 doesn't work under JSONCONS_NO_DEPRECATED, due to the end of a class getting removed.
The problematic directive was introduced in 5d2f83d.