### PR TITLE
ky/source buffer guards

### DIFF
--- a/include/jsoncons/source.hpp
+++ b/include/jsoncons/source.hpp
@@ -417,38 +417,13 @@ namespace jsoncons {
             }
         }
     private:
-        void reserve_buffer(std::size_t capacity)
-        {
-            if (capacity <= buffer_size_)
-            {
-                return;
-            }
-
-            value_type* new_buffer = std::allocator_traits<char_allocator_type>::allocate(alloc_, capacity);
-            if (length_ > 0)
-            {
-                std::memcpy(new_buffer, data_, sizeof(value_type)*length_);
-            }
-            if (buffer_)
-            {
-                std::allocator_traits<char_allocator_type>::deallocate(alloc_, buffer_, buffer_size_);
-            }
-            buffer_ = new_buffer;
-            buffer_size_ = capacity;
-            data_ = buffer_;
-        }
-
         void make_available(std::size_t length)
         {
             if (length > buffer_size_)
             {
-                if (length > default_max_buffer_size)
-                {
-                    return;
-                }
-                reserve_buffer(length);
+                return;
             }
-            else if (length_ > 0 && data_ != buffer_)
+            if (length_ > 0 && data_ != buffer_)
             {
                 std::memmove(buffer_, data_, sizeof(value_type)*length_);
                 data_ = buffer_;
@@ -692,13 +667,9 @@ namespace jsoncons {
 
         span<const value_type> read_span(std::size_t length)
         {
-            if (length > default_max_buffer_size)
-            {
-                return span<const value_type>();
-            }
             if (length > buffer_.size())
             {
-                buffer_.resize(length);
+                return span<const value_type>();
             }
             std::size_t actual = read(buffer_.data(), length);
             if (actual != length)
@@ -928,13 +899,9 @@ namespace jsoncons {
 
         span<const value_type> read_span(std::size_t length)
         {
-            if (length > default_max_buffer_size)
-            {
-                return span<const value_type>();
-            }
             if (length > buffer_.size())
             {
-                buffer_.resize(length);
+                return span<const value_type>();
             }
             std::size_t actual = read(buffer_.data(), length);
             if (actual != length)

--- a/test/cbor/src/cbor_cursor_tests.cpp
+++ b/test/cbor/src/cbor_cursor_tests.cpp
@@ -63,6 +63,124 @@ TEST_CASE("cbor stream source spans straddled strings")
     CHECK(cursor.current().get<std::string>() == "hello");
 }
 
+TEST_CASE("cbor stream source with tiny buffer reads strings around the buffer size")
+{
+    SECTION("text string shorter than the buffer size")
+    {
+        std::string data;
+        data.push_back('\x63');
+        data.append("abc");
+        std::istringstream is(data);
+        jsoncons::binary_stream_source source(is, 4);
+        std::error_code ec;
+        cbor::cbor_stream_cursor cursor(std::move(source), ec);
+
+        REQUIRE_FALSE(ec);
+        REQUIRE(staj_events::string_value == cursor.current().event_type());
+        CHECK(cursor.current().get<std::string>() == "abc");
+    }
+
+    SECTION("text string of exactly the buffer size")
+    {
+        std::string data;
+        data.push_back('\x64');
+        data.append("abcd");
+        std::istringstream is(data);
+        jsoncons::binary_stream_source source(is, 4);
+        std::error_code ec;
+        cbor::cbor_stream_cursor cursor(std::move(source), ec);
+
+        REQUIRE_FALSE(ec);
+        REQUIRE(staj_events::string_value == cursor.current().event_type());
+        CHECK(cursor.current().get<std::string>() == "abcd");
+    }
+
+    SECTION("text string longer than the buffer size")
+    {
+        std::string data;
+        data.push_back('\x65');
+        data.append("abcde");
+        std::istringstream is(data);
+        jsoncons::binary_stream_source source(is, 4);
+        std::error_code ec;
+        cbor::cbor_stream_cursor cursor(std::move(source), ec);
+
+        REQUIRE_FALSE(ec);
+        REQUIRE(staj_events::string_value == cursor.current().event_type());
+        CHECK(cursor.current().get<std::string>() == "abcde");
+    }
+
+    SECTION("byte string longer than the buffer size")
+    {
+        std::string data;
+        data.push_back('\x45');
+        data.append("abcde");
+        std::istringstream is(data);
+        jsoncons::binary_stream_source source(is, 4);
+        std::error_code ec;
+        cbor::cbor_stream_cursor cursor(std::move(source), ec);
+
+        REQUIRE_FALSE(ec);
+        REQUIRE(staj_events::byte_string_value == cursor.current().event_type());
+        auto bytes = cursor.current().get<byte_string_view>();
+        REQUIRE(5 == bytes.size());
+        CHECK('a' == bytes[0]);
+        CHECK('e' == bytes[4]);
+    }
+}
+
+TEST_CASE("cbor iterator source with tiny buffer reads strings around the buffer size")
+{
+    using source_type = jsoncons::binary_iterator_source<std::vector<uint8_t>::const_iterator>;
+
+    SECTION("text string shorter than the buffer size")
+    {
+        std::vector<uint8_t> data = {0x63,'a','b','c'};
+        std::error_code ec;
+        cbor::basic_cbor_cursor<source_type> cursor(source_type(data.cbegin(), data.cend(), 4), ec);
+
+        REQUIRE_FALSE(ec);
+        REQUIRE(staj_events::string_value == cursor.current().event_type());
+        CHECK(cursor.current().get<std::string>() == "abc");
+    }
+
+    SECTION("text string of exactly the buffer size")
+    {
+        std::vector<uint8_t> data = {0x64,'a','b','c','d'};
+        std::error_code ec;
+        cbor::basic_cbor_cursor<source_type> cursor(source_type(data.cbegin(), data.cend(), 4), ec);
+
+        REQUIRE_FALSE(ec);
+        REQUIRE(staj_events::string_value == cursor.current().event_type());
+        CHECK(cursor.current().get<std::string>() == "abcd");
+    }
+
+    SECTION("text string longer than the buffer size")
+    {
+        std::vector<uint8_t> data = {0x65,'a','b','c','d','e'};
+        std::error_code ec;
+        cbor::basic_cbor_cursor<source_type> cursor(source_type(data.cbegin(), data.cend(), 4), ec);
+
+        REQUIRE_FALSE(ec);
+        REQUIRE(staj_events::string_value == cursor.current().event_type());
+        CHECK(cursor.current().get<std::string>() == "abcde");
+    }
+
+    SECTION("byte string longer than the buffer size")
+    {
+        std::vector<uint8_t> data = {0x45,1,2,3,4,5};
+        std::error_code ec;
+        cbor::basic_cbor_cursor<source_type> cursor(source_type(data.cbegin(), data.cend(), 4), ec);
+
+        REQUIRE_FALSE(ec);
+        REQUIRE(staj_events::byte_string_value == cursor.current().event_type());
+        auto bytes = cursor.current().get<byte_string_view>();
+        REQUIRE(5 == bytes.size());
+        CHECK(1 == bytes[0]);
+        CHECK(5 == bytes[4]);
+    }
+}
+
 TEST_CASE("cbor stream rejects truncated huge byte string length")
 {
     std::string data;

--- a/test/corelib/src/source_tests.cpp
+++ b/test/corelib/src/source_tests.cpp
@@ -509,6 +509,80 @@ TEST_CASE("binary_stream_source tests")
     }
 }
 
+TEST_CASE("binary_stream_source read_span tests")
+{
+    std::string data = "0123456789abcdef";
+
+    SECTION("read_span within the configured buffer size")
+    {
+        std::istringstream is(data);
+        jsoncons::binary_stream_source source(is,4);
+
+        auto s = source.read_span(3);
+        REQUIRE(3 == s.size());
+        CHECK(std::equal(s.begin(), s.end(), data.begin()));
+        CHECK(3 == source.position());
+        CHECK(4 == source.buffer_size());
+    }
+
+    SECTION("read_span of exactly the configured buffer size")
+    {
+        std::istringstream is(data);
+        jsoncons::binary_stream_source source(is,4);
+
+        auto s = source.read_span(4);
+        REQUIRE(4 == s.size());
+        CHECK(std::equal(s.begin(), s.end(), data.begin()));
+        CHECK(4 == source.position());
+        CHECK(4 == source.buffer_size());
+    }
+
+    SECTION("read_span straddling buffer refills")
+    {
+        std::istringstream is(data);
+        jsoncons::binary_stream_source source(is,4);
+
+        auto s = source.read_span(3);
+        REQUIRE(3 == s.size());
+        auto s2 = source.read_span(3);
+        REQUIRE(3 == s2.size());
+        CHECK(std::equal(s2.begin(), s2.end(), data.begin()+3));
+        CHECK(6 == source.position());
+        CHECK(4 == source.buffer_size());
+    }
+
+    SECTION("read_span larger than the configured buffer size fails without consuming")
+    {
+        std::istringstream is(data);
+        jsoncons::binary_stream_source source(is,4);
+
+        auto s = source.read_span(5);
+        CHECK(0 == s.size());
+        CHECK(0 == source.position());
+        CHECK(4 == source.buffer_size());
+
+        std::vector<uint8_t> v(5);
+        REQUIRE(5 == source.read(v.data(),5));
+        CHECK(std::equal(v.begin(), v.end(), data.begin()));
+    }
+
+    SECTION("read_span larger than the default buffer size succeeds when configured")
+    {
+        std::string big(20000, '\0');
+        for (std::size_t i = 0; i < big.size(); ++i)
+        {
+            big[i] = static_cast<char>('a' + (i % 26));
+        }
+        std::istringstream is(big);
+        jsoncons::binary_stream_source source(is,big.size());
+
+        auto s = source.read_span(17000);
+        REQUIRE(17000 == s.size());
+        CHECK(std::equal(s.begin(), s.end(), big.begin()));
+        CHECK(big.size() == source.buffer_size());
+    }
+}
+
 TEST_CASE("random access iterator iterator_stream source tests")
 {
     std::string data = "012345678";
@@ -580,6 +654,96 @@ TEST_CASE("forward iterator iterator_stream source tests")
         CHECK(1 == s.size());
         CHECK(std::equal(s.begin(), s.end(), data.begin()+8));
         CHECK(9 == source.position());
+    }
+}
+
+TEST_CASE("iterator_source read_span tests")
+{
+    std::string data = "0123456789abcdef";
+
+    SECTION("read_span within the configured buffer size")
+    {
+        jsoncons::iterator_source<std::string::iterator> source(data.begin(), data.end(), 4);
+
+        auto s = source.read_span(3);
+        REQUIRE(3 == s.size());
+        CHECK(std::equal(s.begin(), s.end(), data.begin()));
+        auto s2 = source.read_span(4);
+        REQUIRE(4 == s2.size());
+        CHECK(std::equal(s2.begin(), s2.end(), data.begin()+3));
+        CHECK(7 == source.position());
+    }
+
+    SECTION("read_span larger than the configured buffer size fails without consuming")
+    {
+        jsoncons::iterator_source<std::string::iterator> source(data.begin(), data.end(), 4);
+
+        auto s = source.read_span(5);
+        CHECK(0 == s.size());
+        CHECK(0 == source.position());
+
+        std::vector<char> v(5);
+        REQUIRE(5 == source.read(v.data(),5));
+        CHECK(std::equal(v.begin(), v.end(), data.begin()));
+    }
+
+    SECTION("read_span larger than the default buffer size succeeds when configured")
+    {
+        std::string big(20000, '\0');
+        for (std::size_t i = 0; i < big.size(); ++i)
+        {
+            big[i] = static_cast<char>('a' + (i % 26));
+        }
+        jsoncons::iterator_source<std::string::iterator> source(big.begin(), big.end(), big.size());
+
+        auto s = source.read_span(17000);
+        REQUIRE(17000 == s.size());
+        CHECK(std::equal(s.begin(), s.end(), big.begin()));
+    }
+}
+
+TEST_CASE("binary_iterator_source read_span tests")
+{
+    std::vector<uint8_t> data = { 0,1,2,3,4,5,6,7,8,10,11,12,13,14,15 };
+
+    SECTION("read_span within the configured buffer size")
+    {
+        jsoncons::binary_iterator_source<std::vector<uint8_t>::iterator> source(data.begin(), data.end(), 4);
+
+        auto s = source.read_span(3);
+        REQUIRE(3 == s.size());
+        CHECK(std::equal(s.begin(), s.end(), data.begin()));
+        auto s2 = source.read_span(4);
+        REQUIRE(4 == s2.size());
+        CHECK(std::equal(s2.begin(), s2.end(), data.begin()+3));
+        CHECK(7 == source.position());
+    }
+
+    SECTION("read_span larger than the configured buffer size fails without consuming")
+    {
+        jsoncons::binary_iterator_source<std::vector<uint8_t>::iterator> source(data.begin(), data.end(), 4);
+
+        auto s = source.read_span(5);
+        CHECK(0 == s.size());
+        CHECK(0 == source.position());
+
+        std::vector<uint8_t> v(5);
+        REQUIRE(5 == source.read(v.data(),5));
+        CHECK(std::equal(v.begin(), v.end(), data.begin()));
+    }
+
+    SECTION("read_span larger than the default buffer size succeeds when configured")
+    {
+        std::vector<uint8_t> big(20000);
+        for (std::size_t i = 0; i < big.size(); ++i)
+        {
+            big[i] = static_cast<uint8_t>(i & 0xff);
+        }
+        jsoncons::binary_iterator_source<std::vector<uint8_t>::iterator> source(big.begin(), big.end(), big.size());
+
+        auto s = source.read_span(17000);
+        REQUIRE(17000 == s.size());
+        CHECK(std::equal(s.begin(), s.end(), big.begin()));
     }
 }
 

--- a/test/corelib/src/source_tests.cpp
+++ b/test/corelib/src/source_tests.cpp
@@ -1,6 +1,10 @@
 // Copyright 2013-2026 Daniel Parker
 // Distributed under Boost license
 
+#if defined(__GNUC__) && !defined(__clang__) && __GNUC__ <= 12
+#pragma GCC diagnostic ignored "-Wstringop-overflow"
+#endif
+
 #include <jsoncons/json.hpp>
 #include <jsoncons/source.hpp>
 #include <sstream>
@@ -704,7 +708,7 @@ TEST_CASE("iterator_source read_span tests")
 
 TEST_CASE("binary_iterator_source read_span tests")
 {
-    std::vector<uint8_t> data = { 0,1,2,3,4,5,6,7,8,10,11,12,13,14,15 };
+    std::vector<uint8_t> data = { 0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15 };
 
     SECTION("read_span within the configured buffer size")
     {


### PR DESCRIPTION
- **Expose read_head in cbor::view namespace**
- **Compare buffer guards against configured buffer size**
