### PR TITLE
Reinstate cbor_view with iterative container walk

### DIFF
--- a/include/jsoncons_ext/cbor/cbor_view.hpp
+++ b/include/jsoncons_ext/cbor/cbor_view.hpp
@@ -1,0 +1,558 @@
+// Copyright 2013-2026 Daniel Parker
+// Distributed under the Boost license, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+// See https://github.com/danielaparker/jsoncons for latest version
+
+#ifndef JSONCONS_EXT_CBOR_CBOR_VIEW_HPP
+#define JSONCONS_EXT_CBOR_CBOR_VIEW_HPP
+
+#include <algorithm>
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+#include <system_error>
+#include <vector>
+
+#include <jsoncons/config/jsoncons_config.hpp>
+#include <jsoncons/json_exception.hpp>
+#include <jsoncons_ext/cbor/cbor_detail.hpp>
+#include <jsoncons_ext/cbor/cbor_error.hpp>
+
+namespace jsoncons {
+namespace cbor {
+namespace view {
+
+    constexpr int default_max_nesting_depth = 1024;
+
+    struct item_head
+    {
+        detail::cbor_major_type major_type{};
+        uint8_t additional_info{0};
+        uint64_t value{0};
+
+        bool indefinite() const noexcept
+        {
+            return additional_info == detail::additional_info::indefinite_length;
+        }
+    };
+
+    struct map_entry_view
+    {
+        span<const uint8_t> key;
+        span<const uint8_t> value;
+    };
+
+    namespace detail_view {
+
+        inline int sign(int value) noexcept
+        {
+            return (value > 0) - (value < 0);
+        }
+
+        inline int compare_size(std::size_t a, std::size_t b) noexcept
+        {
+            return a < b ? -1 : (a > b ? 1 : 0);
+        }
+
+        inline int compare_bytes(span<const uint8_t> a, span<const uint8_t> b) noexcept
+        {
+            const std::size_t n = (std::min)(a.size(), b.size());
+            if (n != 0)
+            {
+                int r = std::memcmp(a.data(), b.data(), n);
+                if (r != 0)
+                {
+                    return sign(r);
+                }
+            }
+            return compare_size(a.size(), b.size());
+        }
+
+        inline bool read_uint(const uint8_t*& p, const uint8_t* end, uint8_t info, uint64_t& value, std::error_code& ec)
+        {
+            if (info < 24)
+            {
+                value = info;
+                return true;
+            }
+
+            std::size_t length = 0;
+            switch (info)
+            {
+                case 24: length = 1; break;
+                case 25: length = 2; break;
+                case 26: length = 4; break;
+                case 27: length = 8; break;
+                default:
+                    ec = cbor_errc::unknown_type;
+                    return false;
+            }
+
+            if (static_cast<std::size_t>(end - p) < length)
+            {
+                ec = cbor_errc::unexpected_eof;
+                return false;
+            }
+
+            value = 0;
+            for (std::size_t i = 0; i < length; ++i)
+            {
+                value = (value << 8) | static_cast<uint64_t>(p[i]);
+            }
+            p += length;
+            return true;
+        }
+
+        inline bool read_head(const uint8_t*& p, const uint8_t* end, item_head& head, std::error_code& ec)
+        {
+            if (p >= end)
+            {
+                ec = cbor_errc::unexpected_eof;
+                return false;
+            }
+
+            const uint8_t initial = *p++;
+            head.major_type = static_cast<cbor::detail::cbor_major_type>(initial >> 5);
+            head.additional_info = initial & 0x1f;
+            head.value = 0;
+
+            if (head.additional_info == cbor::detail::additional_info::indefinite_length)
+            {
+                switch (head.major_type)
+                {
+                    case cbor::detail::cbor_major_type::byte_string:
+                    case cbor::detail::cbor_major_type::text_string:
+                    case cbor::detail::cbor_major_type::array:
+                    case cbor::detail::cbor_major_type::map:
+                        break;
+                    default:
+                        ec = cbor_errc::unknown_type;
+                        return false;
+                }
+                return true;
+            }
+            return read_uint(p, end, head.additional_info, head.value, ec);
+        }
+
+        inline bool skip_string_chunks(const uint8_t*& p, const uint8_t* end,
+                                      cbor::detail::cbor_major_type expected_major, std::error_code& ec)
+        {
+            for (;;)
+            {
+                if (p >= end)
+                {
+                    ec = cbor_errc::unexpected_eof;
+                    return false;
+                }
+                if (*p == 0xff)
+                {
+                    ++p;
+                    return true;
+                }
+
+                item_head chunk;
+                if (!read_head(p, end, chunk, ec))
+                {
+                    return false;
+                }
+                if (chunk.major_type != expected_major || chunk.indefinite())
+                {
+                    ec = cbor_errc::illegal_chunked_string;
+                    return false;
+                }
+                if (static_cast<uint64_t>(end - p) < chunk.value)
+                {
+                    ec = cbor_errc::unexpected_eof;
+                    return false;
+                }
+                p += static_cast<std::size_t>(chunk.value);
+            }
+        }
+
+        // Head of the value itself, past any leading semantic tags.
+        inline bool read_value_head(const uint8_t*& p, const uint8_t* end, item_head& head, std::error_code& ec)
+        {
+            do
+            {
+                if (!read_head(p, end, head, ec))
+                {
+                    return false;
+                }
+            }
+            while (head.major_type == cbor::detail::cbor_major_type::semantic_tag);
+            return true;
+        }
+
+        // Skips the payload of any non-container head in place.
+        inline bool skip_scalar_or_string(const item_head& head, const uint8_t*& p, const uint8_t* end, std::error_code& ec)
+        {
+            switch (head.major_type)
+            {
+                case cbor::detail::cbor_major_type::unsigned_integer:
+                case cbor::detail::cbor_major_type::negative_integer:
+                case cbor::detail::cbor_major_type::simple:
+                    return true;
+
+                case cbor::detail::cbor_major_type::byte_string:
+                case cbor::detail::cbor_major_type::text_string:
+                    if (head.indefinite())
+                    {
+                        return skip_string_chunks(p, end, head.major_type, ec);
+                    }
+                    if (static_cast<uint64_t>(end - p) < head.value)
+                    {
+                        ec = cbor_errc::unexpected_eof;
+                        return false;
+                    }
+                    p += static_cast<std::size_t>(head.value);
+                    return true;
+
+                default:
+                    ec = cbor_errc::unknown_type;
+                    return false;
+            }
+        }
+
+        // Remaining raw items in an open container, or a marker for an
+        // indefinite-length one, which ends at a break byte instead: arrays
+        // accept a break before any element, maps only between entries, never
+        // between a key and its value. Counts admitted by skip_container are
+        // bounded by the bytes remaining in the input, so a count can never
+        // collide with a marker.
+        constexpr uint64_t indefinite_array_marker = UINT64_MAX;
+        constexpr uint64_t indefinite_map_key_marker = UINT64_MAX - 1;
+        constexpr uint64_t indefinite_map_value_marker = UINT64_MAX - 2;
+
+        class pending_stack
+        {
+            static constexpr std::size_t local_capacity = 32;
+
+            uint64_t local_[local_capacity];
+            std::vector<uint64_t> spill_;
+            std::size_t size_{0};
+        public:
+            bool empty() const noexcept
+            {
+                return size_ == 0;
+            }
+
+            std::size_t size() const noexcept
+            {
+                return size_;
+            }
+
+            void push(uint64_t count)
+            {
+                if (size_ < local_capacity)
+                {
+                    local_[size_] = count;
+                }
+                else
+                {
+                    spill_.push_back(count);
+                }
+                ++size_;
+            }
+
+            uint64_t pop() noexcept
+            {
+                --size_;
+                if (size_ >= local_capacity)
+                {
+                    const uint64_t count = spill_.back();
+                    spill_.pop_back();
+                    return count;
+                }
+                return local_[size_];
+            }
+        };
+
+        // Iterative walk of the array or map whose head has just been read,
+        // so nested input is bounded by max_nesting_depth alone and can never
+        // exhaust the call stack. The innermost level's state stays in a
+        // local; enclosing levels wait in `parents`, with a synthetic root
+        // level of zero at the bottom.
+        inline bool skip_container(const uint8_t*& p, const uint8_t* end, item_head head,
+            int max_nesting_depth, std::error_code& ec)
+        {
+            const std::size_t depth_limit = max_nesting_depth > 0 ? static_cast<std::size_t>(max_nesting_depth) : 0;
+
+            pending_stack parents;
+            uint64_t current = 0;
+
+            for (;;)
+            {
+                // Open the container in `head`.
+                if (JSONCONS_UNLIKELY(parents.size() >= depth_limit))
+                {
+                    ec = cbor_errc::max_nesting_depth_exceeded;
+                    return false;
+                }
+                if (head.indefinite())
+                {
+                    parents.push(current);
+                    current = head.major_type == cbor::detail::cbor_major_type::map
+                        ? indefinite_map_key_marker : indefinite_array_marker;
+                }
+                else
+                {
+                    // Every unread item occupies at least one byte, so a
+                    // count the remaining input cannot hold is EOF now.
+                    const bool is_map = head.major_type == cbor::detail::cbor_major_type::map;
+                    const uint64_t avail = static_cast<uint64_t>(end - p);
+                    if (head.value > (is_map ? avail / 2 : avail))
+                    {
+                        ec = cbor_errc::unexpected_eof;
+                        return false;
+                    }
+                    const uint64_t count = is_map ? 2 * head.value : head.value;
+                    if (count != 0)
+                    {
+                        parents.push(current);
+                        current = count;
+                    }
+                }
+
+                // Walk items in place until the next container head.
+                for (;;)
+                {
+                    // Retire finished levels, then reserve the next unread item.
+                    if (current != 0 && current < indefinite_map_value_marker)
+                    {
+                        --current;
+                    }
+                    else if (current == 0)
+                    {
+                        if (parents.empty())
+                        {
+                            return true;
+                        }
+                        current = parents.pop();
+                        continue;
+                    }
+                    else if (current == indefinite_map_value_marker)
+                    {
+                        current = indefinite_map_key_marker;
+                    }
+                    else // at an element or entry boundary, where a break may close the level
+                    {
+                        if (p >= end)
+                        {
+                            ec = cbor_errc::unexpected_eof;
+                            return false;
+                        }
+                        if (*p == 0xff)
+                        {
+                            ++p;
+                            current = parents.pop();
+                            continue;
+                        }
+                        if (current == indefinite_map_key_marker)
+                        {
+                            current = indefinite_map_value_marker;
+                        }
+                    }
+
+                    if (!read_value_head(p, end, head, ec))
+                    {
+                        return false;
+                    }
+                    if (head.major_type == cbor::detail::cbor_major_type::array ||
+                        head.major_type == cbor::detail::cbor_major_type::map)
+                    {
+                        break;
+                    }
+                    if (!skip_scalar_or_string(head, p, end, ec))
+                    {
+                        return false;
+                    }
+                }
+            }
+        }
+
+        inline bool skip_item(const uint8_t*& p, const uint8_t* end, int max_nesting_depth, std::error_code& ec)
+        {
+            item_head head;
+            if (!read_value_head(p, end, head, ec))
+            {
+                return false;
+            }
+            if (head.major_type == cbor::detail::cbor_major_type::array ||
+                head.major_type == cbor::detail::cbor_major_type::map)
+            {
+                return skip_container(p, end, head, max_nesting_depth, ec);
+            }
+            return skip_scalar_or_string(head, p, end, ec);
+        }
+
+        inline span<const uint8_t> read_item_span(const uint8_t*& p, const uint8_t* end, int depth, std::error_code& ec)
+        {
+            const uint8_t* first = p;
+            if (!skip_item(p, end, depth, ec))
+            {
+                return span<const uint8_t>();
+            }
+            return span<const uint8_t>(first, static_cast<std::size_t>(p - first));
+        }
+
+        inline bool read_map_entries(span<const uint8_t> item, std::vector<map_entry_view>& entries,
+            int depth, std::error_code& ec)
+        {
+            const uint8_t* p = item.data();
+            const uint8_t* end = p + item.size();
+            item_head head;
+            if (!read_head(p, end, head, ec))
+            {
+                return false;
+            }
+            if (head.major_type != cbor::detail::cbor_major_type::map)
+            {
+                ec = cbor_errc::unknown_type;
+                return false;
+            }
+            if (JSONCONS_UNLIKELY(depth <= 0))
+            {
+                ec = cbor_errc::max_nesting_depth_exceeded;
+                return false;
+            }
+
+            if (!head.indefinite())
+            {
+                if (static_cast<std::size_t>(head.value) != head.value)
+                {
+                    ec = cbor_errc::number_too_large;
+                    return false;
+                }
+                entries.reserve(static_cast<std::size_t>(
+                    (std::min)(head.value, static_cast<uint64_t>(end - p) / 2)));
+                for (uint64_t i = 0; i < head.value; ++i)
+                {
+                    auto key = read_item_span(p, end, depth - 1, ec);
+                    if (ec) { return false; }
+                    auto value = read_item_span(p, end, depth - 1, ec);
+                    if (ec) { return false; }
+                    entries.push_back(map_entry_view{key, value});
+                }
+                return true;
+            }
+
+            for (;;)
+            {
+                if (p >= end)
+                {
+                    ec = cbor_errc::unexpected_eof;
+                    return false;
+                }
+                if (*p == 0xff)
+                {
+                    ++p;
+                    return true;
+                }
+                auto key = read_item_span(p, end, depth - 1, ec);
+                if (ec) { return false; }
+                auto value = read_item_span(p, end, depth - 1, ec);
+                if (ec) { return false; }
+                entries.push_back(map_entry_view{key, value});
+            }
+        }
+
+    } // namespace detail_view
+
+    struct bytewise_order
+    {
+        int operator()(span<const uint8_t> a, span<const uint8_t> b) const noexcept
+        {
+            return detail_view::compare_bytes(a, b);
+        }
+    };
+
+    struct length_first_order
+    {
+        int operator()(span<const uint8_t> a, span<const uint8_t> b) const noexcept
+        {
+            const int r = detail_view::compare_size(a.size(), b.size());
+            return r != 0 ? r : detail_view::compare_bytes(a, b);
+        }
+    };
+
+    inline bool read_head(const uint8_t*& p, const uint8_t* end, item_head& head, std::error_code& ec)
+    {
+        return detail_view::read_head(p, end, head, ec);
+    }
+
+    inline bool skip_item(const uint8_t*& p, const uint8_t* end, std::error_code& ec,
+        int max_nesting_depth = default_max_nesting_depth)
+    {
+        return detail_view::skip_item(p, end, max_nesting_depth, ec);
+    }
+
+    inline span<const uint8_t> item_span(span<const uint8_t> input, std::error_code& ec,
+        int max_nesting_depth = default_max_nesting_depth)
+    {
+        const uint8_t* p = input.data();
+        return detail_view::read_item_span(p, p + input.size(), max_nesting_depth, ec);
+    }
+
+    inline bool map_entries(span<const uint8_t> input, std::vector<map_entry_view>& entries, std::error_code& ec,
+        int max_nesting_depth = default_max_nesting_depth)
+    {
+        entries.clear();
+        return detail_view::read_map_entries(input, entries, max_nesting_depth, ec);
+    }
+
+    template <typename Order = bytewise_order>
+    int compare(span<const uint8_t> a, span<const uint8_t> b, std::error_code& ec,
+        Order order = Order(), int max_nesting_depth = default_max_nesting_depth)
+    {
+        const uint8_t* ap = a.data();
+        auto ia = detail_view::read_item_span(ap, ap + a.size(), max_nesting_depth, ec);
+        if (ec)
+        {
+            return 0;
+        }
+        const uint8_t* bp = b.data();
+        auto ib = detail_view::read_item_span(bp, bp + b.size(), max_nesting_depth, ec);
+        if (ec)
+        {
+            return 0;
+        }
+        return order(ia, ib);
+    }
+
+    template <typename Order = bytewise_order>
+    int compare(span<const uint8_t> a, span<const uint8_t> b)
+    {
+        std::error_code ec;
+        int result = compare(a, b, ec, Order());
+        if (JSONCONS_UNLIKELY(ec))
+        {
+            JSONCONS_THROW(ser_error(ec));
+        }
+        return result;
+    }
+
+    template <typename Order = bytewise_order>
+    bool map_keys_sorted(span<const uint8_t> input, std::error_code& ec,
+        Order order = Order(), int max_nesting_depth = default_max_nesting_depth)
+    {
+        std::vector<map_entry_view> entries;
+        if (!detail_view::read_map_entries(input, entries, max_nesting_depth, ec))
+        {
+            return false;
+        }
+        for (std::size_t i = 1; i < entries.size(); ++i)
+        {
+            if (order(entries[i-1].key, entries[i].key) >= 0)
+            {
+                return false;
+            }
+        }
+        return true;
+    }
+
+} // namespace view
+} // namespace cbor
+} // namespace jsoncons
+
+#endif

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -75,6 +75,7 @@ add_executable(unit_tests
                cbor/src/cbor_reader_tests.cpp
                cbor/src/cbor_tests.cpp
                cbor/src/cbor_typed_array_tests.cpp
+               cbor/src/cbor_view_tests.cpp
                cbor/src/decode_cbor_tests.cpp
                cbor/src/encode_cbor_tests.cpp
                corelib/src/detail/optional_tests.cpp

--- a/test/cbor/src/cbor_view_tests.cpp
+++ b/test/cbor/src/cbor_view_tests.cpp
@@ -1,0 +1,247 @@
+// Copyright 2013-2026 Daniel Parker
+// Distributed under Boost license
+
+#if defined(_MSC_VER)
+#include "windows.h" // test no inadvertant macro expansions
+#endif
+
+#include <jsoncons_ext/cbor/cbor_view.hpp>
+
+#include <system_error>
+#include <vector>
+#include <catch/catch.hpp>
+
+using namespace jsoncons;
+
+TEST_CASE("cbor raw view utilities")
+{
+    SECTION("item span reads one item")
+    {
+        std::vector<uint8_t> data = {0x01,0x02};
+        std::error_code ec;
+        auto item = cbor::view::item_span(jsoncons::span<const uint8_t>(data), ec);
+        REQUIRE_FALSE(ec);
+        REQUIRE(item.size() == 1);
+        CHECK(item[0] == 0x01);
+    }
+
+    SECTION("trailing bytes after the first item are ignored")
+    {
+        std::vector<uint8_t> a = {0x01,0x63,'a','b','c'};
+        std::vector<uint8_t> b = {0x01};
+        std::error_code ec;
+        CHECK(cbor::view::compare(jsoncons::span<const uint8_t>(a), jsoncons::span<const uint8_t>(b), ec) == 0);
+        CHECK_FALSE(ec);
+    }
+
+    SECTION("nesting at the default depth bound succeeds")
+    {
+        std::vector<uint8_t> data(cbor::view::default_max_nesting_depth, 0x81);
+        data.push_back(0x01);
+        std::error_code ec;
+        auto item = cbor::view::item_span(jsoncons::span<const uint8_t>(data), ec);
+        REQUIRE_FALSE(ec);
+        CHECK(item.size() == data.size());
+    }
+
+    SECTION("nesting past the depth bound is rejected")
+    {
+        std::vector<uint8_t> data(cbor::view::default_max_nesting_depth + 1, 0x81);
+        data.push_back(0x01);
+        std::error_code ec;
+        auto item = cbor::view::item_span(jsoncons::span<const uint8_t>(data), ec);
+        CHECK(item.empty());
+        CHECK(ec == cbor::cbor_errc::max_nesting_depth_exceeded);
+
+        ec.clear();
+        item = cbor::view::item_span(jsoncons::span<const uint8_t>(data), ec, 4000);
+        REQUIRE_FALSE(ec);
+        CHECK(item.size() == data.size());
+    }
+
+    SECTION("tag chains do not consume nesting depth or stack")
+    {
+        std::vector<uint8_t> data(1000000, 0xc0);
+        data.push_back(0x01);
+        std::error_code ec;
+        auto item = cbor::view::item_span(jsoncons::span<const uint8_t>(data), ec);
+        REQUIRE_FALSE(ec);
+        CHECK(item.size() == data.size());
+    }
+
+    SECTION("map claiming a huge entry count is rejected")
+    {
+        std::vector<uint8_t> data = {0xba,0xff,0xff,0xff,0xff};
+        std::vector<cbor::view::map_entry_view> entries;
+        std::error_code ec;
+        CHECK_FALSE(cbor::view::map_entries(jsoncons::span<const uint8_t>(data), entries, ec));
+        CHECK(ec == cbor::cbor_errc::unexpected_eof);
+    }
+
+    SECTION("array claiming a huge element count is rejected")
+    {
+        std::vector<uint8_t> data = {0x9a,0xff,0xff,0xff,0xff};
+        std::error_code ec;
+        auto item = cbor::view::item_span(jsoncons::span<const uint8_t>(data), ec);
+        CHECK(item.empty());
+        CHECK(ec == cbor::cbor_errc::unexpected_eof);
+    }
+
+    SECTION("definite and indefinite nesting can mix")
+    {
+        // [_ {1: [2]}, [], {} ] followed by trailing bytes
+        std::vector<uint8_t> data = {0x9f,0xa1,0x01,0x81,0x02,0x80,0xa0,0xff,0x63,'a','b','c'};
+        std::error_code ec;
+        auto item = cbor::view::item_span(jsoncons::span<const uint8_t>(data), ec);
+        REQUIRE_FALSE(ec);
+        CHECK(item.size() == 8);
+    }
+
+    SECTION("indefinite map break may not split a key from its value")
+    {
+        std::vector<uint8_t> dangling_key = {0xbf,0x01,0xff};
+        std::error_code ec;
+        auto item = cbor::view::item_span(jsoncons::span<const uint8_t>(dangling_key), ec);
+        CHECK(item.empty());
+        CHECK(ec == cbor::cbor_errc::unknown_type);
+
+        std::vector<uint8_t> complete_entry = {0xbf,0x01,0x02,0xff};
+        ec.clear();
+        item = cbor::view::item_span(jsoncons::span<const uint8_t>(complete_entry), ec);
+        REQUIRE_FALSE(ec);
+        CHECK(item.size() == complete_entry.size());
+    }
+
+    SECTION("map entries expose key and value spans")
+    {
+        std::vector<uint8_t> data = {0xa2,0x01,0x61,0x61,0x61,0x6b,0x02};
+        std::vector<cbor::view::map_entry_view> entries;
+        std::error_code ec;
+        REQUIRE(cbor::view::map_entries(jsoncons::span<const uint8_t>(data), entries, ec));
+        REQUIRE_FALSE(ec);
+        REQUIRE(entries.size() == 2);
+        CHECK(entries[0].key.data() == data.data() + 1);
+        CHECK(entries[0].key.size() == 1);
+        CHECK(entries[0].value.data() == data.data() + 2);
+        CHECK(entries[0].value.size() == 2);
+        CHECK(entries[1].key.data() == data.data() + 4);
+        CHECK(entries[1].key.size() == 2);
+        CHECK(entries[1].value.data() == data.data() + 6);
+        CHECK(entries[1].value.size() == 1);
+    }
+
+    SECTION("invalid indefinite integer is rejected")
+    {
+        std::vector<uint8_t> data = {0x1f};
+        std::error_code ec;
+        auto item = cbor::view::item_span(jsoncons::span<const uint8_t>(data), ec);
+        CHECK(item.empty());
+        CHECK(ec == cbor::cbor_errc::unknown_type);
+    }
+}
+
+TEST_CASE("cbor view items compare in deterministic encoding key orders")
+{
+    const std::vector<std::vector<uint8_t>> bytewise_sorted = {
+        {0x0a},
+        {0x18,0x64},
+        {0x20},
+        {0x61,0x7a},
+        {0x62,0x61,0x61},
+        {0x81,0x18,0x64},
+        {0x81,0x20},
+        {0xf4}
+    };
+
+    const std::vector<std::vector<uint8_t>> length_first_sorted = {
+        {0x0a},
+        {0x20},
+        {0xf4},
+        {0x18,0x64},
+        {0x61,0x7a},
+        {0x81,0x20},
+        {0x62,0x61,0x61},
+        {0x81,0x18,0x64}
+    };
+
+    SECTION("bytewise order matches the RFC 8949 4.2.1 example")
+    {
+        for (std::size_t i = 0; i < bytewise_sorted.size(); ++i)
+        {
+            for (std::size_t j = 0; j < bytewise_sorted.size(); ++j)
+            {
+                std::error_code ec;
+                const int r = cbor::view::compare(jsoncons::span<const uint8_t>(bytewise_sorted[i]),
+                    jsoncons::span<const uint8_t>(bytewise_sorted[j]), ec);
+                REQUIRE_FALSE(ec);
+                CHECK((i < j ? r < 0 : (i > j ? r > 0 : r == 0)));
+            }
+        }
+    }
+
+    SECTION("length-first order matches the RFC 8949 4.2.3 example")
+    {
+        for (std::size_t i = 0; i < length_first_sorted.size(); ++i)
+        {
+            for (std::size_t j = 0; j < length_first_sorted.size(); ++j)
+            {
+                std::error_code ec;
+                const int r = cbor::view::compare(jsoncons::span<const uint8_t>(length_first_sorted[i]),
+                    jsoncons::span<const uint8_t>(length_first_sorted[j]), ec, cbor::view::length_first_order());
+                REQUIRE_FALSE(ec);
+                CHECK((i < j ? r < 0 : (i > j ? r > 0 : r == 0)));
+            }
+        }
+    }
+
+    SECTION("other orderings can be plugged in")
+    {
+        struct reverse_bytewise_order
+        {
+            int operator()(jsoncons::span<const uint8_t> a, jsoncons::span<const uint8_t> b) const noexcept
+            {
+                return -cbor::view::bytewise_order()(a, b);
+            }
+        };
+
+        std::vector<uint8_t> ten = {0x0a};
+        std::vector<uint8_t> hundred = {0x18,0x64};
+        std::error_code ec;
+        CHECK(cbor::view::compare(jsoncons::span<const uint8_t>(ten), jsoncons::span<const uint8_t>(hundred), ec) < 0);
+        REQUIRE_FALSE(ec);
+        CHECK(cbor::view::compare(jsoncons::span<const uint8_t>(ten), jsoncons::span<const uint8_t>(hundred), ec, reverse_bytewise_order()) > 0);
+        REQUIRE_FALSE(ec);
+    }
+}
+
+TEST_CASE("cbor view map_keys_sorted")
+{
+    SECTION("detects deterministically ordered keys")
+    {
+        std::vector<uint8_t> sorted_map = {0xa2,0x01,0x61,0x61,0x61,0x6b,0x02};
+        std::vector<uint8_t> unsorted_map = {0xa2,0x61,0x6b,0x02,0x01,0x61,0x61};
+        std::error_code ec;
+        CHECK(cbor::view::map_keys_sorted(jsoncons::span<const uint8_t>(sorted_map), ec));
+        CHECK_FALSE(ec);
+        CHECK_FALSE(cbor::view::map_keys_sorted(jsoncons::span<const uint8_t>(unsorted_map), ec));
+        CHECK_FALSE(ec);
+    }
+
+    SECTION("duplicate keys are not sorted")
+    {
+        std::vector<uint8_t> dup_map = {0xa2,0x01,0x00,0x01,0x01};
+        std::error_code ec;
+        CHECK_FALSE(cbor::view::map_keys_sorted(jsoncons::span<const uint8_t>(dup_map), ec));
+        CHECK_FALSE(ec);
+    }
+
+    SECTION("bytewise and length-first orders can disagree")
+    {
+        std::vector<uint8_t> m = {0xa2,0x18,0x64,0x00,0x20,0x00};
+        std::error_code ec;
+        CHECK(cbor::view::map_keys_sorted(jsoncons::span<const uint8_t>(m), ec));
+        CHECK_FALSE(ec);
+        CHECK_FALSE(cbor::view::map_keys_sorted(jsoncons::span<const uint8_t>(m), ec, cbor::view::length_first_order()));
+        CHECK_FALSE(ec);
+    }
+}


### PR DESCRIPTION
Hi @danielaparker , this is now iterative instead of recursive (and includes a few extra logic fixes found along the way), so hopefully there are no outstanding issues now.

I hope I'm doing the right thing here - this is targeting master, if you create a cbor_view branch I can continue work there (getters, traversers, etc). If you'd like to proceed some other way, just let me know.

Built with the help of fable-5.
