### PR TITLE
Recast cbor_view as checked encoded-item layer

### DIFF
--- a/doc/ref/cbor/cbor.md
+++ b/doc/ref/cbor/cbor.md
@@ -8,6 +8,8 @@ data structures, using [json_type_traits](../corelib/json_type_traits/json_type_
 
 [basic_cbor_cursor](basic_cbor_cursor.md)
 
+[cbor::view](cbor_view.md)
+
 [encode_cbor](encode_cbor.md)
 
 [basic_cbor_encoder](basic_cbor_encoder.md)

--- a/doc/ref/cbor/cbor_view.md
+++ b/doc/ref/cbor/cbor_view.md
@@ -1,0 +1,236 @@
+### jsoncons::cbor::view
+
+```cpp
+#include <jsoncons_ext/cbor/cbor_view.hpp>
+```
+
+<br>
+
+The `cbor::view` namespace reads the *encoded* structure of
+[Concise Binary Object Representation](http://cbor.io/) data in place,
+without copying it or building a data structure. It is a deliberately
+narrow, wire-level facility: scanning validates that bytes are
+well-formed CBOR once, and everything afterwards operates on checked
+`item` views and cannot fail structurally. Semantic interpretation —
+what tag 2 bytes or a tag 25 string reference *mean* — belongs to
+[decode_cbor](decode_cbor.md) and [basic_cbor_cursor](basic_cbor_cursor.md),
+not here: tags are exposed, never interpreted.
+
+This namespace is experimental.
+
+#### Ownership and lifetime
+
+Everything in this namespace borrows. An `item`, the items produced by
+iterating it, and every span and string view obtained from them point
+into the scanned input bytes, and are invalidated by anything that
+invalidates those bytes: destroying the container, mutating it, or any
+reallocation. Scanning a temporary container is rejected at compile
+time. The copying accessors (`text` into `std::string`, `bytes` into
+`std::vector`) are the way to keep content beyond the input's lifetime.
+
+#### Scanning
+
+```cpp
+class scan_context;                    // depth policy + reusable workspace
+
+struct scan_error
+{
+    cbor_errc code;
+    std::size_t offset;                // bytes consumed when detected
+};
+
+struct scan_result
+{
+    item first;
+    span<const uint8_t> remainder;
+};
+
+expected<scan_result, scan_error> scan_prefix(span<const uint8_t> input);
+expected<scan_result, scan_error> scan_prefix(span<const uint8_t> input, scan_context& context);
+
+expected<item, scan_error> parse_exact(span<const uint8_t> input);
+expected<item, scan_error> parse_exact(span<const uint8_t> input, scan_context& context);
+```
+
+`scan_prefix` validates and returns the first item in `input`, with the
+bytes that follow it; scan a stream of items by looping on `remainder`.
+`parse_exact` requires `input` to be exactly one item, and reports
+anything after it as `cbor_errc::trailing_data`.
+
+Scanning enforces `scan_context::max_nesting_depth` (default
+`default_max_nesting_depth`, 1024) using constant call-stack space at
+any depth. It allocates only when nesting exceeds 32 open containers;
+a reused `scan_context` retains that capacity across scans.
+
+#### The checked item
+
+```cpp
+class item
+{
+    span<const uint8_t> encoded_bytes() const noexcept;  // tags included
+    item_kind kind() const noexcept;                     // of the untagged content
+    uint64_t argument() const noexcept;                  // RFC 8949 head argument
+    bool indefinite() const noexcept;
+    tag_range tags() const noexcept;                     // leading tags, outermost first
+
+    element_range elements() const noexcept;             // array elements
+    entry_range entries() const noexcept;                // map entries
+    chunk_range chunks() const noexcept;                 // string content spans
+
+    bool uint64_value(uint64_t& value) const noexcept;
+    bool int64_value(int64_t& value) const noexcept;
+    bool bool_value(bool& value) const noexcept;
+    bool double_value(double& value) const noexcept;
+    bool text(string_view& value) const noexcept;        // definite only, zero copy
+    bool bytes(span<const uint8_t>& value) const noexcept;
+    bool text(std::string& value) const;                 // assembles chunks
+    bool bytes(std::vector<uint8_t>& value) const;
+};
+
+enum class item_kind
+{
+    unsigned_integer, negative_integer, byte_string, text_string,
+    array, map, simple
+};
+
+struct map_entry
+{
+    item key;
+    item value;
+};
+```
+
+An `item` is one complete, well-formed encoded item: its leading
+semantic tags, head, and content. `kind()` classifies the content after
+tags (`simple` covers major type 7: simple values and floating point);
+`argument()` is the head's argument — an integer's value, a string's
+length, a container's count, a simple value's number, or the bit
+pattern of a floating-point value.
+
+The ranges iterate with plain range-`for` and cannot fail: validation
+already happened. `elements()` and `entries()` yield checked items;
+`chunks()` yields the contiguous spans of a string's content, one per
+chunk for indefinite-length strings. Kind mismatches yield empty
+ranges. Iterating a container walks its encoding, so navigating to
+depth *d* of a document rescans the subtrees on that path; iteration
+beyond 32 levels of nesting inside one item may allocate.
+
+The typed accessors return `false`, leaving `value` untouched, exactly
+when the item is not of the requested kind; conversions are strict.
+The copying `text` and `bytes` overloads are transactional — `value`
+is replaced on success and untouched on failure — and `value` may
+alias the scanned bytes themselves. Tags are never silently dropped:
+they are visible on every item via `tags()`, and reading the value of
+a tagged item is the caller's explicit decision.
+
+```cpp
+bool validate_text(const item& text_item) noexcept;
+```
+
+True if `text_item` is a text string whose content is well-formed
+UTF-8; each chunk of an indefinite-length text string must itself be
+well-formed (RFC 8949 3.2.3). No other function in this namespace
+validates text content.
+
+#### Deterministic encoding orders
+
+```cpp
+struct bytewise_compare;       // RFC 8949 4.2.1 order, three-way
+struct length_first_compare;   // RFC 8949 4.2.3 order, three-way
+struct bytewise_less;          // strict weak orders for sorting
+struct length_first_less;
+
+template <typename Compare = bytewise_compare>
+bool map_keys_sorted(const item& map_item, Compare compare = Compare());
+```
+
+The order function objects compare encoded bytes and accept either two
+items or two raw `span<const uint8_t>`. The `*_compare` forms return
+negative, zero, or positive; the `*_less` forms are predicates for
+`std::sort` and ordered containers. `map_keys_sorted` is true if
+`map_item` is a map whose keys are strictly ascending in the given
+order — the deterministic-encoding key condition — and does not
+allocate.
+
+### Examples
+
+#### Reading a message without copying it
+
+```cpp
+#include <jsoncons_ext/cbor/cbor_view.hpp>
+#include <iostream>
+
+int main()
+{
+    // {"id": 42, "name": "ada", "scores": [1, 2]}
+    const std::vector<uint8_t> data = {
+        0xa3,
+        0x62,'i','d', 0x18,0x2a,
+        0x64,'n','a','m','e', 0x63,'a','d','a',
+        0x66,'s','c','o','r','e','s', 0x82,0x01,0x02
+    };
+
+    auto doc = jsoncons::cbor::view::parse_exact(
+        jsoncons::span<const uint8_t>(data.data(), data.size()));
+    if (!doc.has_value())
+    {
+        std::cout << "malformed at offset " << doc.error().offset << "\n";
+        return 1;
+    }
+
+    for (jsoncons::cbor::view::map_entry entry : doc.value().entries())
+    {
+        jsoncons::string_view name;
+        if (!entry.key.text(name))
+        {
+            continue;
+        }
+        std::cout << name << ":";
+
+        uint64_t number = 0;
+        jsoncons::string_view text;
+        if (entry.value.text(text))
+        {
+            std::cout << " " << text;
+        }
+        else if (entry.value.uint64_value(number))
+        {
+            std::cout << " " << number;
+        }
+        else
+        {
+            for (jsoncons::cbor::view::item element : entry.value.elements())
+            {
+                if (element.uint64_value(number))
+                {
+                    std::cout << " " << number;
+                }
+            }
+        }
+        std::cout << "\n";
+    }
+}
+```
+
+Output:
+```
+id: 42
+name: ada
+scores: 1 2
+```
+
+#### Splitting a stream of items
+
+```cpp
+jsoncons::span<const uint8_t> rest(data.data(), data.size());
+while (!rest.empty())
+{
+    auto scanned = jsoncons::cbor::view::scan_prefix(rest);
+    if (!scanned.has_value())
+    {
+        break;   // scanned.error().code, scanned.error().offset
+    }
+    handle(scanned.value().first);
+    rest = scanned.value().remainder;
+}
+```

--- a/fuzzers/build_fuzzers.sh
+++ b/fuzzers/build_fuzzers.sh
@@ -34,6 +34,9 @@ oss_fuzz_compile_all()
 
     # Fuzzers that target the cursors
     $CXX ./fuzzers/fuzz_json_cursor.cpp -I./include -I./third_party $CXXFLAGS $LIB_FUZZING_ENGINE -o $OUT/fuzz_json_cursor
+
+    # Fuzzers that target the views
+    $CXX ./fuzzers/fuzz_cbor_view.cpp -I./include -I./third_party $CXXFLAGS $LIB_FUZZING_ENGINE -o $OUT/fuzz_cbor_view
 }
 
 if [[ -z "${OUT}" ]]; then

--- a/fuzzers/fuzz_cbor_view.cpp
+++ b/fuzzers/fuzz_cbor_view.cpp
@@ -1,0 +1,219 @@
+#include <jsoncons_ext/cbor/cbor_view.hpp>
+
+#include <algorithm>
+#include <cstdlib>
+#include <cstring>
+#include <limits>
+#include <string>
+#include <system_error>
+#include <vector>
+
+using namespace jsoncons::cbor::view;
+
+namespace {
+
+    using byte_span = jsoncons::span<const uint8_t>;
+
+    void require(bool condition)
+    {
+        if (!condition)
+        {
+            std::abort();
+        }
+    }
+
+    bool contains(byte_span outer, byte_span inner) noexcept
+    {
+        return inner.data() >= outer.data() &&
+               inner.data() + inner.size() >= inner.data() &&
+               inner.data() + inner.size() <= outer.data() + outer.size();
+    }
+
+    int sign(int value) noexcept
+    {
+        return (value > 0) - (value < 0);
+    }
+
+    void exercise_item(const item& scanned, int depth_budget)
+    {
+        const byte_span bytes = scanned.encoded_bytes();
+        require(bytes.size() > 0);
+
+        // Self-similarity: an item's encoding is exactly one item.
+        auto reparsed = parse_exact(bytes);
+        require(reparsed.has_value());
+        require(reparsed.value().encoded_bytes().data() == bytes.data());
+        require(reparsed.value().encoded_bytes().size() == bytes.size());
+        require(reparsed.value().kind() == scanned.kind());
+        require(reparsed.value().argument() == scanned.argument());
+        require(reparsed.value().indefinite() == scanned.indefinite());
+
+        std::size_t tag_count = 0;
+        for (uint64_t tag : scanned.tags())
+        {
+            (void)tag;
+            if (++tag_count > 4096)
+            {
+                break;
+            }
+        }
+
+        // Typed accessors are total over checked items.
+        uint64_t u = 0;
+        int64_t i = 0;
+        bool b = false;
+        double d = 0;
+        const bool u_ok = scanned.uint64_value(u);
+        const bool i_ok = scanned.int64_value(i);
+        if (u_ok && u <= static_cast<uint64_t>((std::numeric_limits<int64_t>::max)()))
+        {
+            require(i_ok && i == static_cast<int64_t>(u));
+        }
+        (void)scanned.bool_value(b);
+        (void)scanned.double_value(d);
+
+        jsoncons::string_view text_view;
+        std::string text_copy;
+        const bool view_ok = scanned.text(text_view);
+        const bool copy_ok = scanned.text(text_copy);
+        if (view_ok)
+        {
+            require(copy_ok && text_copy.size() == text_view.size());
+            require(text_view.empty() ||
+                std::memcmp(text_copy.data(), text_view.data(), text_view.size()) == 0);
+        }
+        require(copy_ok == (scanned.kind() == item_kind::text_string));
+
+        byte_span bytes_view;
+        std::vector<uint8_t> bytes_copy;
+        const bool bytes_view_ok = scanned.bytes(bytes_view);
+        const bool bytes_copy_ok = scanned.bytes(bytes_copy);
+        if (bytes_view_ok)
+        {
+            require(bytes_copy_ok && bytes_copy.size() == bytes_view.size());
+            require(bytes_view.empty() ||
+                std::memcmp(bytes_copy.data(), bytes_view.data(), bytes_view.size()) == 0);
+        }
+
+        // Chunks partition the copied content.
+        std::size_t chunk_total = 0;
+        for (byte_span chunk : scanned.chunks())
+        {
+            require(chunk.size() == 0 || contains(bytes, chunk));
+            chunk_total += chunk.size();
+        }
+        if (copy_ok)
+        {
+            require(chunk_total == text_copy.size());
+        }
+        if (bytes_copy_ok)
+        {
+            require(chunk_total == bytes_copy.size());
+        }
+
+        if (scanned.kind() == item_kind::text_string)
+        {
+            (void)validate_text(scanned);
+        }
+        else
+        {
+            require(!validate_text(scanned));
+        }
+
+        // Containers: children are checked items inside the parent.
+        if (depth_budget > 0)
+        {
+            const uint8_t* prev_end = nullptr;
+            for (item element : scanned.elements())
+            {
+                require(contains(bytes, element.encoded_bytes()));
+                if (prev_end != nullptr)
+                {
+                    require(element.encoded_bytes().data() >= prev_end);
+                }
+                prev_end = element.encoded_bytes().data() + element.encoded_bytes().size();
+                exercise_item(element, depth_budget - 1);
+            }
+            for (map_entry entry : scanned.entries())
+            {
+                require(contains(bytes, entry.key.encoded_bytes()));
+                require(contains(bytes, entry.value.encoded_bytes()));
+                require(entry.value.encoded_bytes().data() ==
+                    entry.key.encoded_bytes().data() + entry.key.encoded_bytes().size());
+                exercise_item(entry.key, depth_budget - 1);
+                exercise_item(entry.value, depth_budget - 1);
+            }
+        }
+
+        (void)map_keys_sorted(scanned);
+        (void)map_keys_sorted(scanned, length_first_compare());
+    }
+
+    void exercise_input(byte_span input, scan_context& context)
+    {
+        auto scanned = scan_prefix(input, context);
+        auto exact = parse_exact(input, context);
+
+        if (scanned.has_value())
+        {
+            const item& first = scanned.value().first;
+            const byte_span remainder = scanned.value().remainder;
+            require(first.encoded_bytes().data() == input.data());
+            require(first.encoded_bytes().size() + remainder.size() == input.size());
+            require(remainder.data() == input.data() + first.encoded_bytes().size());
+
+            require(exact.has_value() == remainder.empty());
+            if (!exact.has_value())
+            {
+                require(exact.error().code == jsoncons::cbor::cbor_errc::trailing_data);
+                require(exact.error().offset == first.encoded_bytes().size());
+            }
+
+            exercise_item(first, 24);
+
+            // Comparison functors agree with their sign-flipped duals.
+            auto second = scan_prefix(remainder, context);
+            if (second.has_value())
+            {
+                const int ab = bytewise_compare()(first, second.value().first);
+                const int ba = bytewise_compare()(second.value().first, first);
+                require(sign(ab) == -sign(ba));
+                const int lab = length_first_compare()(first, second.value().first);
+                const int lba = length_first_compare()(second.value().first, first);
+                require(sign(lab) == -sign(lba));
+                require(bytewise_less()(first, second.value().first) == (ab < 0));
+                require(length_first_less()(first, second.value().first) == (lab < 0));
+            }
+        }
+        else
+        {
+            require(!exact.has_value());
+            require(scanned.error().offset <= input.size());
+            require(scanned.error().code != jsoncons::cbor::cbor_errc::success);
+        }
+    }
+
+} // namespace
+
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, std::size_t size)
+{
+    static const uint8_t empty_input = 0;
+    const uint8_t* base = size == 0 ? &empty_input : data;
+    byte_span input(base, size);
+    const std::size_t p0 = size == 0 ? 0 : base[0] % (size + 1);
+    const std::size_t mid = size / 2;
+
+    const int fuzz_depth = size <= 2 ? default_max_nesting_depth : static_cast<int>(base[2] & 0x0f);
+    const int depths[] = {0, 1, fuzz_depth, default_max_nesting_depth};
+
+    for (int depth : depths)
+    {
+        scan_context context(depth);
+        exercise_input(input, context);
+        exercise_input(byte_span(base, mid), context);
+        exercise_input(byte_span(base + mid, size - mid), context);
+        exercise_input(byte_span(base + p0, size - p0), context);
+    }
+
+    return 0;
+}

--- a/include/jsoncons_ext/cbor/cbor_error.hpp
+++ b/include/jsoncons_ext/cbor/cbor_error.hpp
@@ -32,7 +32,8 @@ enum class cbor_errc
     unknown_type,
     illegal_chunked_string,
     bad_mdarray,
-    bad_extents
+    bad_extents,
+    trailing_data
 };
 
 class cbor_error_category_impl
@@ -75,6 +76,8 @@ public:
                 return "Invalid multi-dimensional array.";
             case cbor_errc::bad_extents:
                 return "Product of extents does not match number of elements.";
+            case cbor_errc::trailing_data:
+                return "Trailing bytes after the end of a CBOR item";
             default:
                 return "Unknown CBOR parser error";
         }

--- a/include/jsoncons_ext/cbor/cbor_view.hpp
+++ b/include/jsoncons_ext/cbor/cbor_view.hpp
@@ -8,16 +8,29 @@
 #define JSONCONS_EXT_CBOR_CBOR_VIEW_HPP
 
 #include <algorithm>
+#include <cassert>
 #include <cstddef>
 #include <cstdint>
 #include <cstring>
+#include <iterator>
+#include <limits>
+#include <string>
 #include <system_error>
+#include <type_traits>
 #include <vector>
 
 #include <jsoncons/config/jsoncons_config.hpp>
-#include <jsoncons/json_exception.hpp>
+#include <jsoncons/detail/expected.hpp>
+#include <jsoncons/utility/unicode_traits.hpp>
 #include <jsoncons_ext/cbor/cbor_detail.hpp>
 #include <jsoncons_ext/cbor/cbor_error.hpp>
+
+// A deliberately narrow, zero-copy facility for reading the *encoded*
+// structure of CBOR data in place. Scanning validates well-formedness
+// once; everything after that operates on checked `item` views and
+// cannot fail structurally. Semantic interpretation (tag 2 bignums,
+// string references, typed arrays, ...) belongs to the parser and
+// cursor layers, not here: tags are exposed, never interpreted.
 
 namespace jsoncons {
 namespace cbor {
@@ -25,25 +38,42 @@ namespace view {
 
     constexpr int default_max_nesting_depth = 1024;
 
-    struct item_head
+    // The wire-level kind of an item, after its leading semantic tags.
+    // `simple` covers RFC 8949 major type 7: simple values and floating
+    // point, distinguished by the head argument.
+    enum class item_kind : uint8_t
     {
-        detail::cbor_major_type major_type{};
-        uint8_t additional_info{0};
-        uint64_t value{0};
-
-        bool indefinite() const noexcept
-        {
-            return additional_info == detail::additional_info::indefinite_length;
-        }
+        unsigned_integer,
+        negative_integer,
+        byte_string,
+        text_string,
+        array,
+        map,
+        simple
     };
 
-    struct map_entry_view
+    struct scan_error
     {
-        span<const uint8_t> key;
-        span<const uint8_t> value;
+        cbor_errc code;
+        std::size_t offset;   // bytes consumed when the error was detected
     };
+
+    using jsoncons::detail::expected;
+    using jsoncons::detail::unexpect;
 
     namespace detail_view {
+
+        struct item_head
+        {
+            cbor::detail::cbor_major_type major_type{};
+            uint8_t additional_info{0};
+            uint64_t value{0};
+
+            bool indefinite() const noexcept
+            {
+                return additional_info == cbor::detail::additional_info::indefinite_length;
+            }
+        };
 
         inline int sign(int value) noexcept
         {
@@ -69,7 +99,7 @@ namespace view {
             return compare_size(a.size(), b.size());
         }
 
-        inline bool read_uint(const uint8_t*& p, const uint8_t* end, uint8_t info, uint64_t& value, std::error_code& ec)
+        JSONCONS_FORCE_INLINE bool read_uint(const uint8_t*& p, const uint8_t* end, uint8_t info, uint64_t& value, std::error_code& ec)
         {
             if (info < 24)
             {
@@ -104,7 +134,7 @@ namespace view {
             return true;
         }
 
-        inline bool read_head(const uint8_t*& p, const uint8_t* end, item_head& head, std::error_code& ec)
+        JSONCONS_FORCE_INLINE bool read_head(const uint8_t*& p, const uint8_t* end, item_head& head, std::error_code& ec)
         {
             if (p >= end)
             {
@@ -132,7 +162,33 @@ namespace view {
                 }
                 return true;
             }
-            return read_uint(p, end, head.additional_info, head.value, ec);
+            if (!read_uint(p, end, head.additional_info, head.value, ec))
+            {
+                return false;
+            }
+            // RFC 8949 3.3: a two-byte encoding of a simple value below 32
+            // is not well-formed.
+            if (head.major_type == cbor::detail::cbor_major_type::simple &&
+                head.additional_info == 24 && head.value < 32)
+            {
+                ec = cbor_errc::unknown_type;
+                return false;
+            }
+            return true;
+        }
+
+        // Head of the item's content, past any leading semantic tags.
+        JSONCONS_FORCE_INLINE bool read_value_head(const uint8_t*& p, const uint8_t* end, item_head& head, std::error_code& ec)
+        {
+            do
+            {
+                if (!read_head(p, end, head, ec))
+                {
+                    return false;
+                }
+            }
+            while (head.major_type == cbor::detail::cbor_major_type::semantic_tag);
+            return true;
         }
 
         inline bool skip_string_chunks(const uint8_t*& p, const uint8_t* end,
@@ -170,22 +226,8 @@ namespace view {
             }
         }
 
-        // Head of the value itself, past any leading semantic tags.
-        inline bool read_value_head(const uint8_t*& p, const uint8_t* end, item_head& head, std::error_code& ec)
-        {
-            do
-            {
-                if (!read_head(p, end, head, ec))
-                {
-                    return false;
-                }
-            }
-            while (head.major_type == cbor::detail::cbor_major_type::semantic_tag);
-            return true;
-        }
-
         // Skips the payload of any non-container head in place.
-        inline bool skip_scalar_or_string(const item_head& head, const uint8_t*& p, const uint8_t* end, std::error_code& ec)
+        JSONCONS_FORCE_INLINE bool skip_scalar_or_string(const item_head& head, const uint8_t*& p, const uint8_t* end, std::error_code& ec)
         {
             switch (head.major_type)
             {
@@ -242,6 +284,12 @@ namespace view {
                 return size_;
             }
 
+            void clear() noexcept
+            {
+                spill_.clear();
+                size_ = 0;
+            }
+
             void push(uint64_t count)
             {
                 if (size_ < local_capacity)
@@ -271,27 +319,27 @@ namespace view {
         // Iterative walk of the array or map whose head has just been read,
         // so nested input is bounded by max_nesting_depth alone and can never
         // exhaust the call stack. The innermost level's state stays in a
-        // local; enclosing levels wait in `parents`, with a synthetic root
+        // local; enclosing levels wait in `open`, with a synthetic root
         // level of zero at the bottom.
         inline bool skip_container(const uint8_t*& p, const uint8_t* end, item_head head,
-            int max_nesting_depth, std::error_code& ec)
+            int max_nesting_depth, pending_stack& open, std::error_code& ec)
         {
             const std::size_t depth_limit = max_nesting_depth > 0 ? static_cast<std::size_t>(max_nesting_depth) : 0;
 
-            pending_stack parents;
+            open.clear();
             uint64_t current = 0;
 
             for (;;)
             {
                 // Open the container in `head`.
-                if (JSONCONS_UNLIKELY(parents.size() >= depth_limit))
+                if (JSONCONS_UNLIKELY(open.size() >= depth_limit))
                 {
                     ec = cbor_errc::max_nesting_depth_exceeded;
                     return false;
                 }
                 if (head.indefinite())
                 {
-                    parents.push(current);
+                    open.push(current);
                     current = head.major_type == cbor::detail::cbor_major_type::map
                         ? indefinite_map_key_marker : indefinite_array_marker;
                 }
@@ -309,7 +357,7 @@ namespace view {
                     const uint64_t count = is_map ? 2 * head.value : head.value;
                     if (count != 0)
                     {
-                        parents.push(current);
+                        open.push(current);
                         current = count;
                     }
                 }
@@ -324,11 +372,11 @@ namespace view {
                     }
                     else if (current == 0)
                     {
-                        if (parents.empty())
+                        if (open.empty())
                         {
                             return true;
                         }
-                        current = parents.pop();
+                        current = open.pop();
                         continue;
                     }
                     else if (current == indefinite_map_value_marker)
@@ -345,7 +393,7 @@ namespace view {
                         if (*p == 0xff)
                         {
                             ++p;
-                            current = parents.pop();
+                            current = open.pop();
                             continue;
                         }
                         if (current == indefinite_map_key_marker)
@@ -371,7 +419,8 @@ namespace view {
             }
         }
 
-        inline bool skip_item(const uint8_t*& p, const uint8_t* end, int max_nesting_depth, std::error_code& ec)
+        inline bool skip_item(const uint8_t*& p, const uint8_t* end, int max_nesting_depth,
+            pending_stack& open, std::error_code& ec)
         {
             item_head head;
             if (!read_value_head(p, end, head, ec))
@@ -381,169 +430,997 @@ namespace view {
             if (head.major_type == cbor::detail::cbor_major_type::array ||
                 head.major_type == cbor::detail::cbor_major_type::map)
             {
-                return skip_container(p, end, head, max_nesting_depth, ec);
+                return skip_container(p, end, head, max_nesting_depth, open, ec);
             }
             return skip_scalar_or_string(head, p, end, ec);
         }
 
-        inline span<const uint8_t> read_item_span(const uint8_t*& p, const uint8_t* end, int depth, std::error_code& ec)
+        // Skips one item over bytes already validated by a scan, surfacing
+        // the untagged head and content position so callers can build items
+        // without reparsing. Cannot fail; the depth bound was enforced when
+        // the bytes were scanned. Shallow items take no workspace at all.
+        inline const uint8_t* skip_checked(const uint8_t* p, const uint8_t* end,
+            item_head& head, const uint8_t*& content) noexcept
         {
-            const uint8_t* first = p;
-            if (!skip_item(p, end, depth, ec))
+            std::error_code ec;
+            bool ok = read_value_head(p, end, head, ec);
+            assert(ok);
+            content = p;
+            if (head.major_type == cbor::detail::cbor_major_type::array ||
+                head.major_type == cbor::detail::cbor_major_type::map)
             {
-                return span<const uint8_t>();
+                pending_stack open;
+                ok = skip_container(p, end, head, (std::numeric_limits<int>::max)(), open, ec);
             }
-            return span<const uint8_t>(first, static_cast<std::size_t>(p - first));
+            else
+            {
+                ok = skip_scalar_or_string(head, p, end, ec);
+            }
+            assert(ok && !ec);
+            (void)ok;
+            return p;
         }
 
-        inline bool read_map_entries(span<const uint8_t> item, std::vector<map_entry_view>& entries,
-            int depth, std::error_code& ec)
+        inline bool validate_utf8(const uint8_t* p, std::size_t length) noexcept
         {
-            const uint8_t* p = item.data();
-            const uint8_t* end = p + item.size();
-            item_head head;
-            if (!read_head(p, end, head, ec))
-            {
-                return false;
-            }
-            if (head.major_type != cbor::detail::cbor_major_type::map)
-            {
-                ec = cbor_errc::unknown_type;
-                return false;
-            }
-            if (JSONCONS_UNLIKELY(depth <= 0))
-            {
-                ec = cbor_errc::max_nesting_depth_exceeded;
-                return false;
-            }
+            const auto result = unicode_traits::validate(reinterpret_cast<const char*>(p), length);
+            return result.ec == unicode_traits::unicode_errc();
+        }
 
-            if (!head.indefinite())
+        struct item_access;
+        struct scan_access;
+
+    } // namespace detail_view
+
+    // A checked, zero-copy view of one complete, well-formed encoded CBOR
+    // item: its leading semantic tags, head, and content. Obtained from
+    // scan_prefix or parse_exact, or by iterating a container item; never
+    // constructed from unvalidated bytes. Borrows the scanned input, so it
+    // must not outlive the bytes it was scanned from.
+    class item
+    {
+    public:
+        // The item's full encoding, leading tags included. Scanning another
+        // copy of these bytes yields an identical item.
+        span<const uint8_t> encoded_bytes() const noexcept
+        {
+            return bytes_;
+        }
+
+        item_kind kind() const noexcept
+        {
+            switch (head_.major_type)
             {
-                if (static_cast<std::size_t>(head.value) != head.value)
-                {
-                    ec = cbor_errc::number_too_large;
-                    return false;
-                }
-                entries.reserve(static_cast<std::size_t>(
-                    (std::min)(head.value, static_cast<uint64_t>(end - p) / 2)));
-                for (uint64_t i = 0; i < head.value; ++i)
-                {
-                    auto key = read_item_span(p, end, depth - 1, ec);
-                    if (ec) { return false; }
-                    auto value = read_item_span(p, end, depth - 1, ec);
-                    if (ec) { return false; }
-                    entries.push_back(map_entry_view{key, value});
-                }
+                case cbor::detail::cbor_major_type::unsigned_integer: return item_kind::unsigned_integer;
+                case cbor::detail::cbor_major_type::negative_integer: return item_kind::negative_integer;
+                case cbor::detail::cbor_major_type::byte_string:      return item_kind::byte_string;
+                case cbor::detail::cbor_major_type::text_string:      return item_kind::text_string;
+                case cbor::detail::cbor_major_type::array:            return item_kind::array;
+                case cbor::detail::cbor_major_type::map:              return item_kind::map;
+                default:                                              return item_kind::simple;
+            }
+        }
+
+        // The head's argument (RFC 8949 3): the integer's value, a string's
+        // length, a container's count, or a simple value's number, including
+        // the bit patterns of floating-point values. Zero when indefinite.
+        uint64_t argument() const noexcept
+        {
+            return head_.value;
+        }
+
+        bool indefinite() const noexcept
+        {
+            return head_.indefinite();
+        }
+
+        class tag_iterator;
+        class tag_range;
+        class element_iterator;
+        class element_range;
+        class chunk_iterator;
+        class chunk_range;
+        class entry_iterator;
+        class entry_range;
+
+        // The item's leading semantic tags, outermost first. Empty for
+        // untagged items. Tags are exposed, never interpreted: deciding what
+        // a tag means is the caller's or a higher layer's concern.
+        tag_range tags() const noexcept;
+
+        // The elements of an array item, in order; empty unless kind() is
+        // array. Iteration is read-only and borrows this item's bytes.
+        element_range elements() const noexcept;
+
+        // The entries of a map item, in order; empty unless kind() is map.
+        entry_range entries() const noexcept;
+
+        // The content of a string item as contiguous spans: one span for a
+        // definite-length string, one per chunk for an indefinite-length
+        // one. Empty unless kind() is byte_string or text_string.
+        chunk_range chunks() const noexcept;
+
+        // The typed accessors below return false, leaving `value` untouched,
+        // when this item is not of the requested kind. Well-formedness was
+        // established when the item was scanned, so kind is the only thing
+        // that can be wrong.
+
+        bool uint64_value(uint64_t& value) const noexcept
+        {
+            if (head_.major_type != cbor::detail::cbor_major_type::unsigned_integer)
+            {
+                return false;
+            }
+            value = head_.value;
+            return true;
+        }
+
+        bool int64_value(int64_t& value) const noexcept
+        {
+            const uint64_t int64_max = static_cast<uint64_t>((std::numeric_limits<int64_t>::max)());
+            if (head_.major_type == cbor::detail::cbor_major_type::unsigned_integer && head_.value <= int64_max)
+            {
+                value = static_cast<int64_t>(head_.value);
                 return true;
             }
-
-            for (;;)
+            if (head_.major_type == cbor::detail::cbor_major_type::negative_integer && head_.value <= int64_max)
             {
-                if (p >= end)
+                value = -1 - static_cast<int64_t>(head_.value);
+                return true;
+            }
+            return false;
+        }
+
+        bool bool_value(bool& value) const noexcept
+        {
+            if (head_.major_type != cbor::detail::cbor_major_type::simple ||
+                (head_.additional_info != 20 && head_.additional_info != 21))
+            {
+                return false;
+            }
+            value = head_.additional_info == 21;
+            return true;
+        }
+
+        bool double_value(double& value) const noexcept
+        {
+            if (head_.major_type != cbor::detail::cbor_major_type::simple)
+            {
+                return false;
+            }
+            switch (head_.additional_info)
+            {
+                case 25:
+                    value = binary::decode_half(static_cast<uint16_t>(head_.value));
+                    return true;
+                case 26:
                 {
-                    ec = cbor_errc::unexpected_eof;
-                    return false;
-                }
-                if (*p == 0xff)
-                {
-                    ++p;
+                    const uint32_t bits = static_cast<uint32_t>(head_.value);
+                    float single;
+                    std::memcpy(&single, &bits, sizeof single);
+                    value = single;
                     return true;
                 }
-                auto key = read_item_span(p, end, depth - 1, ec);
-                if (ec) { return false; }
-                auto value = read_item_span(p, end, depth - 1, ec);
-                if (ec) { return false; }
-                entries.push_back(map_entry_view{key, value});
+                case 27:
+                {
+                    const uint64_t bits = head_.value;
+                    std::memcpy(&value, &bits, sizeof value);
+                    return true;
+                }
+                default:
+                    return false;
             }
+        }
+
+        // Zero-copy string content. False for indefinite-length (chunked)
+        // strings, whose content is not contiguous; use chunks() or the
+        // copying overloads for those.
+        bool text(string_view& value) const noexcept
+        {
+            if (head_.major_type != cbor::detail::cbor_major_type::text_string || head_.indefinite())
+            {
+                return false;
+            }
+            value = string_view(reinterpret_cast<const char*>(content_), static_cast<std::size_t>(head_.value));
+            return true;
+        }
+
+        bool bytes(span<const uint8_t>& value) const noexcept
+        {
+            if (head_.major_type != cbor::detail::cbor_major_type::byte_string || head_.indefinite())
+            {
+                return false;
+            }
+            value = span<const uint8_t>(content_, static_cast<std::size_t>(head_.value));
+            return true;
+        }
+
+        // Copying string content, assembling chunked strings. Transactional:
+        // `value` is replaced on success and untouched on failure, and may
+        // alias this item's underlying bytes.
+        bool text(std::string& value) const;
+        bool bytes(std::vector<uint8_t>& value) const;
+
+    private:
+        friend struct detail_view::item_access;
+
+        explicit item(span<const uint8_t> bytes) noexcept
+            : bytes_(bytes)
+        {
+            const uint8_t* p = bytes.data();
+            const uint8_t* end = p + bytes.size();
+            std::error_code ec;
+            const bool ok = detail_view::read_value_head(p, end, head_, ec);
+            assert(ok && !ec);
+            (void)ok;
+            content_ = p;
+        }
+
+        item(span<const uint8_t> bytes, const detail_view::item_head& head, const uint8_t* content) noexcept
+            : bytes_(bytes), head_(head), content_(content)
+        {
+        }
+
+        span<const uint8_t> bytes_;
+        detail_view::item_head head_;
+        const uint8_t* content_;   // first byte after the untagged head
+    };
+
+    namespace detail_view {
+
+        struct item_access
+        {
+            static item make(span<const uint8_t> bytes) noexcept
+            {
+                return item(bytes);
+            }
+
+            static item make(span<const uint8_t> bytes, const item_head& head, const uint8_t* content) noexcept
+            {
+                return item(bytes, head, content);
+            }
+        };
+
+    } // namespace detail_view
+
+    // Iterates the values of an item's leading semantic tags.
+    class item::tag_iterator
+    {
+    public:
+        using value_type = uint64_t;
+        using reference = uint64_t;
+        using pointer = void;
+        using difference_type = std::ptrdiff_t;
+        using iterator_category = std::input_iterator_tag;
+
+        tag_iterator() noexcept : pos_(nullptr), stop_(nullptr), value_(0) {}
+
+        uint64_t operator*() const noexcept
+        {
+            assert(pos_ != nullptr);
+            return value_;
+        }
+
+        tag_iterator& operator++()
+        {
+            advance();
+            return *this;
+        }
+
+        tag_iterator operator++(int)
+        {
+            tag_iterator temp = *this;
+            advance();
+            return temp;
+        }
+
+        friend bool operator==(const tag_iterator& a, const tag_iterator& b) noexcept
+        {
+            return a.pos_ == b.pos_;
+        }
+
+        friend bool operator!=(const tag_iterator& a, const tag_iterator& b) noexcept
+        {
+            return a.pos_ != b.pos_;
+        }
+
+    private:
+        friend class item;
+        friend class tag_range;
+
+        tag_iterator(const uint8_t* pos, const uint8_t* stop) noexcept
+            : pos_(pos), stop_(stop), value_(0)
+        {
+            advance();
+        }
+
+        void advance() noexcept
+        {
+            if (pos_ == nullptr || pos_ >= stop_)
+            {
+                pos_ = nullptr;
+                return;
+            }
+            item_head head;
+            std::error_code ec;
+            const uint8_t* p = pos_;
+            const bool ok = detail_view::read_head(p, stop_, head, ec);
+            assert(ok && head.major_type == cbor::detail::cbor_major_type::semantic_tag);
+            (void)ok;
+            value_ = head.value;
+            pos_ = p;
+        }
+
+        using item_head = detail_view::item_head;
+        const uint8_t* pos_;    // nullptr when exhausted
+        const uint8_t* stop_;   // first byte of the untagged head
+        uint64_t value_;
+    };
+
+    class item::tag_range
+    {
+    public:
+        using iterator = tag_iterator;
+        using const_iterator = tag_iterator;
+
+        tag_iterator begin() const noexcept { return tag_iterator(first_, stop_); }
+        tag_iterator end() const noexcept { return tag_iterator(); }
+        bool empty() const noexcept { return first_ == stop_; }
+
+    private:
+        friend class item;
+        tag_range(const uint8_t* first, const uint8_t* stop) noexcept : first_(first), stop_(stop) {}
+
+        const uint8_t* first_;
+        const uint8_t* stop_;
+    };
+
+    inline item::tag_range item::tags() const noexcept
+    {
+        // Leading tags occupy [start of encoding, start of untagged head).
+        const uint8_t* p = bytes_.data();
+        const uint8_t* stop = p;
+        detail_view::item_head head;
+        std::error_code ec;
+        while (detail_view::read_head(p, bytes_.data() + bytes_.size(), head, ec) &&
+               head.major_type == cbor::detail::cbor_major_type::semantic_tag)
+        {
+            stop = p;
+        }
+        return tag_range(bytes_.data(), stop);
+    }
+
+    // Iterates the elements of an array item as checked items.
+    class item::element_iterator
+    {
+    public:
+        using value_type = item;
+        using reference = item;
+        using pointer = void;
+        using difference_type = std::ptrdiff_t;
+        using iterator_category = std::input_iterator_tag;
+
+        element_iterator() noexcept : pos_(nullptr), end_(nullptr), remaining_(0), current_(nullptr), content_(nullptr) {}
+
+        item operator*() const noexcept
+        {
+            assert(pos_ != nullptr);
+            return detail_view::item_access::make(
+                span<const uint8_t>(pos_, static_cast<std::size_t>(current_ - pos_)), head_, content_);
+        }
+
+        element_iterator& operator++()
+        {
+            pos_ = current_;
+            advance();
+            return *this;
+        }
+
+        element_iterator operator++(int)
+        {
+            element_iterator temp = *this;
+            ++(*this);
+            return temp;
+        }
+
+        friend bool operator==(const element_iterator& a, const element_iterator& b) noexcept
+        {
+            return a.pos_ == b.pos_;
+        }
+
+        friend bool operator!=(const element_iterator& a, const element_iterator& b) noexcept
+        {
+            return a.pos_ != b.pos_;
+        }
+
+    private:
+        friend class item;
+        friend class element_range;
+
+        element_iterator(const uint8_t* pos, const uint8_t* end, uint64_t remaining) noexcept
+            : pos_(pos), end_(end), remaining_(remaining), current_(nullptr), content_(nullptr)
+        {
+            advance();
+        }
+
+        void advance() noexcept
+        {
+            if (pos_ == nullptr)
+            {
+                return;
+            }
+            if (remaining_ == detail_view::indefinite_array_marker)
+            {
+                assert(pos_ < end_);
+                if (*pos_ == 0xff)
+                {
+                    pos_ = nullptr;
+                    return;
+                }
+            }
+            else if (remaining_ == 0)
+            {
+                pos_ = nullptr;
+                return;
+            }
+            else
+            {
+                --remaining_;
+            }
+            current_ = detail_view::skip_checked(pos_, end_, head_, content_);
+        }
+
+        const uint8_t* pos_;       // start of the current element; nullptr at end
+        const uint8_t* end_;
+        uint64_t remaining_;       // count left, or indefinite_array_marker
+        const uint8_t* current_;   // end of the current element
+        detail_view::item_head head_;
+        const uint8_t* content_;
+    };
+
+    class item::element_range
+    {
+    public:
+        using iterator = element_iterator;
+        using const_iterator = element_iterator;
+
+        element_iterator begin() const noexcept { return element_iterator(first_, end_, remaining_); }
+        element_iterator end() const noexcept { return element_iterator(); }
+        bool empty() const noexcept { return begin() == this->end(); }
+
+    private:
+        friend class item;
+        element_range(const uint8_t* first, const uint8_t* end, uint64_t remaining) noexcept
+            : first_(first), end_(end), remaining_(remaining) {}
+
+        const uint8_t* first_;
+        const uint8_t* end_;
+        uint64_t remaining_;
+    };
+
+    inline item::element_range item::elements() const noexcept
+    {
+        if (head_.major_type != cbor::detail::cbor_major_type::array)
+        {
+            return element_range(nullptr, nullptr, 0);
+        }
+        return element_range(content_, bytes_.data() + bytes_.size(),
+            head_.indefinite() ? detail_view::indefinite_array_marker : head_.value);
+    }
+
+    // One entry of a map item.
+    struct map_entry
+    {
+        item key;
+        item value;
+    };
+
+    // Iterates the entries of a map item as checked key and value items.
+    class item::entry_iterator
+    {
+    public:
+        using value_type = map_entry;
+        using reference = map_entry;
+        using pointer = void;
+        using difference_type = std::ptrdiff_t;
+        using iterator_category = std::input_iterator_tag;
+
+        entry_iterator() noexcept : pos_(nullptr), end_(nullptr), remaining_(0), key_end_(nullptr), value_end_(nullptr),
+            key_content_(nullptr), value_content_(nullptr) {}
+
+        map_entry operator*() const noexcept
+        {
+            assert(pos_ != nullptr);
+            return map_entry{
+                detail_view::item_access::make(
+                    span<const uint8_t>(pos_, static_cast<std::size_t>(key_end_ - pos_)), key_head_, key_content_),
+                detail_view::item_access::make(
+                    span<const uint8_t>(key_end_, static_cast<std::size_t>(value_end_ - key_end_)), value_head_, value_content_)};
+        }
+
+        entry_iterator& operator++()
+        {
+            pos_ = value_end_;
+            advance();
+            return *this;
+        }
+
+        entry_iterator operator++(int)
+        {
+            entry_iterator temp = *this;
+            ++(*this);
+            return temp;
+        }
+
+        friend bool operator==(const entry_iterator& a, const entry_iterator& b) noexcept
+        {
+            return a.pos_ == b.pos_;
+        }
+
+        friend bool operator!=(const entry_iterator& a, const entry_iterator& b) noexcept
+        {
+            return a.pos_ != b.pos_;
+        }
+
+    private:
+        friend class item;
+        friend class entry_range;
+
+        entry_iterator(const uint8_t* pos, const uint8_t* end, uint64_t remaining) noexcept
+            : pos_(pos), end_(end), remaining_(remaining), key_end_(nullptr), value_end_(nullptr),
+              key_content_(nullptr), value_content_(nullptr)
+        {
+            advance();
+        }
+
+        void advance() noexcept
+        {
+            if (pos_ == nullptr)
+            {
+                return;
+            }
+            if (remaining_ == detail_view::indefinite_map_key_marker)
+            {
+                assert(pos_ < end_);
+                if (*pos_ == 0xff)
+                {
+                    pos_ = nullptr;
+                    return;
+                }
+            }
+            else if (remaining_ == 0)
+            {
+                pos_ = nullptr;
+                return;
+            }
+            else
+            {
+                --remaining_;
+            }
+            key_end_ = detail_view::skip_checked(pos_, end_, key_head_, key_content_);
+            value_end_ = detail_view::skip_checked(key_end_, end_, value_head_, value_content_);
+        }
+
+        const uint8_t* pos_;        // start of the current entry's key; nullptr at end
+        const uint8_t* end_;
+        uint64_t remaining_;        // entry count left, or indefinite_map_key_marker
+        const uint8_t* key_end_;
+        const uint8_t* value_end_;
+        detail_view::item_head key_head_;
+        const uint8_t* key_content_;
+        detail_view::item_head value_head_;
+        const uint8_t* value_content_;
+    };
+
+    class item::entry_range
+    {
+    public:
+        using iterator = entry_iterator;
+        using const_iterator = entry_iterator;
+
+        entry_iterator begin() const noexcept { return entry_iterator(first_, end_, remaining_); }
+        entry_iterator end() const noexcept { return entry_iterator(); }
+        bool empty() const noexcept { return begin() == this->end(); }
+
+    private:
+        friend class item;
+        entry_range(const uint8_t* first, const uint8_t* end, uint64_t remaining) noexcept
+            : first_(first), end_(end), remaining_(remaining) {}
+
+        const uint8_t* first_;
+        const uint8_t* end_;
+        uint64_t remaining_;
+    };
+
+    inline item::entry_range item::entries() const noexcept
+    {
+        if (head_.major_type != cbor::detail::cbor_major_type::map)
+        {
+            return entry_range(nullptr, nullptr, 0);
+        }
+        return entry_range(content_, bytes_.data() + bytes_.size(),
+            head_.indefinite() ? detail_view::indefinite_map_key_marker : head_.value);
+    }
+
+    // Iterates the contiguous spans of a string item's content.
+    class item::chunk_iterator
+    {
+    public:
+        using value_type = span<const uint8_t>;
+        using reference = span<const uint8_t>;
+        using pointer = void;
+        using difference_type = std::ptrdiff_t;
+        using iterator_category = std::input_iterator_tag;
+
+        chunk_iterator() noexcept : pos_(nullptr), end_(nullptr) {}
+
+        span<const uint8_t> operator*() const noexcept
+        {
+            assert(pos_ != nullptr);
+            return current_;
+        }
+
+        chunk_iterator& operator++()
+        {
+            advance();
+            return *this;
+        }
+
+        chunk_iterator operator++(int)
+        {
+            chunk_iterator temp = *this;
+            advance();
+            return temp;
+        }
+
+        friend bool operator==(const chunk_iterator& a, const chunk_iterator& b) noexcept
+        {
+            return a.pos_ == b.pos_;
+        }
+
+        friend bool operator!=(const chunk_iterator& a, const chunk_iterator& b) noexcept
+        {
+            return a.pos_ != b.pos_;
+        }
+
+    private:
+        friend class item;
+        friend class chunk_range;
+
+        // Definite string: one chunk covering the whole payload.
+        chunk_iterator(span<const uint8_t> payload) noexcept
+            : pos_(payload.data()), end_(nullptr), current_(payload)
+        {
+        }
+
+        // Indefinite string: one chunk per definite-length piece.
+        chunk_iterator(const uint8_t* pos, const uint8_t* end) noexcept
+            : pos_(pos), end_(end)
+        {
+            advance();
+        }
+
+        void advance() noexcept
+        {
+            if (pos_ == nullptr)
+            {
+                return;
+            }
+            if (end_ == nullptr || *pos_ == 0xff)   // single definite chunk consumed, or break
+            {
+                pos_ = nullptr;
+                return;
+            }
+            detail_view::item_head head;
+            std::error_code ec;
+            const uint8_t* p = pos_;
+            const bool ok = detail_view::read_head(p, end_, head, ec);
+            assert(ok && !head.indefinite());
+            (void)ok;
+            current_ = span<const uint8_t>(p, static_cast<std::size_t>(head.value));
+            pos_ = p + static_cast<std::size_t>(head.value);
+        }
+
+        const uint8_t* pos_;    // nullptr when exhausted
+        const uint8_t* end_;    // nullptr for the single definite chunk
+        span<const uint8_t> current_;
+    };
+
+    class item::chunk_range
+    {
+    public:
+        using iterator = chunk_iterator;
+        using const_iterator = chunk_iterator;
+
+        chunk_iterator begin() const noexcept
+        {
+            if (first_ == nullptr)
+            {
+                return chunk_iterator();
+            }
+            if (indefinite_)
+            {
+                return chunk_iterator(first_, end_);
+            }
+            return chunk_iterator(span<const uint8_t>(first_, static_cast<std::size_t>(end_ - first_)));
+        }
+
+        chunk_iterator end() const noexcept { return chunk_iterator(); }
+        bool empty() const noexcept { return begin() == this->end(); }
+
+    private:
+        friend class item;
+        chunk_range(const uint8_t* first, const uint8_t* end, bool indefinite) noexcept
+            : first_(first), end_(end), indefinite_(indefinite) {}
+
+        const uint8_t* first_;
+        const uint8_t* end_;
+        bool indefinite_;
+    };
+
+    inline item::chunk_range item::chunks() const noexcept
+    {
+        if (head_.major_type != cbor::detail::cbor_major_type::byte_string &&
+            head_.major_type != cbor::detail::cbor_major_type::text_string)
+        {
+            return chunk_range(nullptr, nullptr, false);
+        }
+        if (head_.indefinite())
+        {
+            return chunk_range(content_, bytes_.data() + bytes_.size(), true);
+        }
+        return chunk_range(content_, content_ + static_cast<std::size_t>(head_.value), false);
+    }
+
+    inline bool item::text(std::string& value) const
+    {
+        if (head_.major_type != cbor::detail::cbor_major_type::text_string)
+        {
+            return false;
+        }
+        std::size_t total = 0;
+        for (chunk_iterator it = chunks().begin(); it != chunk_iterator(); ++it)
+        {
+            total += (*it).size();
+        }
+        std::string content;
+        content.reserve(total);
+        for (chunk_iterator it = chunks().begin(); it != chunk_iterator(); ++it)
+        {
+            const span<const uint8_t> chunk = *it;
+            content.append(reinterpret_cast<const char*>(chunk.data()), chunk.size());
+        }
+        value = std::move(content);
+        return true;
+    }
+
+    inline bool item::bytes(std::vector<uint8_t>& value) const
+    {
+        if (head_.major_type != cbor::detail::cbor_major_type::byte_string)
+        {
+            return false;
+        }
+        std::size_t total = 0;
+        for (chunk_iterator it = chunks().begin(); it != chunk_iterator(); ++it)
+        {
+            total += (*it).size();
+        }
+        std::vector<uint8_t> content;
+        content.reserve(total);
+        for (chunk_iterator it = chunks().begin(); it != chunk_iterator(); ++it)
+        {
+            const span<const uint8_t> chunk = *it;
+            content.insert(content.end(), chunk.data(), chunk.data() + chunk.size());
+        }
+        value = std::move(content);
+        return true;
+    }
+
+    // Reusable scanning state: the depth policy and the walker's workspace.
+    // Scanning allocates only when nesting exceeds 32 open containers, and
+    // a reused context retains that capacity.
+    class scan_context
+    {
+    public:
+        scan_context() noexcept
+            : max_nesting_depth_(default_max_nesting_depth)
+        {
+        }
+
+        explicit scan_context(int max_nesting_depth) noexcept
+            : max_nesting_depth_(max_nesting_depth)
+        {
+        }
+
+        int max_nesting_depth() const noexcept
+        {
+            return max_nesting_depth_;
+        }
+
+    private:
+        friend struct detail_view::scan_access;
+
+        int max_nesting_depth_;
+        detail_view::pending_stack workspace_;
+    };
+
+    namespace detail_view {
+
+        struct scan_access
+        {
+            static pending_stack& workspace(scan_context& context) noexcept
+            {
+                return context.workspace_;
+            }
+        };
+
+        // All error codes assigned by the walker are cbor_errc values.
+        inline cbor_errc to_cbor_errc(const std::error_code& ec) noexcept
+        {
+            return static_cast<cbor_errc>(ec.value());
         }
 
     } // namespace detail_view
 
-    struct bytewise_order
+    struct scan_result
+    {
+        item first;
+        span<const uint8_t> remainder;
+    };
+
+    // Scans the first item in `input`, validating its well-formedness, and
+    // returns it together with the remaining bytes. On failure the error
+    // holds the offending code and the offset at which scanning stopped.
+    inline expected<scan_result, scan_error> scan_prefix(span<const uint8_t> input, scan_context& context)
+    {
+        const uint8_t* p = input.data();
+        const uint8_t* end = p + input.size();
+        std::error_code ec;
+        if (!detail_view::skip_item(p, end, context.max_nesting_depth(),
+                detail_view::scan_access::workspace(context), ec))
+        {
+            return expected<scan_result, scan_error>(unexpect,
+                scan_error{detail_view::to_cbor_errc(ec), static_cast<std::size_t>(p - input.data())});
+        }
+        return scan_result{
+            detail_view::item_access::make(span<const uint8_t>(input.data(), static_cast<std::size_t>(p - input.data()))),
+            span<const uint8_t>(p, static_cast<std::size_t>(end - p))};
+    }
+
+    inline expected<scan_result, scan_error> scan_prefix(span<const uint8_t> input)
+    {
+        scan_context context;
+        return scan_prefix(input, context);
+    }
+
+    // Scans `input`, which must hold exactly one item: trailing bytes are
+    // an error (cbor_errc::trailing_data), unlike scan_prefix.
+    inline expected<item, scan_error> parse_exact(span<const uint8_t> input, scan_context& context)
+    {
+        auto scanned = scan_prefix(input, context);
+        if (!scanned)
+        {
+            return expected<item, scan_error>(unexpect, scanned.error());
+        }
+        if (!scanned.value().remainder.empty())
+        {
+            return expected<item, scan_error>(unexpect,
+                scan_error{cbor_errc::trailing_data, scanned.value().first.encoded_bytes().size()});
+        }
+        return scanned.value().first;
+    }
+
+    inline expected<item, scan_error> parse_exact(span<const uint8_t> input)
+    {
+        scan_context context;
+        return parse_exact(input, context);
+    }
+
+    // Guard against scanning a temporary container: the resulting views
+    // would dangle immediately. Non-owning view types (spans, string views)
+    // are trivially copyable and pass through.
+    template <typename Container, typename std::enable_if<!std::is_trivially_copyable<Container>::value, int>::type = 0>
+    expected<scan_result, scan_error> scan_prefix(const Container&&, scan_context&) = delete;
+    template <typename Container, typename std::enable_if<!std::is_trivially_copyable<Container>::value, int>::type = 0>
+    expected<scan_result, scan_error> scan_prefix(const Container&&) = delete;
+    template <typename Container, typename std::enable_if<!std::is_trivially_copyable<Container>::value, int>::type = 0>
+    expected<item, scan_error> parse_exact(const Container&&, scan_context&) = delete;
+    template <typename Container, typename std::enable_if<!std::is_trivially_copyable<Container>::value, int>::type = 0>
+    expected<item, scan_error> parse_exact(const Container&&) = delete;
+
+    // Deterministic encoding orders over the encoded bytes of items.
+    // The *_compare forms return a three-way result; the *_less forms are
+    // strict-weak-order predicates for sorting and ordered containers.
+
+    struct bytewise_compare
     {
         int operator()(span<const uint8_t> a, span<const uint8_t> b) const noexcept
         {
             return detail_view::compare_bytes(a, b);
         }
+
+        int operator()(const item& a, const item& b) const noexcept
+        {
+            return (*this)(a.encoded_bytes(), b.encoded_bytes());
+        }
     };
 
-    struct length_first_order
+    struct length_first_compare
     {
         int operator()(span<const uint8_t> a, span<const uint8_t> b) const noexcept
         {
             const int r = detail_view::compare_size(a.size(), b.size());
             return r != 0 ? r : detail_view::compare_bytes(a, b);
         }
+
+        int operator()(const item& a, const item& b) const noexcept
+        {
+            return (*this)(a.encoded_bytes(), b.encoded_bytes());
+        }
     };
 
-    inline bool read_head(const uint8_t*& p, const uint8_t* end, item_head& head, std::error_code& ec)
+    struct bytewise_less
     {
-        return detail_view::read_head(p, end, head, ec);
-    }
-
-    inline bool skip_item(const uint8_t*& p, const uint8_t* end, std::error_code& ec,
-        int max_nesting_depth = default_max_nesting_depth)
-    {
-        return detail_view::skip_item(p, end, max_nesting_depth, ec);
-    }
-
-    inline span<const uint8_t> item_span(span<const uint8_t> input, std::error_code& ec,
-        int max_nesting_depth = default_max_nesting_depth)
-    {
-        const uint8_t* p = input.data();
-        return detail_view::read_item_span(p, p + input.size(), max_nesting_depth, ec);
-    }
-
-    inline bool map_entries(span<const uint8_t> input, std::vector<map_entry_view>& entries, std::error_code& ec,
-        int max_nesting_depth = default_max_nesting_depth)
-    {
-        entries.clear();
-        return detail_view::read_map_entries(input, entries, max_nesting_depth, ec);
-    }
-
-    template <typename Order = bytewise_order>
-    int compare(span<const uint8_t> a, span<const uint8_t> b, std::error_code& ec,
-        Order order = Order(), int max_nesting_depth = default_max_nesting_depth)
-    {
-        const uint8_t* ap = a.data();
-        auto ia = detail_view::read_item_span(ap, ap + a.size(), max_nesting_depth, ec);
-        if (ec)
+        bool operator()(span<const uint8_t> a, span<const uint8_t> b) const noexcept
         {
-            return 0;
+            return bytewise_compare()(a, b) < 0;
         }
-        const uint8_t* bp = b.data();
-        auto ib = detail_view::read_item_span(bp, bp + b.size(), max_nesting_depth, ec);
-        if (ec)
-        {
-            return 0;
-        }
-        return order(ia, ib);
-    }
 
-    template <typename Order = bytewise_order>
-    int compare(span<const uint8_t> a, span<const uint8_t> b)
-    {
-        std::error_code ec;
-        int result = compare(a, b, ec, Order());
-        if (JSONCONS_UNLIKELY(ec))
+        bool operator()(const item& a, const item& b) const noexcept
         {
-            JSONCONS_THROW(ser_error(ec));
+            return bytewise_compare()(a, b) < 0;
         }
-        return result;
-    }
+    };
 
-    template <typename Order = bytewise_order>
-    bool map_keys_sorted(span<const uint8_t> input, std::error_code& ec,
-        Order order = Order(), int max_nesting_depth = default_max_nesting_depth)
+    struct length_first_less
     {
-        std::vector<map_entry_view> entries;
-        if (!detail_view::read_map_entries(input, entries, max_nesting_depth, ec))
+        bool operator()(span<const uint8_t> a, span<const uint8_t> b) const noexcept
+        {
+            return length_first_compare()(a, b) < 0;
+        }
+
+        bool operator()(const item& a, const item& b) const noexcept
+        {
+            return length_first_compare()(a, b) < 0;
+        }
+    };
+
+    // True if `map_item` is a map whose keys are strictly ascending in the
+    // given order, RFC 8949 4.2 deterministic encoding style. Duplicate
+    // keys are not ascending. Does not allocate.
+    template <typename Compare = bytewise_compare>
+    bool map_keys_sorted(const item& map_item, Compare compare = Compare())
+    {
+        if (map_item.kind() != item_kind::map)
         {
             return false;
         }
-        for (std::size_t i = 1; i < entries.size(); ++i)
+        span<const uint8_t> prev;
+        for (item::entry_iterator it = map_item.entries().begin(); it != item::entry_iterator(); ++it)
         {
-            if (order(entries[i-1].key, entries[i].key) >= 0)
+            const span<const uint8_t> key = (*it).key.encoded_bytes();
+            if (!prev.empty() && compare(prev, key) >= 0)
+            {
+                return false;
+            }
+            prev = key;
+        }
+        return true;
+    }
+
+    // True if `text_item` is a text string whose content is well-formed
+    // UTF-8. Each chunk of an indefinite-length text string must itself be
+    // well-formed (RFC 8949 3.2.3). No other function validates text.
+    inline bool validate_text(const item& text_item) noexcept
+    {
+        if (text_item.kind() != item_kind::text_string)
+        {
+            return false;
+        }
+        for (item::chunk_iterator it = text_item.chunks().begin(); it != item::chunk_iterator(); ++it)
+        {
+            const span<const uint8_t> chunk = *it;
+            if (!detail_view::validate_utf8(chunk.data(), chunk.size()))
             {
                 return false;
             }

--- a/test/cbor/src/cbor_view_tests.cpp
+++ b/test/cbor/src/cbor_view_tests.cpp
@@ -7,140 +7,545 @@
 
 #include <jsoncons_ext/cbor/cbor_view.hpp>
 
-#include <system_error>
+#include <algorithm>
+#include <limits>
+#include <string>
 #include <vector>
 #include <catch/catch.hpp>
 
 using namespace jsoncons;
 
-TEST_CASE("cbor raw view utilities")
+namespace {
+
+    cbor::view::item parse(const std::vector<uint8_t>& data)
+    {
+        auto result = cbor::view::parse_exact(jsoncons::span<const uint8_t>(data.data(), data.size()));
+        REQUIRE(result.has_value());
+        return result.value();
+    }
+
+} // namespace
+
+TEST_CASE("cbor view scan_prefix and parse_exact")
 {
-    SECTION("item span reads one item")
+    SECTION("scan_prefix returns the first item and the remainder")
     {
         std::vector<uint8_t> data = {0x01,0x02};
-        std::error_code ec;
-        auto item = cbor::view::item_span(jsoncons::span<const uint8_t>(data), ec);
-        REQUIRE_FALSE(ec);
-        REQUIRE(item.size() == 1);
-        CHECK(item[0] == 0x01);
+        auto result = cbor::view::scan_prefix(jsoncons::span<const uint8_t>(data));
+        REQUIRE(result.has_value());
+        CHECK(result.value().first.encoded_bytes().data() == data.data());
+        CHECK(result.value().first.encoded_bytes().size() == 1);
+        CHECK(result.value().remainder.data() == data.data() + 1);
+        CHECK(result.value().remainder.size() == 1);
     }
 
-    SECTION("trailing bytes after the first item are ignored")
+    SECTION("scan_prefix walks a sequence of items")
     {
-        std::vector<uint8_t> a = {0x01,0x63,'a','b','c'};
-        std::vector<uint8_t> b = {0x01};
-        std::error_code ec;
-        CHECK(cbor::view::compare(jsoncons::span<const uint8_t>(a), jsoncons::span<const uint8_t>(b), ec) == 0);
-        CHECK_FALSE(ec);
+        std::vector<uint8_t> data = {0x01,0x61,'a',0x80};
+        jsoncons::span<const uint8_t> rest(data.data(), data.size());
+        std::size_t count = 0;
+        while (!rest.empty())
+        {
+            auto result = cbor::view::scan_prefix(rest);
+            REQUIRE(result.has_value());
+            rest = result.value().remainder;
+            ++count;
+        }
+        CHECK(count == 3);
     }
 
+    SECTION("parse_exact rejects trailing bytes with their offset")
+    {
+        std::vector<uint8_t> data = {0x01,0x02};
+        auto result = cbor::view::parse_exact(jsoncons::span<const uint8_t>(data));
+        REQUIRE_FALSE(result.has_value());
+        CHECK(result.error().code == cbor::cbor_errc::trailing_data);
+        CHECK(result.error().offset == 1);
+
+        std::vector<uint8_t> exact = {0x01};
+        CHECK(cbor::view::parse_exact(jsoncons::span<const uint8_t>(exact)).has_value());
+    }
+
+    SECTION("empty input fails at offset zero")
+    {
+        auto result = cbor::view::scan_prefix(jsoncons::span<const uint8_t>());
+        REQUIRE_FALSE(result.has_value());
+        CHECK(result.error().code == cbor::cbor_errc::unexpected_eof);
+        CHECK(result.error().offset == 0);
+    }
+
+    SECTION("errors carry the offset where scanning stopped")
+    {
+        // [1, <invalid head 0x1f>]
+        std::vector<uint8_t> data = {0x82,0x01,0x1f};
+        auto result = cbor::view::scan_prefix(jsoncons::span<const uint8_t>(data));
+        REQUIRE_FALSE(result.has_value());
+        CHECK(result.error().code == cbor::cbor_errc::unknown_type);
+        CHECK(result.error().offset == 3);
+    }
+
+    SECTION("a scan_context is reusable across scans")
+    {
+        cbor::view::scan_context context(4000);
+        std::vector<uint8_t> deep(2000, 0x81);
+        deep.push_back(0x01);
+        std::vector<uint8_t> shallow = {0x01};
+
+        CHECK(cbor::view::parse_exact(jsoncons::span<const uint8_t>(deep), context).has_value());
+        CHECK(cbor::view::parse_exact(jsoncons::span<const uint8_t>(shallow), context).has_value());
+        CHECK(cbor::view::parse_exact(jsoncons::span<const uint8_t>(deep), context).has_value());
+    }
+}
+
+TEST_CASE("cbor view scanning validates well-formedness")
+{
     SECTION("nesting at the default depth bound succeeds")
     {
         std::vector<uint8_t> data(cbor::view::default_max_nesting_depth, 0x81);
         data.push_back(0x01);
-        std::error_code ec;
-        auto item = cbor::view::item_span(jsoncons::span<const uint8_t>(data), ec);
-        REQUIRE_FALSE(ec);
-        CHECK(item.size() == data.size());
+        auto result = cbor::view::parse_exact(jsoncons::span<const uint8_t>(data));
+        REQUIRE(result.has_value());
+        CHECK(result.value().encoded_bytes().size() == data.size());
     }
 
     SECTION("nesting past the depth bound is rejected")
     {
         std::vector<uint8_t> data(cbor::view::default_max_nesting_depth + 1, 0x81);
         data.push_back(0x01);
-        std::error_code ec;
-        auto item = cbor::view::item_span(jsoncons::span<const uint8_t>(data), ec);
-        CHECK(item.empty());
-        CHECK(ec == cbor::cbor_errc::max_nesting_depth_exceeded);
+        auto result = cbor::view::parse_exact(jsoncons::span<const uint8_t>(data));
+        REQUIRE_FALSE(result.has_value());
+        CHECK(result.error().code == cbor::cbor_errc::max_nesting_depth_exceeded);
 
-        ec.clear();
-        item = cbor::view::item_span(jsoncons::span<const uint8_t>(data), ec, 4000);
-        REQUIRE_FALSE(ec);
-        CHECK(item.size() == data.size());
+        cbor::view::scan_context deeper(4000);
+        CHECK(cbor::view::parse_exact(jsoncons::span<const uint8_t>(data), deeper).has_value());
     }
 
     SECTION("tag chains do not consume nesting depth or stack")
     {
         std::vector<uint8_t> data(1000000, 0xc0);
         data.push_back(0x01);
-        std::error_code ec;
-        auto item = cbor::view::item_span(jsoncons::span<const uint8_t>(data), ec);
-        REQUIRE_FALSE(ec);
-        CHECK(item.size() == data.size());
+        auto result = cbor::view::parse_exact(jsoncons::span<const uint8_t>(data));
+        REQUIRE(result.has_value());
+
+        std::size_t count = 0;
+        for (uint64_t tag : result.value().tags())
+        {
+            CHECK(tag == 0);
+            ++count;
+        }
+        CHECK(count == 1000000);
     }
 
-    SECTION("map claiming a huge entry count is rejected")
+    SECTION("containers claiming huge counts are rejected")
     {
-        std::vector<uint8_t> data = {0xba,0xff,0xff,0xff,0xff};
-        std::vector<cbor::view::map_entry_view> entries;
-        std::error_code ec;
-        CHECK_FALSE(cbor::view::map_entries(jsoncons::span<const uint8_t>(data), entries, ec));
-        CHECK(ec == cbor::cbor_errc::unexpected_eof);
-    }
+        std::vector<uint8_t> array = {0x9a,0xff,0xff,0xff,0xff};
+        auto array_result = cbor::view::scan_prefix(jsoncons::span<const uint8_t>(array));
+        REQUIRE_FALSE(array_result.has_value());
+        CHECK(array_result.error().code == cbor::cbor_errc::unexpected_eof);
 
-    SECTION("array claiming a huge element count is rejected")
-    {
-        std::vector<uint8_t> data = {0x9a,0xff,0xff,0xff,0xff};
-        std::error_code ec;
-        auto item = cbor::view::item_span(jsoncons::span<const uint8_t>(data), ec);
-        CHECK(item.empty());
-        CHECK(ec == cbor::cbor_errc::unexpected_eof);
+        std::vector<uint8_t> map = {0xba,0xff,0xff,0xff,0xff};
+        auto map_result = cbor::view::scan_prefix(jsoncons::span<const uint8_t>(map));
+        REQUIRE_FALSE(map_result.has_value());
+        CHECK(map_result.error().code == cbor::cbor_errc::unexpected_eof);
     }
 
     SECTION("definite and indefinite nesting can mix")
     {
         // [_ {1: [2]}, [], {} ] followed by trailing bytes
         std::vector<uint8_t> data = {0x9f,0xa1,0x01,0x81,0x02,0x80,0xa0,0xff,0x63,'a','b','c'};
-        std::error_code ec;
-        auto item = cbor::view::item_span(jsoncons::span<const uint8_t>(data), ec);
-        REQUIRE_FALSE(ec);
-        CHECK(item.size() == 8);
+        auto result = cbor::view::scan_prefix(jsoncons::span<const uint8_t>(data));
+        REQUIRE(result.has_value());
+        CHECK(result.value().first.encoded_bytes().size() == 8);
+        CHECK(result.value().remainder.size() == 4);
     }
 
-    SECTION("indefinite map break may not split a key from its value")
+    SECTION("an indefinite map break may not split a key from its value")
     {
         std::vector<uint8_t> dangling_key = {0xbf,0x01,0xff};
-        std::error_code ec;
-        auto item = cbor::view::item_span(jsoncons::span<const uint8_t>(dangling_key), ec);
-        CHECK(item.empty());
-        CHECK(ec == cbor::cbor_errc::unknown_type);
+        auto result = cbor::view::scan_prefix(jsoncons::span<const uint8_t>(dangling_key));
+        REQUIRE_FALSE(result.has_value());
+        CHECK(result.error().code == cbor::cbor_errc::unknown_type);
 
         std::vector<uint8_t> complete_entry = {0xbf,0x01,0x02,0xff};
-        ec.clear();
-        item = cbor::view::item_span(jsoncons::span<const uint8_t>(complete_entry), ec);
-        REQUIRE_FALSE(ec);
-        CHECK(item.size() == complete_entry.size());
+        CHECK(cbor::view::parse_exact(jsoncons::span<const uint8_t>(complete_entry)).has_value());
     }
 
-    SECTION("map entries expose key and value spans")
-    {
-        std::vector<uint8_t> data = {0xa2,0x01,0x61,0x61,0x61,0x6b,0x02};
-        std::vector<cbor::view::map_entry_view> entries;
-        std::error_code ec;
-        REQUIRE(cbor::view::map_entries(jsoncons::span<const uint8_t>(data), entries, ec));
-        REQUIRE_FALSE(ec);
-        REQUIRE(entries.size() == 2);
-        CHECK(entries[0].key.data() == data.data() + 1);
-        CHECK(entries[0].key.size() == 1);
-        CHECK(entries[0].value.data() == data.data() + 2);
-        CHECK(entries[0].value.size() == 2);
-        CHECK(entries[1].key.data() == data.data() + 4);
-        CHECK(entries[1].key.size() == 2);
-        CHECK(entries[1].value.data() == data.data() + 6);
-        CHECK(entries[1].value.size() == 1);
-    }
-
-    SECTION("invalid indefinite integer is rejected")
+    SECTION("an invalid indefinite integer is rejected")
     {
         std::vector<uint8_t> data = {0x1f};
-        std::error_code ec;
-        auto item = cbor::view::item_span(jsoncons::span<const uint8_t>(data), ec);
-        CHECK(item.empty());
-        CHECK(ec == cbor::cbor_errc::unknown_type);
+        auto result = cbor::view::scan_prefix(jsoncons::span<const uint8_t>(data));
+        REQUIRE_FALSE(result.has_value());
+        CHECK(result.error().code == cbor::cbor_errc::unknown_type);
+    }
+
+    SECTION("a two-byte simple value below 32 is not well-formed")
+    {
+        // RFC 8949 3.3
+        std::vector<uint8_t> below = {0xf8,0x13};
+        auto below_result = cbor::view::scan_prefix(jsoncons::span<const uint8_t>(below));
+        REQUIRE_FALSE(below_result.has_value());
+        CHECK(below_result.error().code == cbor::cbor_errc::unknown_type);
+
+        std::vector<uint8_t> nested = {0x81,0xf8,0x00};
+        CHECK_FALSE(cbor::view::scan_prefix(jsoncons::span<const uint8_t>(nested)).has_value());
+
+        std::vector<uint8_t> at_32 = {0xf8,0x20};
+        auto at_32_result = cbor::view::parse_exact(jsoncons::span<const uint8_t>(at_32));
+        REQUIRE(at_32_result.has_value());
+        CHECK(at_32_result.value().kind() == cbor::view::item_kind::simple);
+        CHECK(at_32_result.value().argument() == 32);
     }
 }
 
-TEST_CASE("cbor view items compare in deterministic encoding key orders")
+TEST_CASE("cbor view item exposes wire structure")
+{
+    SECTION("kinds follow the untagged major type")
+    {
+        CHECK(parse({0x00}).kind() == cbor::view::item_kind::unsigned_integer);
+        CHECK(parse({0x20}).kind() == cbor::view::item_kind::negative_integer);
+        CHECK(parse({0x41,0x01}).kind() == cbor::view::item_kind::byte_string);
+        CHECK(parse({0x61,'a'}).kind() == cbor::view::item_kind::text_string);
+        CHECK(parse({0x80}).kind() == cbor::view::item_kind::array);
+        CHECK(parse({0xa0}).kind() == cbor::view::item_kind::map);
+        CHECK(parse({0xf4}).kind() == cbor::view::item_kind::simple);
+    }
+
+    SECTION("argument exposes the head argument")
+    {
+        CHECK(parse({0x0a}).argument() == 10);
+        CHECK(parse({0x18,0x64}).argument() == 100);
+        CHECK(parse({0x63,'a','b','c'}).argument() == 3);
+        CHECK(parse({0x82,0x01,0x02}).argument() == 2);
+        CHECK(parse({0xf6}).argument() == 22);   // null
+        CHECK(parse({0xf7}).argument() == 23);   // undefined
+    }
+
+    SECTION("indefinite length is visible")
+    {
+        std::vector<uint8_t> data = {0x9f,0x01,0xff};
+        cbor::view::item scanned = parse(data);
+        CHECK(scanned.indefinite());
+        CHECK(scanned.argument() == 0);
+        CHECK_FALSE(parse({0x81,0x01}).indefinite());
+    }
+
+    SECTION("tags are exposed, not interpreted")
+    {
+        std::vector<uint8_t> data = {0xd8,0x40,0xc2,0x42,0x01,0x02};   // tag 64, tag 2, bytes
+        cbor::view::item tagged = parse(data);
+        CHECK(tagged.kind() == cbor::view::item_kind::byte_string);
+
+        std::vector<uint64_t> tags;
+        for (uint64_t tag : tagged.tags())
+        {
+            tags.push_back(tag);
+        }
+        CHECK((tags == std::vector<uint64_t>{64,2}));
+
+        std::vector<uint8_t> untagged = {0x01};
+        CHECK(parse(untagged).tags().empty());
+    }
+
+    SECTION("encoded_bytes covers the whole item, tags included")
+    {
+        std::vector<uint8_t> data = {0xc1,0x0a};
+        cbor::view::item tagged = parse(data);
+        CHECK(tagged.encoded_bytes().data() == data.data());
+        CHECK(tagged.encoded_bytes().size() == data.size());
+    }
+}
+
+TEST_CASE("cbor view typed accessors")
+{
+    SECTION("uint64_value")
+    {
+        uint64_t v = 0;
+        CHECK(parse({0x00}).uint64_value(v));
+        CHECK(v == 0);
+        CHECK(parse({0x1b,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff}).uint64_value(v));
+        CHECK(v == (std::numeric_limits<uint64_t>::max)());
+
+        CHECK_FALSE(parse({0x20}).uint64_value(v));
+        CHECK_FALSE(parse({0x61,'a'}).uint64_value(v));
+    }
+
+    SECTION("int64_value")
+    {
+        int64_t v = 0;
+        CHECK(parse({0x0a}).int64_value(v));
+        CHECK(v == 10);
+        CHECK(parse({0x20}).int64_value(v));
+        CHECK(v == -1);
+        CHECK(parse({0x1b,0x7f,0xff,0xff,0xff,0xff,0xff,0xff,0xff}).int64_value(v));
+        CHECK(v == (std::numeric_limits<int64_t>::max)());
+        CHECK(parse({0x3b,0x7f,0xff,0xff,0xff,0xff,0xff,0xff,0xff}).int64_value(v));
+        CHECK(v == (std::numeric_limits<int64_t>::min)());
+
+        CHECK_FALSE(parse({0x1b,0x80,0x00,0x00,0x00,0x00,0x00,0x00,0x00}).int64_value(v));
+        CHECK_FALSE(parse({0x3b,0x80,0x00,0x00,0x00,0x00,0x00,0x00,0x00}).int64_value(v));
+    }
+
+    SECTION("bool_value")
+    {
+        bool v = false;
+        CHECK(parse({0xf5}).bool_value(v));
+        CHECK(v);
+        CHECK(parse({0xf4}).bool_value(v));
+        CHECK_FALSE(v);
+        CHECK_FALSE(parse({0xf6}).bool_value(v));
+    }
+
+    SECTION("double_value")
+    {
+        double v = 0;
+        CHECK(parse({0xf9,0x3c,0x00}).double_value(v));
+        CHECK(v == 1.0);
+        CHECK(parse({0xf9,0x7c,0x00}).double_value(v));
+        CHECK(v == std::numeric_limits<double>::infinity());
+        CHECK(parse({0xfa,0x3f,0xc0,0x00,0x00}).double_value(v));
+        CHECK(v == 1.5);
+        CHECK(parse({0xfb,0x3f,0xf1,0x99,0x99,0x99,0x99,0x99,0x9a}).double_value(v));
+        CHECK(v == 1.1);
+
+        CHECK_FALSE(parse({0x01}).double_value(v));
+    }
+
+    SECTION("a tagged scalar still reads, with its tag visible")
+    {
+        std::vector<uint8_t> data = {0xc1,0x0a};   // tag 1 (epoch time) 10
+        cbor::view::item tagged = parse(data);
+        CHECK_FALSE(tagged.tags().empty());
+        uint64_t v = 0;
+        CHECK(tagged.uint64_value(v));
+        CHECK(v == 10);
+    }
+
+    SECTION("text views definite strings in place")
+    {
+        std::vector<uint8_t> data = {0x63,'a','b','c'};
+        cbor::view::item text_item = parse(data);
+        jsoncons::string_view sv;
+        REQUIRE(text_item.text(sv));
+        CHECK(std::string(sv.data(), sv.size()) == "abc");
+        CHECK(reinterpret_cast<const uint8_t*>(sv.data()) == data.data() + 1);
+
+        std::vector<uint8_t> empty = {0x60};
+        REQUIRE(parse(empty).text(sv));
+        CHECK(sv.empty());
+
+        std::vector<uint8_t> chunked = {0x7f,0x61,'a',0xff};
+        CHECK_FALSE(parse(chunked).text(sv));
+        std::vector<uint8_t> bytes = {0x41,0x01};
+        CHECK_FALSE(parse(bytes).text(sv));
+    }
+
+    SECTION("bytes views definite strings in place")
+    {
+        std::vector<uint8_t> data = {0x43,0x01,0x02,0x03};
+        jsoncons::span<const uint8_t> bs;
+        REQUIRE(parse(data).bytes(bs));
+        CHECK(bs.data() == data.data() + 1);
+        CHECK(bs.size() == 3);
+    }
+}
+
+TEST_CASE("cbor view copying accessors are transactional")
+{
+    SECTION("text assembles chunked strings")
+    {
+        std::string s;
+        REQUIRE(parse({0x63,'a','b','c'}).text(s));
+        CHECK(s == "abc");
+        REQUIRE(parse({0x7f,0x62,'h','e',0x63,'l','l','o',0xff}).text(s));
+        CHECK(s == "hello");
+        REQUIRE(parse({0x7f,0xff}).text(s));
+        CHECK(s.empty());
+    }
+
+    SECTION("bytes assembles chunked strings")
+    {
+        std::vector<uint8_t> buffer;
+        REQUIRE(parse({0x5f,0x41,0x01,0x42,0x02,0x03,0xff}).bytes(buffer));
+        CHECK((buffer == std::vector<uint8_t>{0x01,0x02,0x03}));
+    }
+
+    SECTION("the destination is untouched on kind mismatch")
+    {
+        std::string s = "sentinel";
+        CHECK_FALSE(parse({0x41,0x01}).text(s));
+        CHECK(s == "sentinel");
+
+        std::vector<uint8_t> buffer = {0xaa};
+        CHECK_FALSE(parse({0x61,'a'}).bytes(buffer));
+        CHECK((buffer == std::vector<uint8_t>{0xaa}));
+    }
+
+    SECTION("the destination may alias the scanned bytes")
+    {
+        std::vector<uint8_t> data = {0x42,0x01,0x02};
+        auto result = cbor::view::parse_exact(jsoncons::span<const uint8_t>(data));
+        REQUIRE(result.has_value());
+        REQUIRE(result.value().bytes(data));   // the item borrows `data` itself
+        CHECK((data == std::vector<uint8_t>{0x01,0x02}));
+    }
+}
+
+TEST_CASE("cbor view container ranges")
+{
+    SECTION("elements are checked items in order")
+    {
+        // [1, "hi", [2, 3]]
+        std::vector<uint8_t> data = {0x83,0x01,0x62,'h','i',0x82,0x02,0x03};
+        cbor::view::item array_item = parse(data);
+
+        std::vector<cbor::view::item_kind> kinds;
+        std::vector<std::size_t> offsets;
+        for (cbor::view::item element : array_item.elements())
+        {
+            kinds.push_back(element.kind());
+            offsets.push_back(static_cast<std::size_t>(element.encoded_bytes().data() - data.data()));
+        }
+        CHECK((kinds == std::vector<cbor::view::item_kind>{
+            cbor::view::item_kind::unsigned_integer,
+            cbor::view::item_kind::text_string,
+            cbor::view::item_kind::array}));
+        CHECK((offsets == std::vector<std::size_t>{1,2,5}));
+    }
+
+    SECTION("nested containers iterate recursively")
+    {
+        std::vector<uint8_t> data = {0x82,0x81,0x0a,0x82,0x0b,0x0c};   // [[10],[11,12]]
+        uint64_t sum = 0;
+        for (cbor::view::item inner : parse(data).elements())
+        {
+            for (cbor::view::item element : inner.elements())
+            {
+                uint64_t v = 0;
+                REQUIRE(element.uint64_value(v));
+                sum += v;
+            }
+        }
+        CHECK(sum == 33);
+    }
+
+    SECTION("indefinite arrays iterate and may stop early")
+    {
+        std::vector<uint8_t> data = {0x9f,0x01,0x02,0x03,0xff};
+        std::size_t count = 0;
+        for (cbor::view::item element : parse(data).elements())
+        {
+            (void)element;
+            if (++count == 2)
+            {
+                break;
+            }
+        }
+        CHECK(count == 2);
+    }
+
+    SECTION("entries expose checked keys and values")
+    {
+        // {1: "a", "k": 2}
+        std::vector<uint8_t> data = {0xa2,0x01,0x61,0x61,0x61,0x6b,0x02};
+        std::size_t count = 0;
+        for (cbor::view::map_entry entry : parse(data).entries())
+        {
+            if (count == 0)
+            {
+                uint64_t k = 0;
+                REQUIRE(entry.key.uint64_value(k));
+                CHECK(k == 1);
+                jsoncons::string_view v;
+                REQUIRE(entry.value.text(v));
+                CHECK(std::string(v.data(), v.size()) == "a");
+                CHECK(entry.key.encoded_bytes().data() == data.data() + 1);
+                CHECK(entry.value.encoded_bytes().data() == data.data() + 2);
+            }
+            else
+            {
+                jsoncons::string_view k;
+                REQUIRE(entry.key.text(k));
+                CHECK(std::string(k.data(), k.size()) == "k");
+                uint64_t v = 0;
+                REQUIRE(entry.value.uint64_value(v));
+                CHECK(v == 2);
+            }
+            ++count;
+        }
+        CHECK(count == 2);
+    }
+
+    SECTION("indefinite and tagged maps iterate alike")
+    {
+        std::vector<uint8_t> indefinite = {0xbf,0x01,0x02,0x03,0x04,0xff};
+        std::size_t count = 0;
+        for (cbor::view::map_entry entry : parse(indefinite).entries())
+        {
+            (void)entry;
+            ++count;
+        }
+        CHECK(count == 2);
+
+        std::vector<uint8_t> tagged = {0xc0,0xa1,0x01,0x02};
+        cbor::view::item tagged_map = parse(tagged);
+        CHECK_FALSE(tagged_map.tags().empty());
+        count = 0;
+        for (cbor::view::map_entry entry : tagged_map.entries())
+        {
+            (void)entry;
+            ++count;
+        }
+        CHECK(count == 1);
+    }
+
+    SECTION("mismatched and empty ranges are empty")
+    {
+        CHECK(parse({0x80}).elements().empty());
+        CHECK(parse({0xa0}).entries().empty());
+        CHECK(parse({0x9f,0xff}).elements().empty());
+        CHECK(parse({0xbf,0xff}).entries().empty());
+        CHECK(parse({0xa1,0x01,0x02}).elements().empty());   // a map has no elements
+        CHECK(parse({0x81,0x01}).entries().empty());         // an array has no entries
+        CHECK(parse({0x01}).elements().empty());
+    }
+}
+
+TEST_CASE("cbor view string chunks")
+{
+    SECTION("a definite string is one chunk in place")
+    {
+        std::vector<uint8_t> data = {0x63,'a','b','c'};
+        std::size_t count = 0;
+        for (jsoncons::span<const uint8_t> chunk : parse(data).chunks())
+        {
+            CHECK(chunk.data() == data.data() + 1);
+            CHECK(chunk.size() == 3);
+            ++count;
+        }
+        CHECK(count == 1);
+    }
+
+    SECTION("an indefinite string is one chunk per piece")
+    {
+        std::vector<uint8_t> data = {0x7f,0x62,'h','e',0x63,'l','l','o',0xff};
+        std::vector<std::size_t> sizes;
+        for (jsoncons::span<const uint8_t> chunk : parse(data).chunks())
+        {
+            sizes.push_back(chunk.size());
+        }
+        CHECK((sizes == std::vector<std::size_t>{2,3}));
+
+        CHECK(parse({0x5f,0xff}).chunks().empty());
+    }
+
+    SECTION("non-strings have no chunks")
+    {
+        CHECK(parse({0x01}).chunks().empty());
+        CHECK(parse({0x81,0x41,0x01}).chunks().empty());
+    }
+}
+
+TEST_CASE("cbor view deterministic encoding orders")
 {
     const std::vector<std::vector<uint8_t>> bytewise_sorted = {
         {0x0a},
@@ -164,53 +569,60 @@ TEST_CASE("cbor view items compare in deterministic encoding key orders")
         {0x81,0x18,0x64}
     };
 
-    SECTION("bytewise order matches the RFC 8949 4.2.1 example")
+    SECTION("bytewise_compare matches the RFC 8949 4.2.1 example")
     {
         for (std::size_t i = 0; i < bytewise_sorted.size(); ++i)
         {
             for (std::size_t j = 0; j < bytewise_sorted.size(); ++j)
             {
-                std::error_code ec;
-                const int r = cbor::view::compare(jsoncons::span<const uint8_t>(bytewise_sorted[i]),
-                    jsoncons::span<const uint8_t>(bytewise_sorted[j]), ec);
-                REQUIRE_FALSE(ec);
+                const int r = cbor::view::bytewise_compare()(parse(bytewise_sorted[i]), parse(bytewise_sorted[j]));
                 CHECK((i < j ? r < 0 : (i > j ? r > 0 : r == 0)));
             }
         }
     }
 
-    SECTION("length-first order matches the RFC 8949 4.2.3 example")
+    SECTION("length_first_compare matches the RFC 8949 4.2.3 example")
     {
         for (std::size_t i = 0; i < length_first_sorted.size(); ++i)
         {
             for (std::size_t j = 0; j < length_first_sorted.size(); ++j)
             {
-                std::error_code ec;
-                const int r = cbor::view::compare(jsoncons::span<const uint8_t>(length_first_sorted[i]),
-                    jsoncons::span<const uint8_t>(length_first_sorted[j]), ec, cbor::view::length_first_order());
-                REQUIRE_FALSE(ec);
+                const int r = cbor::view::length_first_compare()(parse(length_first_sorted[i]), parse(length_first_sorted[j]));
                 CHECK((i < j ? r < 0 : (i > j ? r > 0 : r == 0)));
             }
         }
     }
 
-    SECTION("other orderings can be plugged in")
+    SECTION("the less predicates sort into the deterministic orders")
     {
-        struct reverse_bytewise_order
+        struct bytewise_vector_less
         {
-            int operator()(jsoncons::span<const uint8_t> a, jsoncons::span<const uint8_t> b) const noexcept
+            bool operator()(const std::vector<uint8_t>& a, const std::vector<uint8_t>& b) const
             {
-                return -cbor::view::bytewise_order()(a, b);
+                return cbor::view::bytewise_less()(jsoncons::span<const uint8_t>(a), jsoncons::span<const uint8_t>(b));
+            }
+        };
+
+        std::vector<std::vector<uint8_t>> shuffled = bytewise_sorted;
+        std::reverse(shuffled.begin(), shuffled.end());
+        std::sort(shuffled.begin(), shuffled.end(), bytewise_vector_less());
+        CHECK(shuffled == bytewise_sorted);
+    }
+
+    SECTION("other orders can be plugged in")
+    {
+        struct reverse_bytewise_compare
+        {
+            int operator()(const cbor::view::item& a, const cbor::view::item& b) const noexcept
+            {
+                return -cbor::view::bytewise_compare()(a, b);
             }
         };
 
         std::vector<uint8_t> ten = {0x0a};
         std::vector<uint8_t> hundred = {0x18,0x64};
-        std::error_code ec;
-        CHECK(cbor::view::compare(jsoncons::span<const uint8_t>(ten), jsoncons::span<const uint8_t>(hundred), ec) < 0);
-        REQUIRE_FALSE(ec);
-        CHECK(cbor::view::compare(jsoncons::span<const uint8_t>(ten), jsoncons::span<const uint8_t>(hundred), ec, reverse_bytewise_order()) > 0);
-        REQUIRE_FALSE(ec);
+        CHECK(cbor::view::bytewise_compare()(parse(ten), parse(hundred)) < 0);
+        CHECK(reverse_bytewise_compare()(parse(ten), parse(hundred)) > 0);
     }
 }
 
@@ -220,28 +632,54 @@ TEST_CASE("cbor view map_keys_sorted")
     {
         std::vector<uint8_t> sorted_map = {0xa2,0x01,0x61,0x61,0x61,0x6b,0x02};
         std::vector<uint8_t> unsorted_map = {0xa2,0x61,0x6b,0x02,0x01,0x61,0x61};
-        std::error_code ec;
-        CHECK(cbor::view::map_keys_sorted(jsoncons::span<const uint8_t>(sorted_map), ec));
-        CHECK_FALSE(ec);
-        CHECK_FALSE(cbor::view::map_keys_sorted(jsoncons::span<const uint8_t>(unsorted_map), ec));
-        CHECK_FALSE(ec);
+        CHECK(cbor::view::map_keys_sorted(parse(sorted_map)));
+        CHECK_FALSE(cbor::view::map_keys_sorted(parse(unsorted_map)));
     }
 
     SECTION("duplicate keys are not sorted")
     {
         std::vector<uint8_t> dup_map = {0xa2,0x01,0x00,0x01,0x01};
-        std::error_code ec;
-        CHECK_FALSE(cbor::view::map_keys_sorted(jsoncons::span<const uint8_t>(dup_map), ec));
-        CHECK_FALSE(ec);
+        CHECK_FALSE(cbor::view::map_keys_sorted(parse(dup_map)));
     }
 
     SECTION("bytewise and length-first orders can disagree")
     {
         std::vector<uint8_t> m = {0xa2,0x18,0x64,0x00,0x20,0x00};
-        std::error_code ec;
-        CHECK(cbor::view::map_keys_sorted(jsoncons::span<const uint8_t>(m), ec));
-        CHECK_FALSE(ec);
-        CHECK_FALSE(cbor::view::map_keys_sorted(jsoncons::span<const uint8_t>(m), ec, cbor::view::length_first_order()));
-        CHECK_FALSE(ec);
+        CHECK(cbor::view::map_keys_sorted(parse(m)));
+        CHECK_FALSE(cbor::view::map_keys_sorted(parse(m), cbor::view::length_first_compare()));
+    }
+
+    SECTION("non-maps are not sorted maps")
+    {
+        CHECK_FALSE(cbor::view::map_keys_sorted(parse({0x81,0x01})));
+        CHECK_FALSE(cbor::view::map_keys_sorted(parse({0x01})));
+    }
+}
+
+TEST_CASE("cbor view validate_text")
+{
+    SECTION("well-formed UTF-8 passes")
+    {
+        CHECK(cbor::view::validate_text(parse({0x63,'a','b','c'})));
+        CHECK(cbor::view::validate_text(parse({0x62,0xc3,0xa9})));
+        CHECK(cbor::view::validate_text(parse({0x7f,0x62,0xc3,0xa9,0x61,'a',0xff})));
+    }
+
+    SECTION("ill-formed UTF-8 is rejected")
+    {
+        CHECK_FALSE(cbor::view::validate_text(parse({0x62,0xc3,0x28})));
+        CHECK_FALSE(cbor::view::validate_text(parse({0x61,0x80})));
+    }
+
+    SECTION("a multibyte sequence may not straddle chunks")
+    {
+        // RFC 8949 3.2.3
+        CHECK_FALSE(cbor::view::validate_text(parse({0x7f,0x61,0xc3,0x61,0xa9,0xff})));
+    }
+
+    SECTION("non-text items are not valid text")
+    {
+        CHECK_FALSE(cbor::view::validate_text(parse({0x01})));
+        CHECK_FALSE(cbor::view::validate_text(parse({0x41,0x61})));
     }
 }


### PR DESCRIPTION
OK - I had a long hard look and wrangled the robot into something I am much happier with.

A view fuzzer is also here, and parser fixes are in https://github.com/danielaparker/jsoncons/pull/731