### PR TITLE
Fix CBOR parser well-formedness defects

### DIFF
--- a/include/jsoncons_ext/cbor/cbor_parser.hpp
+++ b/include/jsoncons_ext/cbor/cbor_parser.hpp
@@ -1350,6 +1350,7 @@ private:
             {
                 return;
             }
+            const std::size_t offset = v.size();
             if (source_reader<Source>::read(source_, v, length) != length)
             {
                 ec = cbor_errc::unexpected_eof;
@@ -1358,7 +1359,21 @@ private:
             {
                 return;
             }
-        } 
+            if (type == jsoncons::cbor::detail::cbor_major_type::text_string)
+            {
+                // RFC 8949 3.2.3: each chunk of an indefinite-length text
+                // string must itself be well-formed UTF-8, so a code point
+                // may not be split across chunks.
+                auto result = unicode_traits::validate(
+                    reinterpret_cast<const char*>(v.data()) + offset, length);
+                if (result.ec != unicode_traits::unicode_errc())
+                {
+                    ec = cbor_errc::invalid_utf8_text_string;
+                    more_ = false;
+                    return;
+                }
+            }
+        }
     }
 
     uint64_t read_uint64(std::error_code& ec)
@@ -1397,7 +1412,12 @@ private:
             case 0x19: // Unsigned integer (two-byte uint16_t follows)
             {
                 uint8_t buf[sizeof(uint16_t)];
-                source_.read(buf, sizeof(uint16_t));
+                if (source_.read(buf, sizeof(uint16_t)) != sizeof(uint16_t))
+                {
+                    ec = cbor_errc::unexpected_eof;
+                    more_ = false;
+                    return val;
+                }
                 val = binary::big_to_native<uint16_t>(buf, sizeof(buf));
                 break;
             }
@@ -1405,7 +1425,12 @@ private:
             case 0x1a: // Unsigned integer (four-byte uint32_t follows)
             {
                 uint8_t buf[sizeof(uint32_t)];
-                source_.read(buf, sizeof(uint32_t));
+                if (source_.read(buf, sizeof(uint32_t)) != sizeof(uint32_t))
+                {
+                    ec = cbor_errc::unexpected_eof;
+                    more_ = false;
+                    return val;
+                }
                 val = binary::big_to_native<uint32_t>(buf, sizeof(buf));
                 break;
             }
@@ -1413,7 +1438,12 @@ private:
             case 0x1b: // Unsigned integer (eight-byte uint64_t follows)
             {
                 uint8_t buf[sizeof(uint64_t)];
-                source_.read(buf, sizeof(uint64_t));
+                if (source_.read(buf, sizeof(uint64_t)) != sizeof(uint64_t))
+                {
+                    ec = cbor_errc::unexpected_eof;
+                    more_ = false;
+                    return val;
+                }
                 val = binary::big_to_native<uint64_t>(buf, sizeof(buf));
                 break;
             }

--- a/test/cbor/src/cbor_reader_tests.cpp
+++ b/test/cbor/src/cbor_reader_tests.cpp
@@ -738,3 +738,70 @@ TEST_CASE("CBOR stringref tag 3")
 
     CHECK(expected == j);
 }
+
+namespace {
+
+    std::error_code parse_cbor_error(const std::vector<uint8_t>& v)
+    {
+        std::error_code ec;
+        jsoncons::json_decoder<json> decoder;
+        cbor_bytes_reader reader(v, decoder);
+        reader.read(ec);
+
+        // the stream source must agree with the bytes source
+        std::string s(v.begin(), v.end());
+        std::istringstream is(s);
+        std::error_code stream_ec;
+        jsoncons::json_decoder<json> stream_decoder;
+        cbor_stream_reader stream_reader(is, stream_decoder);
+        stream_reader.read(stream_ec);
+        CHECK(stream_ec == ec);
+
+        return ec;
+    }
+
+} // namespace
+
+TEST_CASE("cbor truncated multibyte heads are rejected")
+{
+    SECTION("truncated integer arguments")
+    {
+        CHECK(parse_cbor_error({0x19,0x01}) == cbor_errc::unexpected_eof);           // uint16
+        CHECK(parse_cbor_error({0x1a,0xff}) == cbor_errc::unexpected_eof);           // uint32
+        CHECK(parse_cbor_error({0x1a,0xff,0xff,0xff}) == cbor_errc::unexpected_eof);
+        CHECK(parse_cbor_error({0x1b,0x01,0x02}) == cbor_errc::unexpected_eof);      // uint64
+    }
+
+    SECTION("truncated half-precision float")
+    {
+        CHECK(parse_cbor_error({0xf9,0x3c}) == cbor_errc::unexpected_eof);
+    }
+
+    SECTION("complete heads still parse")
+    {
+        check_parse_cbor({0x19,0x01,0x00}, json(256));
+        check_parse_cbor({0x1a,0xff,0x00,0x00,0x00}, json(4278190080ULL));
+        // a complete half head still reads through the same two-byte path
+        json half = decode_cbor<json>(std::vector<uint8_t>{0xf9,0x3c,0x00});
+        CHECK(half.as<double>() == 1.0);
+    }
+}
+
+TEST_CASE("cbor indefinite length text chunks are validated individually")
+{
+    SECTION("a code point split across chunks is rejected")
+    {
+        // RFC 8949 3.2.3
+        CHECK(parse_cbor_error({0x7f,0x61,0xc3,0x61,0xa9,0xff}) == cbor_errc::invalid_utf8_text_string);
+    }
+
+    SECTION("well-formed chunks are accepted")
+    {
+        check_parse_cbor({0x7f,0x62,0xc3,0xa9,0x61,0x61,0xff}, json(std::string("\xc3\xa9""a")));
+    }
+
+    SECTION("byte string chunks are not text")
+    {
+        check_parse_cbor({0x5f,0x41,0xc3,0xff}, json(byte_string({0xc3})));
+    }
+}


### PR DESCRIPTION
truncated-integer and split-UTF-8 inputs that used to decode now (correctly) error, which I believe is the last disagreement between parser and view with regard to validity
