### PR TITLE
Add cbor_view low-level tier and span orders

### DIFF
--- a/doc/ref/cbor/cbor_view.md
+++ b/doc/ref/cbor/cbor_view.md
@@ -8,11 +8,14 @@
 
 The `cbor::view` namespace reads the *encoded* structure of
 [Concise Binary Object Representation](http://cbor.io/) data in place,
-without copying it or building a data structure. It is a deliberately
-narrow, wire-level facility: scanning validates that bytes are
-well-formed CBOR once, and everything afterwards operates on checked
-`item` views and cannot fail structurally. Semantic interpretation —
-what tag 2 bytes or a tag 25 string reference *mean* — belongs to
+without copying it or building a data structure. Its spine is four stages:
+
+> owned bytes -> structural validation -> borrowed checked items -> application semantics
+
+A scan validates that bytes are *structurally* well-formed CBOR once
+(framing only — not validity such as UTF-8); everything afterwards
+operates on checked `item` views and cannot fail structurally. The last
+stage — what tag 2 bytes or a tag 25 string reference *mean* — belongs to
 [decode_cbor](decode_cbor.md) and [basic_cbor_cursor](basic_cbor_cursor.md),
 not here: tags are exposed, never interpreted.
 
@@ -142,6 +145,15 @@ struct length_first_less;
 
 template <typename Compare = bytewise_compare>
 bool map_keys_sorted(const item& map_item, Compare compare = Compare());
+
+// Span overloads for raw-span consumers; validate input, then order.
+template <typename Order = bytewise_compare>
+expected<int, scan_error> compare(span<const uint8_t> a, span<const uint8_t> b,
+    Order order = Order(), int max_nesting_depth = default_max_nesting_depth);
+
+template <typename Order = bytewise_compare>
+expected<bool, scan_error> map_keys_sorted(span<const uint8_t> input,
+    Order order = Order(), int max_nesting_depth = default_max_nesting_depth);
 ```
 
 The order function objects compare encoded bytes and accept either two
@@ -149,8 +161,27 @@ items or two raw `span<const uint8_t>`. The `*_compare` forms return
 negative, zero, or positive; the `*_less` forms are predicates for
 `std::sort` and ordered containers. `map_keys_sorted` is true if
 `map_item` is a map whose keys are strictly ascending in the given
-order — the deterministic-encoding key condition — and does not
-allocate.
+order — the deterministic-encoding key condition. The span overloads
+validate before ordering and, on malformed input, return an error carrying
+the code and byte offset; trailing bytes after the first item are tolerated.
+
+#### Low-level tier
+
+```cpp
+enum class major_type;   // CBOR major types 0-7
+
+struct item_head { major_type major_type; uint8_t additional_info; uint64_t value; bool indefinite(); };
+
+bool read_head(const uint8_t*& p, const uint8_t* end, item_head& head, std::error_code& ec);
+bool skip_item(const uint8_t*& p, const uint8_t* end, std::error_code& ec,
+    int max_nesting_depth = default_max_nesting_depth);
+```
+
+The wire-level head decoding the checked item layer is built on, for
+consumers that need sub-item head access. Prefer the checked item layer
+unless you are walking objects yourself with intention. `read_head`
+advances `p` past one head only (tags are returned as their own heads) and
+validates just that head; `skip_item` advances past one complete item.
 
 ### Examples
 

--- a/fuzzers/fuzz_cbor_view.cpp
+++ b/fuzzers/fuzz_cbor_view.cpp
@@ -149,6 +149,72 @@ namespace {
         (void)map_keys_sorted(scanned, length_first_compare());
     }
 
+    void exercise_lowlevel(byte_span input)
+    {
+        const uint8_t* const end = input.data() + input.size();
+
+        // read_head walks heads, always advancing; ok <=> !ec.
+        const uint8_t* p = input.data();
+        for (int steps = 0; steps < 64 && p < end; ++steps)
+        {
+            const uint8_t* before = p;
+            item_head head;
+            std::error_code ec;
+            const bool ok = read_head(p, end, head, ec);
+            require(ok != static_cast<bool>(ec));
+            require(p >= before && p <= end);
+            if (!ok)
+            {
+                break;
+            }
+            require(p > before);
+        }
+
+        // skip_item agrees with scan_prefix on outcome and consumed length.
+        const uint8_t* sp = input.data();
+        std::error_code ec;
+        const bool ok = skip_item(sp, end, ec);
+        require(ok != static_cast<bool>(ec));
+        scan_context context;
+        auto scanned = scan_prefix(input, context);
+        require(ok == scanned.has_value());
+        if (ok)
+        {
+            require(sp == input.data() + scanned.value().first.encoded_bytes().size());
+        }
+    }
+
+    void exercise_span_orders(byte_span a, byte_span b)
+    {
+        auto ab = compare(a, b);
+        auto ba = compare(b, a);
+        if (ab.has_value() && ba.has_value())
+        {
+            require(sign(ab.value()) == -sign(ba.value()));
+        }
+
+        scan_context ca;
+        auto sa = scan_prefix(a, ca);
+        scan_context cb;
+        auto sb = scan_prefix(b, cb);
+        if (sa.has_value() && sb.has_value())
+        {
+            require(ab.has_value());
+            require(sign(ab.value()) == sign(bytewise_compare()(sa.value().first, sb.value().first)));
+        }
+        else
+        {
+            require(!ab.has_value());
+        }
+
+        auto sorted = map_keys_sorted(a);
+        require(sorted.has_value() == sa.has_value());
+        if (sorted.has_value())
+        {
+            require(sorted.value() == map_keys_sorted(sa.value().first));
+        }
+    }
+
     void exercise_input(byte_span input, scan_context& context)
     {
         auto scanned = scan_prefix(input, context);
@@ -205,6 +271,10 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, std::size_t size)
 
     const int fuzz_depth = size <= 2 ? default_max_nesting_depth : static_cast<int>(base[2] & 0x0f);
     const int depths[] = {0, 1, fuzz_depth, default_max_nesting_depth};
+
+    exercise_lowlevel(input);
+    exercise_span_orders(byte_span(base, mid), byte_span(base + mid, size - mid));
+    exercise_span_orders(input, byte_span(base + p0, size - p0));
 
     for (int depth : depths)
     {

--- a/include/jsoncons_ext/cbor/cbor_view.hpp
+++ b/include/jsoncons_ext/cbor/cbor_view.hpp
@@ -52,6 +52,19 @@ namespace view {
         simple
     };
 
+    // The CBOR major type
+    enum class major_type : uint8_t
+    {
+        unsigned_integer = 0,
+        negative_integer = 1,
+        byte_string = 2,
+        text_string = 3,
+        array = 4,
+        map = 5,
+        semantic_tag = 6,
+        simple = 7
+    };
+
     struct scan_error
     {
         cbor_errc code;
@@ -683,6 +696,45 @@ namespace view {
 
     } // namespace detail_view
 
+    // ---- Low-level tier ----
+    // The wire-level head decoding the checked item layer is built on, for
+    // consumers that need sub-item head access. Prefer the checked item layer
+    // unless you are walking objects yourself with intention.
+
+    struct item_head
+    {
+        view::major_type major_type{};
+        uint8_t additional_info{0};
+        uint64_t value{0};
+
+        bool indefinite() const noexcept
+        {
+            return additional_info == 31;   // additional-info 31 = indefinite length
+        }
+    };
+
+    // Reads one head, advancing p past the head only; tags read as their own heads.
+    inline bool read_head(const uint8_t*& p, const uint8_t* end, item_head& head, std::error_code& ec)
+    {
+        detail_view::item_head h;
+        if (!detail_view::read_head(p, end, h, ec))
+        {
+            return false;
+        }
+        head.major_type = static_cast<view::major_type>(static_cast<uint8_t>(h.major_type));
+        head.additional_info = h.additional_info;
+        head.value = h.value;
+        return true;
+    }
+
+    // Advances p past one complete item, bounded by max_nesting_depth.
+    inline bool skip_item(const uint8_t*& p, const uint8_t* end, std::error_code& ec,
+        int max_nesting_depth = default_max_nesting_depth)
+    {
+        detail_view::pending_stack open;
+        return detail_view::skip_item(p, end, max_nesting_depth, open, ec);
+    }
+
     // Iterates the values of an item's leading semantic tags.
     class item::tag_iterator
     {
@@ -1276,14 +1328,30 @@ namespace view {
         const uint8_t* p = input.data();
         const uint8_t* end = p + input.size();
         std::error_code ec;
-        if (!detail_view::skip_item(p, end, context.max_nesting_depth(),
-                detail_view::scan_access::workspace(context), ec))
+
+        // Parse the head once and keep it, so the item is built below without
+        // re-reading its own head.
+        detail_view::item_head head;
+        if (!detail_view::read_value_head(p, end, head, ec))
+        {
+            return expected<scan_result, scan_error>(unexpect,
+                scan_error{detail_view::to_cbor_errc(ec), static_cast<std::size_t>(p - input.data())});
+        }
+        const uint8_t* content = p;
+
+        const bool ok = (head.major_type == cbor::detail::cbor_major_type::array ||
+                         head.major_type == cbor::detail::cbor_major_type::map)
+            ? detail_view::skip_container(p, end, head, context.max_nesting_depth(),
+                  detail_view::scan_access::workspace(context), ec)
+            : detail_view::skip_scalar_or_string(head, p, end, ec);
+        if (!ok)
         {
             return expected<scan_result, scan_error>(unexpect,
                 scan_error{detail_view::to_cbor_errc(ec), static_cast<std::size_t>(p - input.data())});
         }
         return scan_result{
-            detail_view::item_access::make(span<const uint8_t>(input.data(), static_cast<std::size_t>(p - input.data()))),
+            detail_view::item_access::make(
+                span<const uint8_t>(input.data(), static_cast<std::size_t>(p - input.data())), head, content),
             span<const uint8_t>(p, static_cast<std::size_t>(end - p))};
     }
 
@@ -1406,6 +1474,42 @@ namespace view {
             prev = key;
         }
         return true;
+    }
+
+    // Span-based order entry points for raw-span consumers (e.g. collation over
+    // byte-string keys). Each validates its input(s) then orders the encoded
+    // bytes; on malformed input the error carries the code and byte offset.
+    // Trailing bytes after the first item are tolerated.
+
+    template <typename Order = bytewise_compare>
+    expected<int, scan_error> compare(span<const uint8_t> a, span<const uint8_t> b,
+        Order order = Order(), int max_nesting_depth = default_max_nesting_depth)
+    {
+        scan_context context(max_nesting_depth);
+        auto ra = scan_prefix(a, context);
+        if (!ra)
+        {
+            return expected<int, scan_error>(unexpect, ra.error());
+        }
+        auto rb = scan_prefix(b, context);
+        if (!rb)
+        {
+            return expected<int, scan_error>(unexpect, rb.error());
+        }
+        return order(ra.value().first.encoded_bytes(), rb.value().first.encoded_bytes());
+    }
+
+    template <typename Order = bytewise_compare>
+    expected<bool, scan_error> map_keys_sorted(span<const uint8_t> input,
+        Order order = Order(), int max_nesting_depth = default_max_nesting_depth)
+    {
+        scan_context context(max_nesting_depth);
+        auto result = scan_prefix(input, context);
+        if (!result)
+        {
+            return expected<bool, scan_error>(unexpect, result.error());
+        }
+        return map_keys_sorted(result.value().first, order);
     }
 
     // True if `text_item` is a text string whose content is well-formed

--- a/test/cbor/src/cbor_view_tests.cpp
+++ b/test/cbor/src/cbor_view_tests.cpp
@@ -683,3 +683,127 @@ TEST_CASE("cbor view validate_text")
         CHECK_FALSE(cbor::view::validate_text(parse({0x41,0x61})));
     }
 }
+
+TEST_CASE("cbor view low-level tier")
+{
+    SECTION("read_head decodes one head and advances past it only")
+    {
+        std::vector<uint8_t> data = {0x82,0x01,0x02};   // [1, 2]
+        const uint8_t* p = data.data();
+        const uint8_t* end = p + data.size();
+        cbor::view::item_head head;
+        std::error_code ec;
+        REQUIRE(cbor::view::read_head(p, end, head, ec));
+        CHECK_FALSE(ec);
+        CHECK(head.major_type == cbor::view::major_type::array);
+        CHECK(head.value == 2);
+        CHECK(p == data.data() + 1);   // past the head, not the elements
+    }
+
+    SECTION("read_head surfaces tags as their own heads")
+    {
+        std::vector<uint8_t> data = {0xc1,0x0a};   // tag 1, 10
+        const uint8_t* p = data.data();
+        const uint8_t* end = p + data.size();
+        cbor::view::item_head head;
+        std::error_code ec;
+        REQUIRE(cbor::view::read_head(p, end, head, ec));
+        CHECK(head.major_type == cbor::view::major_type::semantic_tag);
+        CHECK(head.value == 1);
+        REQUIRE(cbor::view::read_head(p, end, head, ec));
+        CHECK(head.major_type == cbor::view::major_type::unsigned_integer);
+        CHECK(head.value == 10);
+        CHECK(p == end);
+    }
+
+    SECTION("read_head reports malformed and truncated heads")
+    {
+        std::vector<uint8_t> empty;
+        const uint8_t* p = empty.data();
+        cbor::view::item_head head;
+        std::error_code ec;
+        CHECK_FALSE(cbor::view::read_head(p, p, head, ec));
+        CHECK(ec == cbor::cbor_errc::unexpected_eof);
+
+        std::vector<uint8_t> truncated = {0x19,0x01};
+        p = truncated.data();
+        ec.clear();
+        CHECK_FALSE(cbor::view::read_head(p, p + truncated.size(), head, ec));
+        CHECK(ec == cbor::cbor_errc::unexpected_eof);
+    }
+
+    SECTION("skip_item advances past one complete item")
+    {
+        std::vector<uint8_t> data = {0x82,0x01,0x02,0x63,'a','b','c'};   // [1,2] then "abc"
+        const uint8_t* p = data.data();
+        const uint8_t* end = p + data.size();
+        std::error_code ec;
+        REQUIRE(cbor::view::skip_item(p, end, ec));
+        CHECK(p == data.data() + 3);
+        REQUIRE(cbor::view::skip_item(p, end, ec));
+        CHECK(p == end);
+    }
+
+    SECTION("skip_item honours the depth bound")
+    {
+        std::vector<uint8_t> data = {0x81,0x81,0x01};   // [[1]]
+        const uint8_t* p = data.data();
+        std::error_code ec;
+        CHECK_FALSE(cbor::view::skip_item(p, p + data.size(), ec, 1));
+        CHECK(ec == cbor::cbor_errc::max_nesting_depth_exceeded);
+    }
+}
+
+TEST_CASE("cbor view span-based order entry points")
+{
+    struct reverse_bytewise
+    {
+        int operator()(jsoncons::span<const uint8_t> a, jsoncons::span<const uint8_t> b) const noexcept
+        {
+            return -cbor::view::bytewise_compare()(a, b);
+        }
+    };
+
+    SECTION("compare validates each span then orders, tolerating trailing bytes")
+    {
+        std::vector<uint8_t> ten = {0x0a};
+        std::vector<uint8_t> hundred = {0x18,0x64};
+        std::vector<uint8_t> ten_plus = {0x0a,0x63,'x','y','z'};   // 10 then trailing
+        auto lt = cbor::view::compare(jsoncons::span<const uint8_t>(ten), jsoncons::span<const uint8_t>(hundred));
+        REQUIRE(lt.has_value());
+        CHECK(lt.value() < 0);
+        auto eq = cbor::view::compare(jsoncons::span<const uint8_t>(ten), jsoncons::span<const uint8_t>(ten_plus));
+        REQUIRE(eq.has_value());
+        CHECK(eq.value() == 0);
+        auto rev = cbor::view::compare(jsoncons::span<const uint8_t>(ten), jsoncons::span<const uint8_t>(hundred), reverse_bytewise());
+        REQUIRE(rev.has_value());
+        CHECK(rev.value() > 0);
+    }
+
+    SECTION("compare reports malformed input with an offset")
+    {
+        std::vector<uint8_t> good = {0x01};
+        std::vector<uint8_t> bad = {0x82,0x01,0x1f};   // [1, <invalid>]
+        auto result = cbor::view::compare(jsoncons::span<const uint8_t>(good), jsoncons::span<const uint8_t>(bad));
+        REQUIRE_FALSE(result.has_value());
+        CHECK(result.error().code == cbor::cbor_errc::unknown_type);
+        CHECK(result.error().offset == 3);
+    }
+
+    SECTION("map_keys_sorted over a span matches the item overload")
+    {
+        std::vector<uint8_t> sorted_map = {0xa2,0x01,0x61,0x61,0x61,0x6b,0x02};
+        std::vector<uint8_t> unsorted_map = {0xa2,0x61,0x6b,0x02,0x01,0x61,0x61};
+        auto sorted = cbor::view::map_keys_sorted(jsoncons::span<const uint8_t>(sorted_map));
+        REQUIRE(sorted.has_value());
+        CHECK(sorted.value());
+        auto unsorted = cbor::view::map_keys_sorted(jsoncons::span<const uint8_t>(unsorted_map));
+        REQUIRE(unsorted.has_value());
+        CHECK_FALSE(unsorted.value());
+
+        std::vector<uint8_t> malformed = {0xa1,0x01};   // key, no value
+        auto bad = cbor::view::map_keys_sorted(jsoncons::span<const uint8_t>(malformed));
+        REQUIRE_FALSE(bad.has_value());
+        CHECK(bad.error().code == cbor::cbor_errc::unexpected_eof);
+    }
+}


### PR DESCRIPTION
OK, at a high level I think this is what I would like to present for your consideration @danielaparker - this is *not* the old JSON-like cbor_view that was quite complex, but a much narrower layer (or pair of layers) where the slogan is basically:

owned bytes -> structural validation -> borrowed checked items -> application semantics

There are some outstanding improvements to come but nothing really fundamental, so while I don't claim this is ready to hit master, I would be grateful for your comments.