### PR TITLE
Ky/cbor view nav refactor

### DIFF
--- a/doc/ref/cbor/cbor_view.md
+++ b/doc/ref/cbor/cbor_view.md
@@ -8,28 +8,30 @@
 
 The `cbor::view` namespace reads the *encoded* structure of
 [Concise Binary Object Representation](http://cbor.io/) data in place,
-without copying it or building a data structure. Its spine is four stages:
+without copying it or building a data structure. Its checked-item layer
+borrows complete encodings; its move-only `navigator` owns reusable traversal
+workspace while borrowing the same bytes. The data flow is:
+> owned bytes -> structural validation -> checked item or navigator -> application semantics
 
-> owned bytes -> structural validation -> borrowed checked items -> application semantics
-
-A scan validates that bytes are *structurally* well-formed CBOR once
-(framing only — not validity such as UTF-8); everything afterwards
-operates on checked `item` views and cannot fail structurally. The last
-stage — what tag 2 bytes or a tag 25 string reference *mean* — belongs to
-[decode_cbor](decode_cbor.md) and [basic_cbor_cursor](basic_cbor_cursor.md),
-not here: tags are exposed, never interpreted.
+Validation checks structural well-formedness once (framing only — not content
+validity such as UTF-8). Checked items and navigator movement then cannot fail
+structurally. The last stage — what tag 2 bytes or a tag 25 string reference
+*mean* — belongs to [decode_cbor](decode_cbor.md) and
+[basic_cbor_cursor](basic_cbor_cursor.md), not here: tags are exposed, never
+interpreted.
 
 This namespace is experimental.
 
 #### Ownership and lifetime
 
-Everything in this namespace borrows. An `item`, the items produced by
-iterating it, and every span and string view obtained from them point
-into the scanned input bytes, and are invalidated by anything that
-invalidates those bytes: destroying the container, mutating it, or any
-reallocation. Scanning a temporary container is rejected at compile
-time. The copying accessors (`text` into `std::string`, `bytes` into
-`std::vector`) are the way to keep content beyond the input's lifetime.
+All views borrow the input bytes. An `item`, a `navigator`, the items produced
+by container ranges, and every span and string view obtained from them are
+invalidated by anything that invalidates those bytes: destroying the container,
+mutating it, or reallocation. A navigator owns only its mutable navigation and
+validation workspace; it does not own the encoded bytes. Factory, reset, and
+`wire_cursor` entry points reject temporary owning containers at compile time.
+The copying item accessors (`text` into `std::string`, `bytes` into
+`std::vector`) retain content independently.
 
 #### Scanning
 
@@ -62,8 +64,92 @@ anything after it as `cbor_errc::trailing_data`.
 
 Scanning enforces `scan_context::max_nesting_depth` (default
 `default_max_nesting_depth`, 1024) using constant call-stack space at
-any depth. It allocates only when nesting exceeds 32 open containers;
-a reused `scan_context` retains that capacity across scans.
+any depth. It allocates only when nesting exceeds 32 open containers; a reused
+`scan_context`, `wire_cursor` with a supplied context, or navigator reset retains
+that validation capacity.
+
+#### Structural navigation
+
+```cpp
+enum class position_role { root, array_element, map_key, map_value };
+
+struct navigation_result
+{
+    navigator first;
+    span<const uint8_t> remainder;
+};
+
+expected<navigation_result, scan_error> navigate_prefix(
+    span<const uint8_t> input,
+    int max_nesting_depth = default_max_nesting_depth);
+
+expected<navigator, scan_error> navigate_exact(
+    span<const uint8_t> input,
+    int max_nesting_depth = default_max_nesting_depth);
+
+class navigator
+{
+public:
+    navigator(navigator&&) noexcept;
+    navigator& operator=(navigator&&) noexcept;
+    navigator(const navigator&) = delete;
+
+    item_kind kind() const noexcept;
+    uint64_t argument() const noexcept;
+    bool indefinite() const noexcept;
+    tag_range tags() const noexcept;
+    position_role role() const noexcept;
+    std::size_t depth() const noexcept;
+
+    bool uint64_value(uint64_t&) const noexcept;
+    bool int64_value(int64_t&) const noexcept;
+    bool bool_value(bool&) const noexcept;
+    bool double_value(double&) const noexcept;
+    bool text(string_view&) const noexcept;
+    bool bytes(span<const uint8_t>&) const noexcept;
+
+    bool enter() noexcept;
+    bool next() noexcept;
+    bool leave() noexcept;
+    void rewind() noexcept;
+
+    item finish_item() noexcept;
+    bool extent_known() const noexcept;
+
+    expected<span<const uint8_t>, scan_error> reset_prefix(
+        span<const uint8_t> input,
+        int max_nesting_depth = default_max_nesting_depth);
+    expected<void, scan_error> reset_exact(
+        span<const uint8_t> input,
+        int max_nesting_depth = default_max_nesting_depth);
+};
+```
+
+A navigator begins at the checked root. `enter()` moves into a nonempty array
+or map; maps expose raw children with alternating key/value roles. `next()`
+moves to the next raw sibling, skipping the current unopened container if
+necessary. At the end of the siblings it returns `false`; `leave()` restores
+the completed parent. Calling `leave()` early skips only the unread remainder.
+`rewind()` restores the root.
+
+The current position exposes its already parsed head and scalar/string content.
+A container child may not yet have a known end. `finish_item()` establishes and
+caches that end, walking the current subtree only when necessary, and returns an
+ordinary complete `item`. `extent_known()` makes that cost visible. Descent after
+`finish_item()` is legal and revisits the subtree.
+
+Validation records the observed peak open-container depth and prepares exactly
+that many frame slots. Movement, subtree skips, and parent restoration use
+indexed assignments into those slots and do not allocate. `reset_prefix` and
+`reset_exact` are transactional and retain both traversal-frame capacity and
+the validation walker's spill capacity across messages.
+
+A known parent boundary propagates to its final definite child. Consequently,
+the last payload in a definite transport tuple can be finished in O(1), even
+when it is a large container. Non-final arbitrary containers have the honest
+O(depth) tradeoff: descend immediately without a pre-walk, or establish/capture
+the exact span with one subtree walk.
+
 
 #### The checked item
 
@@ -194,6 +280,7 @@ remaining bytes without a mutable pointer/end pair. `read_head` advances past
 one head only (tags are returned as their own heads); `read_item` validates and
 returns one complete checked item. Errors report offsets from the beginning of
 the cursor's input.
+ The former public `(const uint8_t*& p, const uint8_t* end)` overloads have been removed; raw pointer pairs remain implementation details only.
 ### Examples
 
 #### Reading a message without copying it

--- a/doc/ref/cbor/cbor_view.md
+++ b/doc/ref/cbor/cbor_view.md
@@ -164,6 +164,7 @@ class item
     tag_range tags() const noexcept;                     // leading tags, outermost first
 
     chunk_range chunks() const noexcept;                 // string content spans
+    child_range children(scan_context& context) const noexcept;   // raw children as items
 
     bool uint64_value(uint64_t& value) const noexcept;
     bool int64_value(int64_t& value) const noexcept;
@@ -191,9 +192,15 @@ length, a container's count, a simple value's number, or the bit
 pattern of a floating-point value.
 
 `chunks()` yields the contiguous spans of a string's content, one per chunk
-for indefinite-length strings. Structural container traversal is intentionally
-provided only by `navigator`, avoiding a second iterator state machine and its
-hidden subtree rescans.
+for indefinite-length strings.
+
+`children(context)` yields a container's raw children in order — array
+elements, or a map's keys and values alternating — each a complete checked
+item, measured once on the way past. The item's bytes are checked, so
+iteration cannot fail; the context, which must outlive the range, supplies
+skip workspace for container children and grows only past 32 open
+containers. `children` serves sibling iteration over checked bytes;
+`navigator` serves stateful traversal with retained parents and extents.
 
 The typed accessors return `false`, leaving `value` untouched, exactly
 when the item is not of the requested kind; conversions are strict.

--- a/doc/ref/cbor/cbor_view.md
+++ b/doc/ref/cbor/cbor_view.md
@@ -172,17 +172,28 @@ enum class major_type;   // CBOR major types 0-7
 
 struct item_head { major_type major_type; uint8_t additional_info; uint64_t value; bool indefinite(); };
 
-bool read_head(const uint8_t*& p, const uint8_t* end, item_head& head, std::error_code& ec);
-bool skip_item(const uint8_t*& p, const uint8_t* end, std::error_code& ec,
-    int max_nesting_depth = default_max_nesting_depth);
+class wire_cursor
+{
+public:
+    wire_cursor() noexcept;
+    explicit wire_cursor(span<const uint8_t> input) noexcept;
+    void reset(span<const uint8_t> input) noexcept;
+
+    std::size_t position() const noexcept;
+    span<const uint8_t> remaining() const noexcept;
+    expected<item_head, scan_error> read_head() noexcept;
+    expected<item, scan_error> read_item(scan_context& context);
+    expected<item, scan_error> read_item(
+        int max_nesting_depth = default_max_nesting_depth);
+};
 ```
 
-The wire-level head decoding the checked item layer is built on, for
-consumers that need sub-item head access. Prefer the checked item layer
-unless you are walking objects yourself with intention. `read_head`
-advances `p` past one head only (tags are returned as their own heads) and
-validates just that head; `skip_item` advances past one complete item.
-
+`wire_cursor` is the offset-based low-level tier for consumers that need
+sub-item head access. It borrows one input span and exposes its position and
+remaining bytes without a mutable pointer/end pair. `read_head` advances past
+one head only (tags are returned as their own heads); `read_item` validates and
+returns one complete checked item. Errors report offsets from the beginning of
+the cursor's input.
 ### Examples
 
 #### Reading a message without copying it

--- a/doc/ref/cbor/cbor_view.md
+++ b/doc/ref/cbor/cbor_view.md
@@ -266,8 +266,7 @@ complete item, returning its encoded bytes unparsed; `skip` advances past
 `count` bytes of already-measured content, such as a definite string payload
 after its head, refusing when fewer bytes remain. Errors report offsets from
 the beginning of the cursor's input.
-The former public `(const uint8_t*& p, const uint8_t* end)` overloads have
-been removed; raw pointer pairs remain implementation details only.
+
 ### Examples
 
 #### Reading a message without copying it

--- a/doc/ref/cbor/cbor_view.md
+++ b/doc/ref/cbor/cbor_view.md
@@ -252,6 +252,8 @@ public:
     span<const uint8_t> remaining() const noexcept;
     expected<item_head, scan_error> read_head() noexcept;
     expected<item, scan_error> read_item(scan_context& context);
+    expected<span<const uint8_t>, scan_error> skip_item(scan_context& context);
+    bool skip(std::size_t count) noexcept;
 };
 ```
 
@@ -259,8 +261,11 @@ public:
 sub-item head access. It borrows one input span and exposes its position and
 remaining bytes without a mutable pointer/end pair. `read_head` advances past
 one head only (tags are returned as their own heads); `read_item` validates and
-returns one complete checked item. Errors report offsets from the beginning of
-the cursor's input.
+returns one complete checked item; `skip_item` validates and passes over one
+complete item, returning its encoded bytes unparsed; `skip` advances past
+`count` bytes of already-measured content, such as a definite string payload
+after its head, refusing when fewer bytes remain. Errors report offsets from
+the beginning of the cursor's input.
 The former public `(const uint8_t*& p, const uint8_t* end)` overloads have
 been removed; raw pointer pairs remain implementation details only.
 ### Examples

--- a/doc/ref/cbor/cbor_view.md
+++ b/doc/ref/cbor/cbor_view.md
@@ -24,8 +24,8 @@ This namespace is experimental.
 
 #### Ownership and lifetime
 
-All views borrow the input bytes. An `item`, a `navigator`, the items produced
-by container ranges, and every span and string view obtained from them are
+All views borrow the input bytes. An `item`, a `navigator`, and every span or
+string view obtained from them are
 invalidated by anything that invalidates those bytes: destroying the container,
 mutating it, or reallocation. A navigator owns only its mutable navigation and
 validation workspace; it does not own the encoded bytes. Factory, reset, and
@@ -119,7 +119,7 @@ public:
     expected<span<const uint8_t>, scan_error> reset_prefix(
         span<const uint8_t> input,
         int max_nesting_depth = default_max_nesting_depth);
-    expected<void, scan_error> reset_exact(
+    expected<span<const uint8_t>, scan_error> reset_exact(
         span<const uint8_t> input,
         int max_nesting_depth = default_max_nesting_depth);
 };
@@ -138,11 +138,12 @@ caches that end, walking the current subtree only when necessary, and returns an
 ordinary complete `item`. `extent_known()` makes that cost visible. Descent after
 `finish_item()` is legal and revisits the subtree.
 
-Validation records the observed peak open-container depth and prepares exactly
-that many frame slots. Movement, subtree skips, and parent restoration use
-indexed assignments into those slots and do not allocate. `reset_prefix` and
-`reset_exact` are transactional and retain both traversal-frame capacity and
-the validation walker's spill capacity across messages.
+Validation records the observed peak open-container depth, prepares that many
+navigation frames, and retains the validation scratch. Movement uses indexed
+frames; subtree skips reuse the retained scratch. Neither allocates after
+successful construction. Resets are transactional and retain both capacities.
+Both reset forms return the unconsumed remainder; it is empty after a
+successful exact reset.
 
 A known parent boundary propagates to its final definite child. Consequently,
 the last payload in a definite transport tuple can be finished in O(1), even
@@ -162,8 +163,6 @@ class item
     bool indefinite() const noexcept;
     tag_range tags() const noexcept;                     // leading tags, outermost first
 
-    element_range elements() const noexcept;             // array elements
-    entry_range entries() const noexcept;                // map entries
     chunk_range chunks() const noexcept;                 // string content spans
 
     bool uint64_value(uint64_t& value) const noexcept;
@@ -182,27 +181,19 @@ enum class item_kind
     array, map, simple
 };
 
-struct map_entry
-{
-    item key;
-    item value;
-};
 ```
 
-An `item` is one complete, well-formed encoded item: its leading
+An `item` is one complete, structurally well-formed encoded item: its leading
 semantic tags, head, and content. `kind()` classifies the content after
 tags (`simple` covers major type 7: simple values and floating point);
 `argument()` is the head's argument — an integer's value, a string's
 length, a container's count, a simple value's number, or the bit
 pattern of a floating-point value.
 
-The ranges iterate with plain range-`for` and cannot fail: validation
-already happened. `elements()` and `entries()` yield checked items;
-`chunks()` yields the contiguous spans of a string's content, one per
-chunk for indefinite-length strings. Kind mismatches yield empty
-ranges. Iterating a container walks its encoding, so navigating to
-depth *d* of a document rescans the subtrees on that path; iteration
-beyond 32 levels of nesting inside one item may allocate.
+`chunks()` yields the contiguous spans of a string's content, one per chunk
+for indefinite-length strings. Structural container traversal is intentionally
+provided only by `navigator`, avoiding a second iterator state machine and its
+hidden subtree rescans.
 
 The typed accessors return `false`, leaving `value` untouched, exactly
 when the item is not of the requested kind; conversions are strict.
@@ -229,9 +220,6 @@ struct length_first_compare;   // RFC 8949 4.2.3 order, three-way
 struct bytewise_less;          // strict weak orders for sorting
 struct length_first_less;
 
-template <typename Compare = bytewise_compare>
-bool map_keys_sorted(const item& map_item, Compare compare = Compare());
-
 // Span overloads for raw-span consumers; validate input, then order.
 template <typename Order = bytewise_compare>
 expected<int, scan_error> compare(span<const uint8_t> a, span<const uint8_t> b,
@@ -242,14 +230,11 @@ expected<bool, scan_error> map_keys_sorted(span<const uint8_t> input,
     Order order = Order(), int max_nesting_depth = default_max_nesting_depth);
 ```
 
-The order function objects compare encoded bytes and accept either two
-items or two raw `span<const uint8_t>`. The `*_compare` forms return
-negative, zero, or positive; the `*_less` forms are predicates for
-`std::sort` and ordered containers. `map_keys_sorted` is true if
-`map_item` is a map whose keys are strictly ascending in the given
-order — the deterministic-encoding key condition. The span overloads
-validate before ordering and, on malformed input, return an error carrying
-the code and byte offset; trailing bytes after the first item are tolerated.
+The order function objects compare encoded bytes and accept either two items
+or two raw spans. The `*_compare` forms return a three-way result; the `*_less`
+forms are predicates for sorting and ordered containers. The span-based
+`map_keys_sorted` validates once, then walks keys with a navigator; malformed
+input returns the code and byte offset, and trailing bytes are tolerated.
 
 #### Low-level tier
 
@@ -261,16 +246,12 @@ struct item_head { major_type major_type; uint8_t additional_info; uint64_t valu
 class wire_cursor
 {
 public:
-    wire_cursor() noexcept;
     explicit wire_cursor(span<const uint8_t> input) noexcept;
-    void reset(span<const uint8_t> input) noexcept;
 
     std::size_t position() const noexcept;
     span<const uint8_t> remaining() const noexcept;
     expected<item_head, scan_error> read_head() noexcept;
     expected<item, scan_error> read_item(scan_context& context);
-    expected<item, scan_error> read_item(
-        int max_nesting_depth = default_max_nesting_depth);
 };
 ```
 
@@ -280,7 +261,8 @@ remaining bytes without a mutable pointer/end pair. `read_head` advances past
 one head only (tags are returned as their own heads); `read_item` validates and
 returns one complete checked item. Errors report offsets from the beginning of
 the cursor's input.
- The former public `(const uint8_t*& p, const uint8_t* end)` overloads have been removed; raw pointer pairs remain implementation details only.
+The former public `(const uint8_t*& p, const uint8_t* end)` overloads have
+been removed; raw pointer pairs remain implementation details only.
 ### Examples
 
 #### Reading a message without copying it
@@ -288,55 +270,61 @@ the cursor's input.
 ```cpp
 #include <jsoncons_ext/cbor/cbor_view.hpp>
 #include <iostream>
+#include <utility>
+#include <vector>
 
 int main()
 {
-    // {"id": 42, "name": "ada", "scores": [1, 2]}
+    // {"id": 42, "scores": [1, 2]}
     const std::vector<uint8_t> data = {
-        0xa3,
+        0xa2,
         0x62,'i','d', 0x18,0x2a,
-        0x64,'n','a','m','e', 0x63,'a','d','a',
         0x66,'s','c','o','r','e','s', 0x82,0x01,0x02
     };
 
-    auto doc = jsoncons::cbor::view::parse_exact(
-        jsoncons::span<const uint8_t>(data.data(), data.size()));
-    if (!doc.has_value())
+    auto result = jsoncons::cbor::view::navigate_exact(
+        jsoncons::span<const uint8_t>(data));
+    if (!result)
     {
-        std::cout << "malformed at offset " << doc.error().offset << "\n";
         return 1;
     }
 
-    for (jsoncons::cbor::view::map_entry entry : doc.value().entries())
+    auto nav = std::move(result.value());
+    if (!nav.enter())
+    {
+        return 0;
+    }
+    for (;;)
     {
         jsoncons::string_view name;
-        if (!entry.key.text(name))
+        if (!nav.text(name) || !nav.next())
         {
-            continue;
+            break;
         }
         std::cout << name << ":";
 
         uint64_t number = 0;
-        jsoncons::string_view text;
-        if (entry.value.text(text))
-        {
-            std::cout << " " << text;
-        }
-        else if (entry.value.uint64_value(number))
+        if (nav.uint64_value(number))
         {
             std::cout << " " << number;
         }
-        else
+        else if (nav.enter())
         {
-            for (jsoncons::cbor::view::item element : entry.value.elements())
+            do
             {
-                if (element.uint64_value(number))
+                if (nav.uint64_value(number))
                 {
                     std::cout << " " << number;
                 }
             }
+            while (nav.next());
+            nav.leave();
         }
         std::cout << "\n";
+        if (!nav.next())
+        {
+            break;
+        }
     }
 }
 ```
@@ -344,7 +332,6 @@ int main()
 Output:
 ```
 id: 42
-name: ada
 scores: 1 2
 ```
 

--- a/fuzzers/fuzz_cbor_view.cpp
+++ b/fuzzers/fuzz_cbor_view.cpp
@@ -151,36 +151,36 @@ namespace {
 
     void exercise_lowlevel(byte_span input)
     {
-        const uint8_t* const end = input.data() + input.size();
-
-        // read_head walks heads, always advancing; ok <=> !ec.
-        const uint8_t* p = input.data();
-        for (int steps = 0; steps < 64 && p < end; ++steps)
+        // read_head walks heads by offset, always advancing when bytes are
+        // consumed; success and error are mutually exclusive.
+        wire_cursor heads(input);
+        for (int steps = 0; steps < 64 && !heads.remaining().empty(); ++steps)
         {
-            const uint8_t* before = p;
-            item_head head;
-            std::error_code ec;
-            const bool ok = read_head(p, end, head, ec);
-            require(ok != static_cast<bool>(ec));
-            require(p >= before && p <= end);
-            if (!ok)
+            const std::size_t before = heads.position();
+            auto result = heads.read_head();
+            require(heads.position() >= before && heads.position() <= input.size());
+            if (!result.has_value())
             {
+                require(result.error().offset == heads.position());
                 break;
             }
-            require(p > before);
+            require(heads.position() > before);
         }
 
-        // skip_item agrees with scan_prefix on outcome and consumed length.
-        const uint8_t* sp = input.data();
-        std::error_code ec;
-        const bool ok = skip_item(sp, end, ec);
-        require(ok != static_cast<bool>(ec));
+        // read_item agrees with scan_prefix on outcome and consumed length.
+        wire_cursor items(input);
         scan_context context;
+        auto read = items.read_item(context);
         auto scanned = scan_prefix(input, context);
-        require(ok == scanned.has_value());
-        if (ok)
+        require(read.has_value() == scanned.has_value());
+        if (read.has_value())
         {
-            require(sp == input.data() + scanned.value().first.encoded_bytes().size());
+            require(items.position() == scanned.value().first.encoded_bytes().size());
+            require(read.value().encoded_bytes().data() == input.data());
+        }
+        else
+        {
+            require(items.position() == read.error().offset);
         }
     }
 

--- a/fuzzers/fuzz_cbor_view.cpp
+++ b/fuzzers/fuzz_cbor_view.cpp
@@ -280,6 +280,53 @@ namespace {
         require(reset.value().size() == navigated.value().remainder.size());
     }
 
+    // Children agree with navigator movement over the same container.
+    void exercise_children(byte_span input, scan_context& context)
+    {
+        auto scanned = scan_prefix(input, context);
+        if (!scanned.has_value())
+        {
+            return;
+        }
+        const item root = scanned.value().first;
+
+        auto navigated = navigate_prefix(input);
+        require(navigated.has_value());
+        navigator nav = std::move(navigated.value().first);
+
+        auto it = root.children(context).begin();
+        if (!nav.enter())
+        {
+            require(root.children(context).empty());
+            require(it == item::child_iterator());
+            return;
+        }
+        require(!root.children(context).empty());
+
+        std::size_t count = 0;
+        for (;;)
+        {
+            require(it != item::child_iterator());
+            const item child = *it;
+            require(child.kind() == nav.kind());
+            require(child.argument() == nav.argument());
+            require(child.indefinite() == nav.indefinite());
+            const item finished = nav.finish_item();
+            require(finished.encoded_bytes().data() == child.encoded_bytes().data());
+            require(finished.encoded_bytes().size() == child.encoded_bytes().size());
+            ++it;
+            if (++count > 4096)
+            {
+                return;
+            }
+            if (!nav.next())
+            {
+                break;
+            }
+        }
+        require(it == item::child_iterator());
+    }
+
 
     void exercise_input(byte_span input, scan_context& context)
     {
@@ -347,6 +394,7 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, std::size_t size)
         scan_context context(depth);
         exercise_input(input, context);
         exercise_navigator(input, depth);
+        exercise_children(input, context);
         exercise_input(byte_span(base, mid), context);
         exercise_navigator(byte_span(base, mid), depth);
         exercise_input(byte_span(base + mid, size - mid), context);

--- a/fuzzers/fuzz_cbor_view.cpp
+++ b/fuzzers/fuzz_cbor_view.cpp
@@ -215,6 +215,68 @@ namespace {
         }
     }
 
+    void exercise_navigator(byte_span input, int depth)
+    {
+        auto navigated = navigate_prefix(input, depth);
+        scan_context context(depth);
+        auto scanned = scan_prefix(input, context);
+        require(navigated.has_value() == scanned.has_value());
+        if (!navigated.has_value())
+        {
+            return;
+        }
+
+        navigator nav = std::move(navigated.value().first);
+        require(navigated.value().remainder.size() == scanned.value().remainder.size());
+        require(nav.role() == position_role::root);
+        require(nav.depth() == 0);
+        require(nav.extent_known());
+
+        const item root = nav.finish_item();
+        require(root.encoded_bytes().data() == input.data());
+        require(root.encoded_bytes().size() == scanned.value().first.encoded_bytes().size());
+
+        for (int steps = 0; steps < 256; ++steps)
+        {
+            uint64_t u = 0;
+            int64_t i = 0;
+            bool b = false;
+            double d = 0;
+            jsoncons::string_view text;
+            byte_span bytes;
+            (void)nav.uint64_value(u);
+            (void)nav.int64_value(i);
+            (void)nav.bool_value(b);
+            (void)nav.double_value(d);
+            (void)nav.text(text);
+            (void)nav.bytes(bytes);
+
+            if (nav.enter())
+            {
+                require(nav.depth() > 0);
+                continue;
+            }
+            if (nav.next())
+            {
+                continue;
+            }
+            if (!nav.leave())
+            {
+                break;
+            }
+        }
+
+        nav.rewind();
+        require(nav.depth() == 0);
+        require(nav.role() == position_role::root);
+        require(nav.finish_item().encoded_bytes().size() == root.encoded_bytes().size());
+
+        auto reset = nav.reset_prefix(input, depth);
+        require(reset.has_value());
+        require(reset.value().size() == navigated.value().remainder.size());
+    }
+
+
     void exercise_input(byte_span input, scan_context& context)
     {
         auto scanned = scan_prefix(input, context);
@@ -280,9 +342,13 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, std::size_t size)
     {
         scan_context context(depth);
         exercise_input(input, context);
+        exercise_navigator(input, depth);
         exercise_input(byte_span(base, mid), context);
+        exercise_navigator(byte_span(base, mid), depth);
         exercise_input(byte_span(base + mid, size - mid), context);
+        exercise_navigator(byte_span(base + mid, size - mid), depth);
         exercise_input(byte_span(base + p0, size - p0), context);
+        exercise_navigator(byte_span(base + p0, size - p0), depth);
     }
 
     return 0;

--- a/fuzzers/fuzz_cbor_view.cpp
+++ b/fuzzers/fuzz_cbor_view.cpp
@@ -120,33 +120,9 @@ namespace {
             require(!validate_text(scanned));
         }
 
-        // Containers: children are checked items inside the parent.
-        if (depth_budget > 0)
-        {
-            const uint8_t* prev_end = nullptr;
-            for (item element : scanned.elements())
-            {
-                require(contains(bytes, element.encoded_bytes()));
-                if (prev_end != nullptr)
-                {
-                    require(element.encoded_bytes().data() >= prev_end);
-                }
-                prev_end = element.encoded_bytes().data() + element.encoded_bytes().size();
-                exercise_item(element, depth_budget - 1);
-            }
-            for (map_entry entry : scanned.entries())
-            {
-                require(contains(bytes, entry.key.encoded_bytes()));
-                require(contains(bytes, entry.value.encoded_bytes()));
-                require(entry.value.encoded_bytes().data() ==
-                    entry.key.encoded_bytes().data() + entry.key.encoded_bytes().size());
-                exercise_item(entry.key, depth_budget - 1);
-                exercise_item(entry.value, depth_budget - 1);
-            }
-        }
-
-        (void)map_keys_sorted(scanned);
-        (void)map_keys_sorted(scanned, length_first_compare());
+        (void)depth_budget;
+        (void)map_keys_sorted(bytes);
+        (void)map_keys_sorted(bytes, length_first_compare());
     }
 
     void exercise_lowlevel(byte_span input)
@@ -211,7 +187,8 @@ namespace {
         require(sorted.has_value() == sa.has_value());
         if (sorted.has_value())
         {
-            require(sorted.value() == map_keys_sorted(sa.value().first));
+            auto checked = map_keys_sorted(sa.value().first.encoded_bytes());
+            require(checked.has_value() && sorted.value() == checked.value());
         }
     }
 

--- a/fuzzers/fuzz_cbor_view.cpp
+++ b/fuzzers/fuzz_cbor_view.cpp
@@ -158,6 +158,33 @@ namespace {
         {
             require(items.position() == read.error().offset);
         }
+
+        // skip_item agrees with read_item on outcome, consumed length, and
+        // failure; on success its span is the item's encoded bytes unparsed.
+        wire_cursor skips(input);
+        auto skipped = skips.skip_item(context);
+        require(skipped.has_value() == read.has_value());
+        require(skips.position() == items.position());
+        if (skipped.has_value())
+        {
+            require(skipped.value().data() == read.value().encoded_bytes().data());
+            require(skipped.value().size() == read.value().encoded_bytes().size());
+        }
+        else
+        {
+            require(skipped.error().code == read.error().code);
+            require(skipped.error().offset == read.error().offset);
+        }
+
+        // skip consumes exactly the requested content when it is available.
+        wire_cursor content(input);
+        const std::size_t half = input.size() / 2;
+        require(content.skip(half));
+        require(content.position() == half);
+        require(!content.skip(input.size() - half + 1));
+        require(content.position() == half);
+        require(content.skip(input.size() - half));
+        require(content.remaining().empty());
     }
 
     void exercise_span_orders(byte_span a, byte_span b)

--- a/include/jsoncons_ext/cbor/cbor_view.hpp
+++ b/include/jsoncons_ext/cbor/cbor_view.hpp
@@ -286,6 +286,7 @@ namespace view {
             uint64_t local_[local_capacity];
             std::vector<uint64_t> spill_;
             std::size_t size_{0};
+            std::size_t peak_size_{0};
         public:
             bool empty() const noexcept
             {
@@ -297,10 +298,16 @@ namespace view {
                 return size_;
             }
 
+            std::size_t peak_size() const noexcept
+            {
+                return peak_size_;
+            }
+
             void clear() noexcept
             {
                 spill_.clear();
                 size_ = 0;
+                peak_size_ = 0;
             }
 
             void push(uint64_t count)
@@ -314,6 +321,10 @@ namespace view {
                     spill_.push_back(count);
                 }
                 ++size_;
+                if (size_ > peak_size_)
+                {
+                    peak_size_ = size_;
+                }
             }
 
             uint64_t pop() noexcept
@@ -713,27 +724,80 @@ namespace view {
         }
     };
 
-    // Reads one head, advancing p past the head only; tags read as their own heads.
-    inline bool read_head(const uint8_t*& p, const uint8_t* end, item_head& head, std::error_code& ec)
-    {
-        detail_view::item_head h;
-        if (!detail_view::read_head(p, end, h, ec))
-        {
-            return false;
-        }
-        head.major_type = static_cast<view::major_type>(static_cast<uint8_t>(h.major_type));
-        head.additional_info = h.additional_info;
-        head.value = h.value;
-        return true;
-    }
+    class scan_context;
 
-    // Advances p past one complete item, bounded by max_nesting_depth.
-    inline bool skip_item(const uint8_t*& p, const uint8_t* end, std::error_code& ec,
-        int max_nesting_depth = default_max_nesting_depth)
+    // Offset-based access to unchecked CBOR wire data. The cursor borrows its
+    // input and never exposes a mutable pointer/end pair.
+    class wire_cursor
     {
-        detail_view::pending_stack open;
-        return detail_view::skip_item(p, end, max_nesting_depth, open, ec);
-    }
+    public:
+        wire_cursor() noexcept
+            : input_(), offset_(0)
+        {
+        }
+
+        explicit wire_cursor(span<const uint8_t> input) noexcept
+            : input_(input), offset_(0)
+        {
+        }
+
+        void reset(span<const uint8_t> input) noexcept
+        {
+            input_ = input;
+            offset_ = 0;
+        }
+
+        std::size_t position() const noexcept
+        {
+            return offset_;
+        }
+
+        span<const uint8_t> remaining() const noexcept
+        {
+            const uint8_t* data = offset_ == 0 ? input_.data() : input_.data() + offset_;
+            return span<const uint8_t>(data, input_.size() - offset_);
+        }
+
+        // Reads one head and advances past that head only. Tags are returned
+        // as their own heads. On failure, position() is the reported offset.
+        expected<item_head, scan_error> read_head() noexcept
+        {
+            if (offset_ >= input_.size())
+            {
+                return expected<item_head, scan_error>(unexpect,
+                    scan_error{cbor_errc::unexpected_eof, offset_});
+            }
+
+            const uint8_t* p = input_.data() + offset_;
+            const uint8_t* end = input_.data() + input_.size();
+            detail_view::item_head h;
+            std::error_code ec;
+            const bool ok = detail_view::read_head(p, end, h, ec);
+            offset_ = static_cast<std::size_t>(p - input_.data());
+            if (!ok)
+            {
+                return expected<item_head, scan_error>(unexpect,
+                    scan_error{static_cast<cbor_errc>(ec.value()), offset_});
+            }
+
+            item_head head;
+            head.major_type = static_cast<view::major_type>(static_cast<uint8_t>(h.major_type));
+            head.additional_info = h.additional_info;
+            head.value = h.value;
+            return head;
+        }
+
+        // Reads and validates one complete item. This is the fallible boundary
+        // at which the supplied scanning workspace may grow.
+        expected<item, scan_error> read_item(scan_context& context);
+
+        expected<item, scan_error> read_item(
+            int max_nesting_depth = default_max_nesting_depth);
+
+    private:
+        span<const uint8_t> input_;
+        std::size_t offset_;
+    };
 
     // Iterates the values of an item's leading semantic tags.
     class item::tag_iterator
@@ -1304,6 +1368,11 @@ namespace view {
             {
                 return context.workspace_;
             }
+
+            static std::size_t peak_depth(scan_context& context) noexcept
+            {
+                return context.workspace_.peak_size();
+            }
         };
 
         // All error codes assigned by the walker are cbor_errc values.
@@ -1329,6 +1398,8 @@ namespace view {
         const uint8_t* end = p + input.size();
         std::error_code ec;
 
+        detail_view::pending_stack& workspace = detail_view::scan_access::workspace(context);
+        workspace.clear();
         // Parse the head once and keep it, so the item is built below without
         // re-reading its own head.
         detail_view::item_head head;
@@ -1342,7 +1413,7 @@ namespace view {
         const bool ok = (head.major_type == cbor::detail::cbor_major_type::array ||
                          head.major_type == cbor::detail::cbor_major_type::map)
             ? detail_view::skip_container(p, end, head, context.max_nesting_depth(),
-                  detail_view::scan_access::workspace(context), ec)
+                  workspace, ec)
             : detail_view::skip_scalar_or_string(head, p, end, ec);
         if (!ok)
         {
@@ -1382,6 +1453,30 @@ namespace view {
     {
         scan_context context;
         return parse_exact(input, context);
+    }
+
+    inline expected<item, scan_error> wire_cursor::read_item(scan_context& context)
+    {
+        const std::size_t start = offset_;
+        auto scanned = scan_prefix(remaining(), context);
+        if (!scanned)
+        {
+            scan_error error = scanned.error();
+            const std::size_t available = input_.size() - offset_;
+            const std::size_t consumed = (std::min)(error.offset, available);
+            offset_ += consumed;
+            error.offset += start;
+            return expected<item, scan_error>(unexpect, error);
+        }
+
+        offset_ += scanned.value().first.encoded_bytes().size();
+        return scanned.value().first;
+    }
+
+    inline expected<item, scan_error> wire_cursor::read_item(int max_nesting_depth)
+    {
+        scan_context context(max_nesting_depth);
+        return read_item(context);
     }
 
     // Guard against scanning a temporary container: the resulting views

--- a/include/jsoncons_ext/cbor/cbor_view.hpp
+++ b/include/jsoncons_ext/cbor/cbor_view.hpp
@@ -788,6 +788,22 @@ namespace view {
         // at which the supplied scanning workspace may grow.
         expected<item, scan_error> read_item(scan_context& context);
 
+        // Validates and passes over one complete item, returning its encoded
+        // bytes unparsed. Costs and failure reporting match read_item.
+        expected<span<const uint8_t>, scan_error> skip_item(scan_context& context);
+
+        // Advances past `count` bytes of already-measured content, such as a
+        // definite string payload after its head. False, leaving the position
+        // unchanged, when fewer bytes remain.
+        bool skip(std::size_t count) noexcept
+        {
+            if (input_.size() - offset_ < count)
+            {
+                return false;
+            }
+            offset_ += count;
+            return true;
+        }
 
     private:
         span<const uint8_t> input_;
@@ -1402,6 +1418,24 @@ namespace view {
 
         offset_ += scanned.value().first.encoded_bytes().size();
         return scanned.value().first;
+    }
+
+    inline expected<span<const uint8_t>, scan_error> wire_cursor::skip_item(scan_context& context)
+    {
+        const uint8_t* const base = input_.data();
+        const uint8_t* p = base + offset_;
+        const uint8_t* const end = base + input_.size();
+        const std::size_t start = offset_;
+        std::error_code ec;
+        const bool ok = detail_view::skip_item(p, end, context.max_nesting_depth(),
+            detail_view::scan_access::workspace(context), ec);
+        offset_ = static_cast<std::size_t>(p - base);
+        if (!ok)
+        {
+            return expected<span<const uint8_t>, scan_error>(unexpect,
+                scan_error{detail_view::to_cbor_errc(ec), offset_});
+        }
+        return span<const uint8_t>(base + start, offset_ - start);
     }
 
 

--- a/include/jsoncons_ext/cbor/cbor_view.hpp
+++ b/include/jsoncons_ext/cbor/cbor_view.hpp
@@ -318,6 +318,19 @@ namespace view {
                 peak_size_ = 0;
             }
 
+            void swap(pending_stack& other) noexcept
+            {
+                for (std::size_t i = 0; i < local_capacity; ++i)
+                {
+                    using std::swap;
+                    swap(local_[i], other.local_[i]);
+                }
+                spill_.swap(other.spill_);
+                using std::swap;
+                swap(size_, other.size_);
+                swap(peak_size_, other.peak_size_);
+            }
+
             void push(uint64_t count)
             {
                 if (size_ < local_capacity)
@@ -750,11 +763,19 @@ namespace view {
         {
         }
 
+        template <typename Container,
+                  typename std::enable_if<!std::is_trivially_copyable<Container>::value, int>::type = 0>
+        wire_cursor(const Container&&) = delete;
+
         void reset(span<const uint8_t> input) noexcept
         {
             input_ = input;
             offset_ = 0;
         }
+
+        template <typename Container,
+                  typename std::enable_if<!std::is_trivially_copyable<Container>::value, int>::type = 0>
+        void reset(const Container&&) = delete;
 
         std::size_t position() const noexcept
         {
@@ -1540,6 +1561,18 @@ namespace view {
             span<const uint8_t> input,
             int max_nesting_depth = default_max_nesting_depth);
 
+        template <typename Container,
+                  typename std::enable_if<!std::is_trivially_copyable<Container>::value, int>::type = 0>
+        expected<span<const uint8_t>, scan_error> reset_prefix(
+            const Container&&,
+            int = default_max_nesting_depth) = delete;
+
+        template <typename Container,
+                  typename std::enable_if<!std::is_trivially_copyable<Container>::value, int>::type = 0>
+        expected<void, scan_error> reset_exact(
+            const Container&&,
+            int = default_max_nesting_depth) = delete;
+
     private:
         friend struct detail_view::navigator_access;
 
@@ -1550,8 +1583,10 @@ namespace view {
                         position_role& role, std::size_t& right_fence) noexcept;
         void establish_end(node_state& node) noexcept;
 
-        navigator(span<const uint8_t> root, std::size_t peak_depth)
-            : input_(root), root_(), current_(), frames_(peak_depth), active_depth_(0)
+        navigator(span<const uint8_t> root, std::size_t peak_depth,
+                  detail_view::pending_stack&& validation_workspace)
+            : input_(root), root_(), current_(), frames_(peak_depth),
+              validation_workspace_(std::move(validation_workspace)), active_depth_(0)
         {
             initialize_root();
         }
@@ -1596,6 +1631,7 @@ namespace view {
         node_state root_;
         node_state current_;
         std::vector<navigation_frame> frames_;
+        detail_view::pending_stack validation_workspace_;
         std::size_t active_depth_;
     };
 
@@ -1603,9 +1639,10 @@ namespace view {
 
         struct navigator_access
         {
-            static navigator make(span<const uint8_t> root, std::size_t peak_depth)
+            static navigator make(span<const uint8_t> root, std::size_t peak_depth,
+                                  pending_stack&& validation_workspace)
             {
-                return navigator(root, peak_depth);
+                return navigator(root, peak_depth, std::move(validation_workspace));
             }
         };
 
@@ -1668,6 +1705,11 @@ namespace view {
             static std::size_t peak_depth(scan_context& context) noexcept
             {
                 return context.workspace_.peak_size();
+            }
+
+            static void swap_workspace(scan_context& context, pending_stack& workspace) noexcept
+            {
+                context.workspace_.swap(workspace);
             }
         };
 
@@ -1788,7 +1830,8 @@ namespace view {
 
         navigator result = detail_view::navigator_access::make(
             scanned.value().first.encoded_bytes(),
-            detail_view::scan_access::peak_depth(context));
+            detail_view::scan_access::peak_depth(context),
+            std::move(detail_view::scan_access::workspace(context)));
         return navigation_result(std::move(result), scanned.value().remainder);
     }
 
@@ -1814,14 +1857,16 @@ namespace view {
         span<const uint8_t> input, int max_nesting_depth)
     {
         scan_context context(max_nesting_depth);
+        detail_view::scan_access::swap_workspace(context, validation_workspace_);
         auto scanned = scan_prefix(input, context);
+        const std::size_t peak_depth = detail_view::scan_access::peak_depth(context);
+        detail_view::scan_access::swap_workspace(context, validation_workspace_);
         if (!scanned)
         {
             return expected<span<const uint8_t>, scan_error>(unexpect, scanned.error());
         }
 
-        prepare_checked(scanned.value().first.encoded_bytes(),
-                        detail_view::scan_access::peak_depth(context));
+        prepare_checked(scanned.value().first.encoded_bytes(), peak_depth);
         return scanned.value().remainder;
     }
 
@@ -1829,7 +1874,10 @@ namespace view {
         span<const uint8_t> input, int max_nesting_depth)
     {
         scan_context context(max_nesting_depth);
+        detail_view::scan_access::swap_workspace(context, validation_workspace_);
         auto scanned = scan_prefix(input, context);
+        const std::size_t peak_depth = detail_view::scan_access::peak_depth(context);
+        detail_view::scan_access::swap_workspace(context, validation_workspace_);
         if (!scanned)
         {
             return expected<void, scan_error>(unexpect, scanned.error());
@@ -1841,8 +1889,7 @@ namespace view {
                     scanned.value().first.encoded_bytes().size()});
         }
 
-        prepare_checked(scanned.value().first.encoded_bytes(),
-                        detail_view::scan_access::peak_depth(context));
+        prepare_checked(scanned.value().first.encoded_bytes(), peak_depth);
         return expected<void, scan_error>();
     }
 
@@ -2149,6 +2196,19 @@ namespace view {
                                 current_.end - current_.begin),
             current_.head, input_.data() + current_.content_begin);
     }
+
+    template <typename Container,
+              typename std::enable_if<!std::is_trivially_copyable<Container>::value, int>::type = 0>
+    expected<navigation_result, scan_error> navigate_prefix(
+        const Container&&,
+        int = default_max_nesting_depth) = delete;
+
+    template <typename Container,
+              typename std::enable_if<!std::is_trivially_copyable<Container>::value, int>::type = 0>
+    expected<navigator, scan_error> navigate_exact(
+        const Container&&,
+        int = default_max_nesting_depth) = delete;
+
 
     // Guard against scanning a temporary container: the resulting views
     // would dangle immediately. Non-owning view types (spans, string views)

--- a/include/jsoncons_ext/cbor/cbor_view.hpp
+++ b/include/jsoncons_ext/cbor/cbor_view.hpp
@@ -672,18 +672,6 @@ namespace view {
     private:
         friend struct detail_view::item_access;
 
-        explicit item(span<const uint8_t> bytes) noexcept
-            : bytes_(bytes)
-        {
-            const uint8_t* p = bytes.data();
-            const uint8_t* end = p + bytes.size();
-            std::error_code ec;
-            const bool ok = detail_view::read_value_head(p, end, head_, ec);
-            assert(ok && !ec);
-            (void)ok;
-            content_ = p;
-        }
-
         item(span<const uint8_t> bytes, const detail_view::item_head& head, const uint8_t* content) noexcept
             : bytes_(bytes), head_(head), content_(content)
         {
@@ -698,11 +686,6 @@ namespace view {
 
         struct item_access
         {
-            static item make(span<const uint8_t> bytes) noexcept
-            {
-                return item(bytes);
-            }
-
             static item make(span<const uint8_t> bytes, const item_head& head, const uint8_t* content) noexcept
             {
                 return item(bytes, head, content);

--- a/include/jsoncons_ext/cbor/cbor_view.hpp
+++ b/include/jsoncons_ext/cbor/cbor_view.hpp
@@ -582,6 +582,8 @@ namespace view {
 
     } // namespace detail_view
 
+    class scan_context;
+
     // A checked, zero-copy view of one complete, structurally well-formed CBOR
     // item: its leading semantic tags, head, and content. Obtained from
     // scan_prefix, parse_exact, wire_cursor, or navigator::finish_item; never
@@ -619,6 +621,8 @@ namespace view {
         class tag_range;
         class chunk_iterator;
         class chunk_range;
+        class child_iterator;
+        class child_range;
 
         // The item's leading semantic tags, outermost first. Empty for
         // untagged items. Tags are exposed, never interpreted: deciding what
@@ -629,6 +633,9 @@ namespace view {
         // definite-length string, one per chunk for an indefinite-length
         // one. Empty unless kind() is byte_string or text_string.
         chunk_range chunks() const noexcept;
+
+        // Raw children of an array or map: elements, or keys and values alternating.
+        child_range children(scan_context& context) const noexcept;
 
         // The typed accessors return false, leaving `value` untouched, on a
         // kind mismatch. Structural well-formedness was established by scanning.
@@ -710,8 +717,6 @@ namespace view {
             return additional_info == 31;   // additional-info 31 = indefinite length
         }
     };
-
-    class scan_context;
 
     // Offset-based access to unchecked CBOR wire data. The cursor borrows its
     // input and never exposes a mutable pointer/end pair.
@@ -1310,6 +1315,166 @@ namespace view {
 
     } // namespace detail_view
 
+    // Iterates the raw children of a checked container item, measuring each
+    // child once to yield it as a complete checked item.
+    class item::child_iterator
+    {
+    public:
+        using value_type = item;
+        using reference = item;
+        using pointer = void;
+        using difference_type = std::ptrdiff_t;
+        using iterator_category = std::input_iterator_tag;
+
+        child_iterator() noexcept
+            : pos_(nullptr), next_(nullptr), end_(nullptr), remaining_(0),
+              content_(nullptr), context_(nullptr)
+        {
+        }
+
+        item operator*() const noexcept
+        {
+            assert(pos_ != nullptr);
+            return detail_view::item_access::make(
+                span<const uint8_t>(pos_, static_cast<std::size_t>(next_ - pos_)),
+                head_, content_);
+        }
+
+        child_iterator& operator++()
+        {
+            advance();
+            return *this;
+        }
+
+        child_iterator operator++(int)
+        {
+            child_iterator temp = *this;
+            advance();
+            return temp;
+        }
+
+        friend bool operator==(const child_iterator& a, const child_iterator& b) noexcept
+        {
+            return a.pos_ == b.pos_;
+        }
+
+        friend bool operator!=(const child_iterator& a, const child_iterator& b) noexcept
+        {
+            return a.pos_ != b.pos_;
+        }
+
+    private:
+        friend class child_range;
+
+        child_iterator(const uint8_t* first, const uint8_t* end, uint64_t remaining,
+                       scan_context& context) noexcept
+            : pos_(nullptr), next_(first), end_(end), remaining_(remaining),
+              content_(nullptr), context_(&context)
+        {
+            advance();
+        }
+
+        void advance()
+        {
+            pos_ = next_;
+            if (remaining_ == detail_view::indefinite_array_marker)
+            {
+                if (*pos_ == 0xff)
+                {
+                    pos_ = nullptr;
+                    return;
+                }
+            }
+            else if (remaining_ == 0)
+            {
+                pos_ = nullptr;
+                return;
+            }
+            else
+            {
+                --remaining_;
+            }
+
+            const uint8_t* p = pos_;
+            std::error_code ec;
+            bool ok = detail_view::read_value_head(p, end_, head_, ec);
+            assert(ok && !ec);
+            content_ = p;
+            ok = head_.major_type == cbor::detail::cbor_major_type::array ||
+                 head_.major_type == cbor::detail::cbor_major_type::map
+                ? detail_view::skip_container(p, end_, head_,
+                      (std::numeric_limits<int>::max)(),
+                      detail_view::scan_access::workspace(*context_), ec)
+                : detail_view::skip_scalar_or_string(head_, p, end_, ec);
+            assert(ok && !ec);
+            (void)ok;
+            next_ = p;
+        }
+
+        const uint8_t* pos_;    // current child's begin, nullptr when exhausted
+        const uint8_t* next_;   // current child's end, the next child's begin
+        const uint8_t* end_;    // the parent's end
+        uint64_t remaining_;    // raw children left; indefinite ends at a break
+        detail_view::item_head head_;
+        const uint8_t* content_;
+        scan_context* context_;
+    };
+
+    class item::child_range
+    {
+    public:
+        using iterator = child_iterator;
+        using const_iterator = child_iterator;
+
+        child_iterator begin() const
+        {
+            if (first_ == nullptr)
+            {
+                return child_iterator();
+            }
+            return child_iterator(first_, end_, remaining_, *context_);
+        }
+
+        child_iterator end() const noexcept
+        {
+            return child_iterator();
+        }
+
+        bool empty() const noexcept
+        {
+            return first_ == nullptr ||
+                (remaining_ == detail_view::indefinite_array_marker
+                    ? *first_ == 0xff : remaining_ == 0);
+        }
+
+    private:
+        friend class item;
+        child_range(const uint8_t* first, const uint8_t* end, uint64_t remaining,
+                    scan_context* context) noexcept
+            : first_(first), end_(end), remaining_(remaining), context_(context)
+        {
+        }
+
+        const uint8_t* first_;
+        const uint8_t* end_;
+        uint64_t remaining_;
+        scan_context* context_;
+    };
+
+    inline item::child_range item::children(scan_context& context) const noexcept
+    {
+        if (head_.major_type != cbor::detail::cbor_major_type::array &&
+            head_.major_type != cbor::detail::cbor_major_type::map)
+        {
+            return child_range(nullptr, nullptr, 0, &context);
+        }
+        const uint64_t remaining = head_.indefinite()
+            ? detail_view::indefinite_array_marker
+            : (head_.major_type == cbor::detail::cbor_major_type::map
+                ? 2 * head_.value : head_.value);
+        return child_range(content_, bytes_.data() + bytes_.size(), remaining, &context);
+    }
+
     struct scan_result
     {
         item first;
@@ -1858,41 +2023,34 @@ namespace view {
     expected<bool, scan_error> map_keys_sorted(span<const uint8_t> input,
         Order order = Order(), int max_nesting_depth = default_max_nesting_depth)
     {
-        auto result = navigate_prefix(input, max_nesting_depth);
-        if (!result)
+        scan_context context(max_nesting_depth);
+        auto scanned = scan_prefix(input, context);
+        if (!scanned)
         {
-            return expected<bool, scan_error>(unexpect, result.error());
+            return expected<bool, scan_error>(unexpect, scanned.error());
         }
-
-        navigator nav = std::move(result.value().first);
-        if (nav.kind() != item_kind::map)
+        const item map_item = scanned.value().first;
+        if (map_item.kind() != item_kind::map)
         {
             return false;
         }
 
         span<const uint8_t> previous;
-        if (!nav.enter())
+        bool is_key = true;
+        for (item child : map_item.children(context))
         {
-            return true;
-        }
-        for (;;)
-        {
-            assert(nav.role() == position_role::map_key);
-            const span<const uint8_t> key = nav.finish_item().encoded_bytes();
-            if (!previous.empty() && order(previous, key) >= 0)
+            if (is_key)
             {
-                return false;
+                const span<const uint8_t> key = child.encoded_bytes();
+                if (!previous.empty() && order(previous, key) >= 0)
+                {
+                    return false;
+                }
+                previous = key;
             }
-            previous = key;
-
-            const bool has_value = nav.next();
-            assert(has_value && nav.role() == position_role::map_value);
-            (void)has_value;
-            if (!nav.next())
-            {
-                return true;
-            }
+            is_key = !is_key;
         }
+        return true;
     }
 
     // True if `text_item` is a text string whose content is well-formed

--- a/include/jsoncons_ext/cbor/cbor_view.hpp
+++ b/include/jsoncons_ext/cbor/cbor_view.hpp
@@ -52,6 +52,14 @@ namespace view {
         simple
     };
 
+    enum class position_role : uint8_t
+    {
+        root,
+        array_element,
+        map_key,
+        map_value
+    };
+
     // The CBOR major type
     enum class major_type : uint8_t
     {
@@ -493,6 +501,7 @@ namespace view {
 
         struct item_access;
         struct scan_access;
+        struct navigator_access;
 
     } // namespace detail_view
 
@@ -885,6 +894,7 @@ namespace view {
 
     private:
         friend class item;
+        friend class navigator;
         tag_range(const uint8_t* first, const uint8_t* stop) noexcept : first_(first), stop_(stop) {}
 
         const uint8_t* first_;
@@ -1332,6 +1342,285 @@ namespace view {
         return true;
     }
 
+    using tag_range = item::tag_range;
+
+    class navigator
+    {
+        static constexpr std::size_t npos = (std::numeric_limits<std::size_t>::max)();
+
+        struct node_state
+        {
+            std::size_t begin{0};
+            std::size_t head_begin{0};
+            std::size_t content_begin{0};
+            std::size_t end{npos};
+            detail_view::item_head head{};
+            position_role role{position_role::root};
+        };
+
+        enum class container_phase : uint8_t
+        {
+            array,
+            map_key,
+            map_value
+        };
+
+        struct navigation_frame
+        {
+            node_state container{};
+            std::size_t next_offset{npos};
+            std::size_t content_fence{npos};
+            uint64_t remaining{0};
+            container_phase phase{container_phase::array};
+            bool indefinite{false};
+            bool completed{false};
+        };
+
+    public:
+        navigator(navigator&&) noexcept = default;
+        navigator& operator=(navigator&&) noexcept = default;
+        navigator(const navigator&) = delete;
+        navigator& operator=(const navigator&) = delete;
+
+        item_kind kind() const noexcept
+        {
+            switch (current_.head.major_type)
+            {
+                case cbor::detail::cbor_major_type::unsigned_integer: return item_kind::unsigned_integer;
+                case cbor::detail::cbor_major_type::negative_integer: return item_kind::negative_integer;
+                case cbor::detail::cbor_major_type::byte_string:      return item_kind::byte_string;
+                case cbor::detail::cbor_major_type::text_string:      return item_kind::text_string;
+                case cbor::detail::cbor_major_type::array:            return item_kind::array;
+                case cbor::detail::cbor_major_type::map:              return item_kind::map;
+                default:                                              return item_kind::simple;
+            }
+        }
+
+        uint64_t argument() const noexcept
+        {
+            return current_.head.value;
+        }
+
+        bool indefinite() const noexcept
+        {
+            return current_.head.indefinite();
+        }
+
+        tag_range tags() const noexcept
+        {
+            return tag_range(input_.data() + current_.begin,
+                             input_.data() + current_.head_begin);
+        }
+
+        position_role role() const noexcept
+        {
+            return current_.role;
+        }
+
+        std::size_t depth() const noexcept
+        {
+            return active_depth_;
+        }
+
+        bool uint64_value(uint64_t& value) const noexcept
+        {
+            if (current_.head.major_type != cbor::detail::cbor_major_type::unsigned_integer)
+            {
+                return false;
+            }
+            value = current_.head.value;
+            return true;
+        }
+
+        bool int64_value(int64_t& value) const noexcept
+        {
+            const uint64_t int64_max = static_cast<uint64_t>((std::numeric_limits<int64_t>::max)());
+            if (current_.head.major_type == cbor::detail::cbor_major_type::unsigned_integer &&
+                current_.head.value <= int64_max)
+            {
+                value = static_cast<int64_t>(current_.head.value);
+                return true;
+            }
+            if (current_.head.major_type == cbor::detail::cbor_major_type::negative_integer &&
+                current_.head.value <= int64_max)
+            {
+                value = -1 - static_cast<int64_t>(current_.head.value);
+                return true;
+            }
+            return false;
+        }
+
+        bool bool_value(bool& value) const noexcept
+        {
+            if (current_.head.major_type != cbor::detail::cbor_major_type::simple ||
+                (current_.head.additional_info != 20 && current_.head.additional_info != 21))
+            {
+                return false;
+            }
+            value = current_.head.additional_info == 21;
+            return true;
+        }
+
+        bool double_value(double& value) const noexcept
+        {
+            if (current_.head.major_type != cbor::detail::cbor_major_type::simple)
+            {
+                return false;
+            }
+            switch (current_.head.additional_info)
+            {
+                case 25:
+                    value = binary::decode_half(static_cast<uint16_t>(current_.head.value));
+                    return true;
+                case 26:
+                {
+                    const uint32_t bits = static_cast<uint32_t>(current_.head.value);
+                    float single;
+                    std::memcpy(&single, &bits, sizeof single);
+                    value = single;
+                    return true;
+                }
+                case 27:
+                {
+                    const uint64_t bits = current_.head.value;
+                    std::memcpy(&value, &bits, sizeof value);
+                    return true;
+                }
+                default:
+                    return false;
+            }
+        }
+
+        bool text(string_view& value) const noexcept
+        {
+            if (current_.head.major_type != cbor::detail::cbor_major_type::text_string ||
+                current_.head.indefinite())
+            {
+                return false;
+            }
+            value = string_view(reinterpret_cast<const char*>(input_.data() + current_.content_begin),
+                                static_cast<std::size_t>(current_.head.value));
+            return true;
+        }
+
+        bool bytes(span<const uint8_t>& value) const noexcept
+        {
+            if (current_.head.major_type != cbor::detail::cbor_major_type::byte_string ||
+                current_.head.indefinite())
+            {
+                return false;
+            }
+            value = span<const uint8_t>(input_.data() + current_.content_begin,
+                                        static_cast<std::size_t>(current_.head.value));
+            return true;
+        }
+
+        bool enter() noexcept;
+        bool next() noexcept;
+        bool leave() noexcept;
+
+        void rewind() noexcept
+        {
+            current_ = root_;
+            active_depth_ = 0;
+        }
+
+        item finish_item() noexcept;
+
+        bool extent_known() const noexcept
+        {
+            return current_.end != npos;
+        }
+
+        expected<span<const uint8_t>, scan_error> reset_prefix(
+            span<const uint8_t> input,
+            int max_nesting_depth = default_max_nesting_depth);
+
+        expected<void, scan_error> reset_exact(
+            span<const uint8_t> input,
+            int max_nesting_depth = default_max_nesting_depth);
+
+    private:
+        friend struct detail_view::navigator_access;
+
+        navigator(span<const uint8_t> root, std::size_t peak_depth)
+            : input_(root), root_(), current_(), frames_(peak_depth), active_depth_(0)
+        {
+            initialize_root();
+        }
+
+        void initialize_root() noexcept
+        {
+            assert(!input_.empty());
+            const uint8_t* const base = input_.data();
+            const uint8_t* p = base;
+            const uint8_t* const end = base + input_.size();
+            detail_view::item_head head;
+            std::error_code ec;
+            std::size_t head_begin = 0;
+            bool ok;
+            do
+            {
+                head_begin = static_cast<std::size_t>(p - base);
+                ok = detail_view::read_head(p, end, head, ec);
+                assert(ok && !ec);
+            }
+            while (head.major_type == cbor::detail::cbor_major_type::semantic_tag);
+            (void)ok;
+
+            root_.begin = 0;
+            root_.head_begin = head_begin;
+            root_.content_begin = static_cast<std::size_t>(p - base);
+            root_.end = input_.size();
+            root_.head = head;
+            root_.role = position_role::root;
+            current_ = root_;
+            active_depth_ = 0;
+        }
+
+        void prepare_checked(span<const uint8_t> root, std::size_t peak_depth)
+        {
+            frames_.resize(peak_depth);
+            input_ = root;
+            initialize_root();
+        }
+
+        span<const uint8_t> input_;
+        node_state root_;
+        node_state current_;
+        std::vector<navigation_frame> frames_;
+        std::size_t active_depth_;
+    };
+
+    namespace detail_view {
+
+        struct navigator_access
+        {
+            static navigator make(span<const uint8_t> root, std::size_t peak_depth)
+            {
+                return navigator(root, peak_depth);
+            }
+        };
+
+    } // namespace detail_view
+
+    struct navigation_result
+    {
+        navigator first;
+        span<const uint8_t> remainder;
+
+        navigation_result(navigator&& first, span<const uint8_t> remainder) noexcept
+            : first(std::move(first)), remainder(remainder)
+        {
+        }
+
+        navigation_result(navigation_result&&) noexcept = default;
+        navigation_result& operator=(navigation_result&&) noexcept = default;
+        navigation_result(const navigation_result&) = delete;
+        navigation_result& operator=(const navigation_result&) = delete;
+    };
+
+
     // Reusable scanning state: the depth policy and the walker's workspace.
     // Scanning allocates only when nesting exceeds 32 open containers, and
     // a reused context retains that capacity.
@@ -1477,6 +1766,77 @@ namespace view {
     {
         scan_context context(max_nesting_depth);
         return read_item(context);
+    }
+
+    inline expected<navigation_result, scan_error> navigate_prefix(
+        span<const uint8_t> input,
+        int max_nesting_depth = default_max_nesting_depth)
+    {
+        scan_context context(max_nesting_depth);
+        auto scanned = scan_prefix(input, context);
+        if (!scanned)
+        {
+            return expected<navigation_result, scan_error>(unexpect, scanned.error());
+        }
+
+        navigator result = detail_view::navigator_access::make(
+            scanned.value().first.encoded_bytes(),
+            detail_view::scan_access::peak_depth(context));
+        return navigation_result(std::move(result), scanned.value().remainder);
+    }
+
+    inline expected<navigator, scan_error> navigate_exact(
+        span<const uint8_t> input,
+        int max_nesting_depth = default_max_nesting_depth)
+    {
+        auto navigated = navigate_prefix(input, max_nesting_depth);
+        if (!navigated)
+        {
+            return expected<navigator, scan_error>(unexpect, navigated.error());
+        }
+        if (!navigated.value().remainder.empty())
+        {
+            return expected<navigator, scan_error>(unexpect,
+                scan_error{cbor_errc::trailing_data,
+                    input.size() - navigated.value().remainder.size()});
+        }
+        return std::move(navigated.value().first);
+    }
+
+    inline expected<span<const uint8_t>, scan_error> navigator::reset_prefix(
+        span<const uint8_t> input, int max_nesting_depth)
+    {
+        scan_context context(max_nesting_depth);
+        auto scanned = scan_prefix(input, context);
+        if (!scanned)
+        {
+            return expected<span<const uint8_t>, scan_error>(unexpect, scanned.error());
+        }
+
+        prepare_checked(scanned.value().first.encoded_bytes(),
+                        detail_view::scan_access::peak_depth(context));
+        return scanned.value().remainder;
+    }
+
+    inline expected<void, scan_error> navigator::reset_exact(
+        span<const uint8_t> input, int max_nesting_depth)
+    {
+        scan_context context(max_nesting_depth);
+        auto scanned = scan_prefix(input, context);
+        if (!scanned)
+        {
+            return expected<void, scan_error>(unexpect, scanned.error());
+        }
+        if (!scanned.value().remainder.empty())
+        {
+            return expected<void, scan_error>(unexpect,
+                scan_error{cbor_errc::trailing_data,
+                    scanned.value().first.encoded_bytes().size()});
+        }
+
+        prepare_checked(scanned.value().first.encoded_bytes(),
+                        detail_view::scan_access::peak_depth(context));
+        return expected<void, scan_error>();
     }
 
     // Guard against scanning a temporary container: the resulting views

--- a/include/jsoncons_ext/cbor/cbor_view.hpp
+++ b/include/jsoncons_ext/cbor/cbor_view.hpp
@@ -1543,6 +1543,13 @@ namespace view {
     private:
         friend struct detail_view::navigator_access;
 
+        node_state read_node(std::size_t begin, position_role role,
+                             std::size_t right_fence = npos) const noexcept;
+        void initialize_frame(navigation_frame& frame, const node_state& container) noexcept;
+        bool take_child(navigation_frame& frame, std::size_t& offset,
+                        position_role& role, std::size_t& right_fence) noexcept;
+        void establish_end(node_state& node) noexcept;
+
         navigator(span<const uint8_t> root, std::size_t peak_depth)
             : input_(root), root_(), current_(), frames_(peak_depth), active_depth_(0)
         {
@@ -1837,6 +1844,310 @@ namespace view {
         prepare_checked(scanned.value().first.encoded_bytes(),
                         detail_view::scan_access::peak_depth(context));
         return expected<void, scan_error>();
+    }
+
+    inline navigator::node_state navigator::read_node(
+        std::size_t begin, position_role role, std::size_t right_fence) const noexcept
+    {
+        const uint8_t* const base = input_.data();
+        const uint8_t* p = base + begin;
+        const uint8_t* const input_end = base + input_.size();
+        detail_view::item_head head;
+        std::error_code ec;
+        std::size_t head_begin = begin;
+        bool ok;
+        do
+        {
+            head_begin = static_cast<std::size_t>(p - base);
+            ok = detail_view::read_head(p, input_end, head, ec);
+            assert(ok && !ec);
+        }
+        while (head.major_type == cbor::detail::cbor_major_type::semantic_tag);
+        (void)ok;
+
+        node_state node;
+        node.begin = begin;
+        node.head_begin = head_begin;
+        node.content_begin = static_cast<std::size_t>(p - base);
+        node.head = head;
+        node.role = role;
+
+        switch (head.major_type)
+        {
+            case cbor::detail::cbor_major_type::unsigned_integer:
+            case cbor::detail::cbor_major_type::negative_integer:
+            case cbor::detail::cbor_major_type::simple:
+                node.end = node.content_begin;
+                break;
+            case cbor::detail::cbor_major_type::byte_string:
+            case cbor::detail::cbor_major_type::text_string:
+                if (!head.indefinite())
+                {
+                    node.end = node.content_begin + static_cast<std::size_t>(head.value);
+                }
+                else if (right_fence != npos)
+                {
+                    node.end = right_fence;
+                }
+                else if (input_[node.content_begin] == 0xff)
+                {
+                    node.end = node.content_begin + 1;
+                }
+                break;
+            case cbor::detail::cbor_major_type::array:
+            case cbor::detail::cbor_major_type::map:
+                if (right_fence != npos)
+                {
+                    node.end = right_fence;
+                }
+                else if (!head.indefinite() && head.value == 0)
+                {
+                    node.end = node.content_begin;
+                }
+                else if (head.indefinite() && input_[node.content_begin] == 0xff)
+                {
+                    node.end = node.content_begin + 1;
+                }
+                break;
+            default:
+                assert(false);
+                break;
+        }
+        return node;
+    }
+
+    inline void navigator::initialize_frame(
+        navigation_frame& frame, const node_state& container) noexcept
+    {
+        frame.container = container;
+        frame.next_offset = container.content_begin;
+        frame.content_fence = container.end;
+        frame.indefinite = container.head.indefinite();
+        frame.completed = false;
+        if (container.head.major_type == cbor::detail::cbor_major_type::array)
+        {
+            frame.phase = container_phase::array;
+            frame.remaining = frame.indefinite ? 0 : container.head.value;
+        }
+        else
+        {
+            assert(container.head.major_type == cbor::detail::cbor_major_type::map);
+            frame.phase = container_phase::map_key;
+            frame.remaining = frame.indefinite ? 0 : 2 * container.head.value;
+        }
+    }
+
+    inline bool navigator::take_child(
+        navigation_frame& frame, std::size_t& offset,
+        position_role& role, std::size_t& right_fence) noexcept
+    {
+        right_fence = npos;
+        if (frame.indefinite)
+        {
+            const bool at_item_boundary = frame.phase != container_phase::map_value;
+            if (at_item_boundary && input_[offset] == 0xff)
+            {
+                ++offset;
+                frame.container.end = offset;
+                frame.next_offset = offset;
+                frame.completed = true;
+                return false;
+            }
+        }
+        else
+        {
+            if (frame.remaining == 0)
+            {
+                if (frame.content_fence != npos)
+                {
+                    assert(offset == frame.content_fence);
+                    offset = frame.content_fence;
+                }
+                frame.container.end = offset;
+                frame.next_offset = offset;
+                frame.completed = true;
+                return false;
+            }
+            --frame.remaining;
+            if (frame.remaining == 0 && frame.content_fence != npos)
+            {
+                right_fence = frame.content_fence;
+            }
+        }
+
+        switch (frame.phase)
+        {
+            case container_phase::array:
+                role = position_role::array_element;
+                break;
+            case container_phase::map_key:
+                role = position_role::map_key;
+                frame.phase = container_phase::map_value;
+                break;
+            case container_phase::map_value:
+                role = position_role::map_value;
+                frame.phase = container_phase::map_key;
+                break;
+        }
+        frame.next_offset = offset;
+        return true;
+    }
+
+    inline void navigator::establish_end(node_state& node) noexcept
+    {
+        if (node.end != npos)
+        {
+            return;
+        }
+
+        const uint8_t* const base = input_.data();
+        const uint8_t* const input_end = base + input_.size();
+        if (node.head.major_type != cbor::detail::cbor_major_type::array &&
+            node.head.major_type != cbor::detail::cbor_major_type::map)
+        {
+            const uint8_t* p = base + node.content_begin;
+            std::error_code ec;
+            const bool ok = detail_view::skip_scalar_or_string(node.head, p, input_end, ec);
+            assert(ok && !ec);
+            (void)ok;
+            node.end = static_cast<std::size_t>(p - base);
+            return;
+        }
+
+        std::size_t scratch_depth = 0;
+        assert(active_depth_ < frames_.size());
+        initialize_frame(frames_[active_depth_], node);
+        ++scratch_depth;
+        std::size_t offset = node.content_begin;
+
+        for (;;)
+        {
+            navigation_frame& frame = frames_[active_depth_ + scratch_depth - 1];
+            position_role child_role = position_role::array_element;
+            std::size_t right_fence = npos;
+            if (!take_child(frame, offset, child_role, right_fence))
+            {
+                offset = frame.container.end;
+                --scratch_depth;
+                if (scratch_depth == 0)
+                {
+                    node.end = offset;
+                    return;
+                }
+                continue;
+            }
+
+            node_state child = read_node(offset, child_role, right_fence);
+            if (child.end != npos)
+            {
+                offset = child.end;
+                continue;
+            }
+            if (child.head.major_type == cbor::detail::cbor_major_type::array ||
+                child.head.major_type == cbor::detail::cbor_major_type::map)
+            {
+                assert(active_depth_ + scratch_depth < frames_.size());
+                initialize_frame(frames_[active_depth_ + scratch_depth], child);
+                ++scratch_depth;
+                offset = child.content_begin;
+                continue;
+            }
+
+            const uint8_t* p = base + child.content_begin;
+            std::error_code ec;
+            const bool ok = detail_view::skip_scalar_or_string(child.head, p, input_end, ec);
+            assert(ok && !ec);
+            (void)ok;
+            offset = static_cast<std::size_t>(p - base);
+        }
+    }
+
+    inline bool navigator::enter() noexcept
+    {
+        if (current_.head.major_type != cbor::detail::cbor_major_type::array &&
+            current_.head.major_type != cbor::detail::cbor_major_type::map)
+        {
+            return false;
+        }
+        if ((!current_.head.indefinite() && current_.head.value == 0) ||
+            (current_.head.indefinite() && input_[current_.content_begin] == 0xff))
+        {
+            return false;
+        }
+
+        assert(active_depth_ < frames_.size());
+        navigation_frame& frame = frames_[active_depth_];
+        initialize_frame(frame, current_);
+        std::size_t offset = current_.content_begin;
+        position_role child_role = position_role::array_element;
+        std::size_t right_fence = npos;
+        const bool has_child = take_child(frame, offset, child_role, right_fence);
+        assert(has_child);
+        (void)has_child;
+        current_ = read_node(offset, child_role, right_fence);
+        ++active_depth_;
+        return true;
+    }
+
+    inline bool navigator::next() noexcept
+    {
+        if (active_depth_ == 0)
+        {
+            return false;
+        }
+
+        navigation_frame& frame = frames_[active_depth_ - 1];
+        if (frame.completed)
+        {
+            return false;
+        }
+        establish_end(current_);
+        std::size_t offset = current_.end;
+        position_role child_role = position_role::array_element;
+        std::size_t right_fence = npos;
+        if (!take_child(frame, offset, child_role, right_fence))
+        {
+            return false;
+        }
+
+        current_ = read_node(offset, child_role, right_fence);
+        return true;
+    }
+
+    inline bool navigator::leave() noexcept
+    {
+        if (active_depth_ == 0)
+        {
+            return false;
+        }
+
+        navigation_frame& frame = frames_[active_depth_ - 1];
+        if (frame.container.end == npos)
+        {
+            establish_end(current_);
+            std::size_t offset = current_.end;
+            position_role child_role = position_role::array_element;
+            std::size_t right_fence = npos;
+            while (take_child(frame, offset, child_role, right_fence))
+            {
+                node_state unread = read_node(offset, child_role, right_fence);
+                establish_end(unread);
+                offset = unread.end;
+            }
+        }
+
+        current_ = frame.container;
+        --active_depth_;
+        return true;
+    }
+
+    inline item navigator::finish_item() noexcept
+    {
+        establish_end(current_);
+        return detail_view::item_access::make(
+            span<const uint8_t>(input_.data() + current_.begin,
+                                current_.end - current_.begin),
+            current_.head, input_.data() + current_.content_begin);
     }
 
     // Guard against scanning a temporary container: the resulting views

--- a/include/jsoncons_ext/cbor/cbor_view.hpp
+++ b/include/jsoncons_ext/cbor/cbor_view.hpp
@@ -16,7 +16,6 @@
 #include <limits>
 #include <string>
 #include <system_error>
-#include <type_traits>
 #include <vector>
 
 #include <jsoncons/config/jsoncons_config.hpp>
@@ -26,8 +25,8 @@
 #include <jsoncons_ext/cbor/cbor_error.hpp>
 
 // A deliberately narrow, zero-copy facility for reading the *encoded*
-// structure of CBOR data in place. Scanning validates well-formedness
-// once; everything after that operates on checked `item` views and
+// structure of CBOR data in place. Scanning validates structural well-formedness
+// once; everything after that operates on checked items or navigation state and
 // cannot fail structurally. Semantic interpretation (tag 2 bignums,
 // string references, typed arrays, ...) belongs to the parser and
 // cursor layers, not here: tags are exposed, never interpreted.
@@ -76,8 +75,9 @@ namespace view {
     struct scan_error
     {
         cbor_errc code;
-        std::size_t offset;   // bytes consumed when the error was detected
+        std::size_t offset;
     };
+
 
     using jsoncons::detail::expected;
     using jsoncons::detail::unexpect;
@@ -95,6 +95,107 @@ namespace view {
                 return additional_info == cbor::detail::additional_info::indefinite_length;
             }
         };
+
+        inline item_kind kind(const item_head& head) noexcept
+        {
+            switch (head.major_type)
+            {
+                case cbor::detail::cbor_major_type::unsigned_integer: return item_kind::unsigned_integer;
+                case cbor::detail::cbor_major_type::negative_integer: return item_kind::negative_integer;
+                case cbor::detail::cbor_major_type::byte_string:      return item_kind::byte_string;
+                case cbor::detail::cbor_major_type::text_string:      return item_kind::text_string;
+                case cbor::detail::cbor_major_type::array:            return item_kind::array;
+                case cbor::detail::cbor_major_type::map:              return item_kind::map;
+                default:                                              return item_kind::simple;
+            }
+        }
+
+        inline bool uint64_value(const item_head& head, uint64_t& value) noexcept
+        {
+            if (head.major_type != cbor::detail::cbor_major_type::unsigned_integer)
+            {
+                return false;
+            }
+            value = head.value;
+            return true;
+        }
+
+        inline bool int64_value(const item_head& head, int64_t& value) noexcept
+        {
+            const uint64_t int64_max = static_cast<uint64_t>((std::numeric_limits<int64_t>::max)());
+            if (head.major_type == cbor::detail::cbor_major_type::unsigned_integer && head.value <= int64_max)
+            {
+                value = static_cast<int64_t>(head.value);
+                return true;
+            }
+            if (head.major_type == cbor::detail::cbor_major_type::negative_integer && head.value <= int64_max)
+            {
+                value = -1 - static_cast<int64_t>(head.value);
+                return true;
+            }
+            return false;
+        }
+
+        inline bool bool_value(const item_head& head, bool& value) noexcept
+        {
+            if (head.major_type != cbor::detail::cbor_major_type::simple ||
+                (head.additional_info != 20 && head.additional_info != 21))
+            {
+                return false;
+            }
+            value = head.additional_info == 21;
+            return true;
+        }
+
+        inline bool double_value(const item_head& head, double& value) noexcept
+        {
+            if (head.major_type != cbor::detail::cbor_major_type::simple)
+            {
+                return false;
+            }
+            switch (head.additional_info)
+            {
+                case 25:
+                    value = binary::decode_half(static_cast<uint16_t>(head.value));
+                    return true;
+                case 26:
+                {
+                    const uint32_t bits = static_cast<uint32_t>(head.value);
+                    float single;
+                    std::memcpy(&single, &bits, sizeof single);
+                    value = single;
+                    return true;
+                }
+                case 27:
+                {
+                    const uint64_t bits = head.value;
+                    std::memcpy(&value, &bits, sizeof value);
+                    return true;
+                }
+                default:
+                    return false;
+            }
+        }
+
+        inline bool text(const item_head& head, const uint8_t* content, string_view& value) noexcept
+        {
+            if (head.major_type != cbor::detail::cbor_major_type::text_string || head.indefinite())
+            {
+                return false;
+            }
+            value = string_view(reinterpret_cast<const char*>(content), static_cast<std::size_t>(head.value));
+            return true;
+        }
+
+        inline bool bytes(const item_head& head, const uint8_t* content, span<const uint8_t>& value) noexcept
+        {
+            if (head.major_type != cbor::detail::cbor_major_type::byte_string || head.indefinite())
+            {
+                return false;
+            }
+            value = span<const uint8_t>(content, static_cast<std::size_t>(head.value));
+            return true;
+        }
 
         inline int sign(int value) noexcept
         {
@@ -291,7 +392,7 @@ namespace view {
         {
             static constexpr std::size_t local_capacity = 32;
 
-            uint64_t local_[local_capacity];
+            uint64_t local_[local_capacity]{};
             std::vector<uint64_t> spill_;
             std::size_t size_{0};
             std::size_t peak_size_{0};
@@ -318,18 +419,6 @@ namespace view {
                 peak_size_ = 0;
             }
 
-            void swap(pending_stack& other) noexcept
-            {
-                for (std::size_t i = 0; i < local_capacity; ++i)
-                {
-                    using std::swap;
-                    swap(local_[i], other.local_[i]);
-                }
-                spill_.swap(other.spill_);
-                using std::swap;
-                swap(size_, other.size_);
-                swap(peak_size_, other.peak_size_);
-            }
 
             void push(uint64_t count)
             {
@@ -480,31 +569,6 @@ namespace view {
             return skip_scalar_or_string(head, p, end, ec);
         }
 
-        // Skips one item over bytes already validated by a scan, surfacing
-        // the untagged head and content position so callers can build items
-        // without reparsing. Cannot fail; the depth bound was enforced when
-        // the bytes were scanned. Shallow items take no workspace at all.
-        inline const uint8_t* skip_checked(const uint8_t* p, const uint8_t* end,
-            item_head& head, const uint8_t*& content) noexcept
-        {
-            std::error_code ec;
-            bool ok = read_value_head(p, end, head, ec);
-            assert(ok);
-            content = p;
-            if (head.major_type == cbor::detail::cbor_major_type::array ||
-                head.major_type == cbor::detail::cbor_major_type::map)
-            {
-                pending_stack open;
-                ok = skip_container(p, end, head, (std::numeric_limits<int>::max)(), open, ec);
-            }
-            else
-            {
-                ok = skip_scalar_or_string(head, p, end, ec);
-            }
-            assert(ok && !ec);
-            (void)ok;
-            return p;
-        }
 
         inline bool validate_utf8(const uint8_t* p, std::size_t length) noexcept
         {
@@ -518,9 +582,9 @@ namespace view {
 
     } // namespace detail_view
 
-    // A checked, zero-copy view of one complete, well-formed encoded CBOR
+    // A checked, zero-copy view of one complete, structurally well-formed CBOR
     // item: its leading semantic tags, head, and content. Obtained from
-    // scan_prefix or parse_exact, or by iterating a container item; never
+    // scan_prefix, parse_exact, wire_cursor, or navigator::finish_item; never
     // constructed from unvalidated bytes. Borrows the scanned input, so it
     // must not outlive the bytes it was scanned from.
     class item
@@ -535,16 +599,7 @@ namespace view {
 
         item_kind kind() const noexcept
         {
-            switch (head_.major_type)
-            {
-                case cbor::detail::cbor_major_type::unsigned_integer: return item_kind::unsigned_integer;
-                case cbor::detail::cbor_major_type::negative_integer: return item_kind::negative_integer;
-                case cbor::detail::cbor_major_type::byte_string:      return item_kind::byte_string;
-                case cbor::detail::cbor_major_type::text_string:      return item_kind::text_string;
-                case cbor::detail::cbor_major_type::array:            return item_kind::array;
-                case cbor::detail::cbor_major_type::map:              return item_kind::map;
-                default:                                              return item_kind::simple;
-            }
+            return detail_view::kind(head_);
         }
 
         // The head's argument (RFC 8949 3): the integer's value, a string's
@@ -562,123 +617,50 @@ namespace view {
 
         class tag_iterator;
         class tag_range;
-        class element_iterator;
-        class element_range;
         class chunk_iterator;
         class chunk_range;
-        class entry_iterator;
-        class entry_range;
 
         // The item's leading semantic tags, outermost first. Empty for
         // untagged items. Tags are exposed, never interpreted: deciding what
         // a tag means is the caller's or a higher layer's concern.
         tag_range tags() const noexcept;
 
-        // The elements of an array item, in order; empty unless kind() is
-        // array. Iteration is read-only and borrows this item's bytes.
-        element_range elements() const noexcept;
-
-        // The entries of a map item, in order; empty unless kind() is map.
-        entry_range entries() const noexcept;
-
         // The content of a string item as contiguous spans: one span for a
         // definite-length string, one per chunk for an indefinite-length
         // one. Empty unless kind() is byte_string or text_string.
         chunk_range chunks() const noexcept;
 
-        // The typed accessors below return false, leaving `value` untouched,
-        // when this item is not of the requested kind. Well-formedness was
-        // established when the item was scanned, so kind is the only thing
-        // that can be wrong.
-
+        // The typed accessors return false, leaving `value` untouched, on a
+        // kind mismatch. Structural well-formedness was established by scanning.
         bool uint64_value(uint64_t& value) const noexcept
         {
-            if (head_.major_type != cbor::detail::cbor_major_type::unsigned_integer)
-            {
-                return false;
-            }
-            value = head_.value;
-            return true;
+            return detail_view::uint64_value(head_, value);
         }
 
         bool int64_value(int64_t& value) const noexcept
         {
-            const uint64_t int64_max = static_cast<uint64_t>((std::numeric_limits<int64_t>::max)());
-            if (head_.major_type == cbor::detail::cbor_major_type::unsigned_integer && head_.value <= int64_max)
-            {
-                value = static_cast<int64_t>(head_.value);
-                return true;
-            }
-            if (head_.major_type == cbor::detail::cbor_major_type::negative_integer && head_.value <= int64_max)
-            {
-                value = -1 - static_cast<int64_t>(head_.value);
-                return true;
-            }
-            return false;
+            return detail_view::int64_value(head_, value);
         }
 
         bool bool_value(bool& value) const noexcept
         {
-            if (head_.major_type != cbor::detail::cbor_major_type::simple ||
-                (head_.additional_info != 20 && head_.additional_info != 21))
-            {
-                return false;
-            }
-            value = head_.additional_info == 21;
-            return true;
+            return detail_view::bool_value(head_, value);
         }
 
         bool double_value(double& value) const noexcept
         {
-            if (head_.major_type != cbor::detail::cbor_major_type::simple)
-            {
-                return false;
-            }
-            switch (head_.additional_info)
-            {
-                case 25:
-                    value = binary::decode_half(static_cast<uint16_t>(head_.value));
-                    return true;
-                case 26:
-                {
-                    const uint32_t bits = static_cast<uint32_t>(head_.value);
-                    float single;
-                    std::memcpy(&single, &bits, sizeof single);
-                    value = single;
-                    return true;
-                }
-                case 27:
-                {
-                    const uint64_t bits = head_.value;
-                    std::memcpy(&value, &bits, sizeof value);
-                    return true;
-                }
-                default:
-                    return false;
-            }
+            return detail_view::double_value(head_, value);
         }
 
-        // Zero-copy string content. False for indefinite-length (chunked)
-        // strings, whose content is not contiguous; use chunks() or the
-        // copying overloads for those.
+        // Zero-copy string content. False for indefinite-length strings.
         bool text(string_view& value) const noexcept
         {
-            if (head_.major_type != cbor::detail::cbor_major_type::text_string || head_.indefinite())
-            {
-                return false;
-            }
-            value = string_view(reinterpret_cast<const char*>(content_), static_cast<std::size_t>(head_.value));
-            return true;
+            return detail_view::text(head_, content_, value);
         }
 
         bool bytes(span<const uint8_t>& value) const noexcept
         {
-            if (head_.major_type != cbor::detail::cbor_major_type::byte_string || head_.indefinite())
-            {
-                return false;
-            }
-            value = span<const uint8_t>(content_, static_cast<std::size_t>(head_.value));
-            return true;
+            return detail_view::bytes(head_, content_, value);
         }
 
         // Copying string content, assembling chunked strings. Transactional:
@@ -753,29 +735,14 @@ namespace view {
     class wire_cursor
     {
     public:
-        wire_cursor() noexcept
-            : input_(), offset_(0)
-        {
-        }
 
         explicit wire_cursor(span<const uint8_t> input) noexcept
             : input_(input), offset_(0)
         {
         }
 
-        template <typename Container,
-                  typename std::enable_if<!std::is_trivially_copyable<Container>::value, int>::type = 0>
+        template <typename Container>
         wire_cursor(const Container&&) = delete;
-
-        void reset(span<const uint8_t> input) noexcept
-        {
-            input_ = input;
-            offset_ = 0;
-        }
-
-        template <typename Container,
-                  typename std::enable_if<!std::is_trivially_copyable<Container>::value, int>::type = 0>
-        void reset(const Container&&) = delete;
 
         std::size_t position() const noexcept
         {
@@ -821,8 +788,6 @@ namespace view {
         // at which the supplied scanning workspace may grow.
         expected<item, scan_error> read_item(scan_context& context);
 
-        expected<item, scan_error> read_item(
-            int max_nesting_depth = default_max_nesting_depth);
 
     private:
         span<const uint8_t> input_;
@@ -937,257 +902,6 @@ namespace view {
         return tag_range(bytes_.data(), stop);
     }
 
-    // Iterates the elements of an array item as checked items.
-    class item::element_iterator
-    {
-    public:
-        using value_type = item;
-        using reference = item;
-        using pointer = void;
-        using difference_type = std::ptrdiff_t;
-        using iterator_category = std::input_iterator_tag;
-
-        element_iterator() noexcept : pos_(nullptr), end_(nullptr), remaining_(0), current_(nullptr), content_(nullptr) {}
-
-        item operator*() const noexcept
-        {
-            assert(pos_ != nullptr);
-            return detail_view::item_access::make(
-                span<const uint8_t>(pos_, static_cast<std::size_t>(current_ - pos_)), head_, content_);
-        }
-
-        element_iterator& operator++()
-        {
-            pos_ = current_;
-            advance();
-            return *this;
-        }
-
-        element_iterator operator++(int)
-        {
-            element_iterator temp = *this;
-            ++(*this);
-            return temp;
-        }
-
-        friend bool operator==(const element_iterator& a, const element_iterator& b) noexcept
-        {
-            return a.pos_ == b.pos_;
-        }
-
-        friend bool operator!=(const element_iterator& a, const element_iterator& b) noexcept
-        {
-            return a.pos_ != b.pos_;
-        }
-
-    private:
-        friend class item;
-        friend class element_range;
-
-        element_iterator(const uint8_t* pos, const uint8_t* end, uint64_t remaining) noexcept
-            : pos_(pos), end_(end), remaining_(remaining), current_(nullptr), content_(nullptr)
-        {
-            advance();
-        }
-
-        void advance() noexcept
-        {
-            if (pos_ == nullptr)
-            {
-                return;
-            }
-            if (remaining_ == detail_view::indefinite_array_marker)
-            {
-                assert(pos_ < end_);
-                if (*pos_ == 0xff)
-                {
-                    pos_ = nullptr;
-                    return;
-                }
-            }
-            else if (remaining_ == 0)
-            {
-                pos_ = nullptr;
-                return;
-            }
-            else
-            {
-                --remaining_;
-            }
-            current_ = detail_view::skip_checked(pos_, end_, head_, content_);
-        }
-
-        const uint8_t* pos_;       // start of the current element; nullptr at end
-        const uint8_t* end_;
-        uint64_t remaining_;       // count left, or indefinite_array_marker
-        const uint8_t* current_;   // end of the current element
-        detail_view::item_head head_;
-        const uint8_t* content_;
-    };
-
-    class item::element_range
-    {
-    public:
-        using iterator = element_iterator;
-        using const_iterator = element_iterator;
-
-        element_iterator begin() const noexcept { return element_iterator(first_, end_, remaining_); }
-        element_iterator end() const noexcept { return element_iterator(); }
-        bool empty() const noexcept { return begin() == this->end(); }
-
-    private:
-        friend class item;
-        element_range(const uint8_t* first, const uint8_t* end, uint64_t remaining) noexcept
-            : first_(first), end_(end), remaining_(remaining) {}
-
-        const uint8_t* first_;
-        const uint8_t* end_;
-        uint64_t remaining_;
-    };
-
-    inline item::element_range item::elements() const noexcept
-    {
-        if (head_.major_type != cbor::detail::cbor_major_type::array)
-        {
-            return element_range(nullptr, nullptr, 0);
-        }
-        return element_range(content_, bytes_.data() + bytes_.size(),
-            head_.indefinite() ? detail_view::indefinite_array_marker : head_.value);
-    }
-
-    // One entry of a map item.
-    struct map_entry
-    {
-        item key;
-        item value;
-    };
-
-    // Iterates the entries of a map item as checked key and value items.
-    class item::entry_iterator
-    {
-    public:
-        using value_type = map_entry;
-        using reference = map_entry;
-        using pointer = void;
-        using difference_type = std::ptrdiff_t;
-        using iterator_category = std::input_iterator_tag;
-
-        entry_iterator() noexcept : pos_(nullptr), end_(nullptr), remaining_(0), key_end_(nullptr), value_end_(nullptr),
-            key_content_(nullptr), value_content_(nullptr) {}
-
-        map_entry operator*() const noexcept
-        {
-            assert(pos_ != nullptr);
-            return map_entry{
-                detail_view::item_access::make(
-                    span<const uint8_t>(pos_, static_cast<std::size_t>(key_end_ - pos_)), key_head_, key_content_),
-                detail_view::item_access::make(
-                    span<const uint8_t>(key_end_, static_cast<std::size_t>(value_end_ - key_end_)), value_head_, value_content_)};
-        }
-
-        entry_iterator& operator++()
-        {
-            pos_ = value_end_;
-            advance();
-            return *this;
-        }
-
-        entry_iterator operator++(int)
-        {
-            entry_iterator temp = *this;
-            ++(*this);
-            return temp;
-        }
-
-        friend bool operator==(const entry_iterator& a, const entry_iterator& b) noexcept
-        {
-            return a.pos_ == b.pos_;
-        }
-
-        friend bool operator!=(const entry_iterator& a, const entry_iterator& b) noexcept
-        {
-            return a.pos_ != b.pos_;
-        }
-
-    private:
-        friend class item;
-        friend class entry_range;
-
-        entry_iterator(const uint8_t* pos, const uint8_t* end, uint64_t remaining) noexcept
-            : pos_(pos), end_(end), remaining_(remaining), key_end_(nullptr), value_end_(nullptr),
-              key_content_(nullptr), value_content_(nullptr)
-        {
-            advance();
-        }
-
-        void advance() noexcept
-        {
-            if (pos_ == nullptr)
-            {
-                return;
-            }
-            if (remaining_ == detail_view::indefinite_map_key_marker)
-            {
-                assert(pos_ < end_);
-                if (*pos_ == 0xff)
-                {
-                    pos_ = nullptr;
-                    return;
-                }
-            }
-            else if (remaining_ == 0)
-            {
-                pos_ = nullptr;
-                return;
-            }
-            else
-            {
-                --remaining_;
-            }
-            key_end_ = detail_view::skip_checked(pos_, end_, key_head_, key_content_);
-            value_end_ = detail_view::skip_checked(key_end_, end_, value_head_, value_content_);
-        }
-
-        const uint8_t* pos_;        // start of the current entry's key; nullptr at end
-        const uint8_t* end_;
-        uint64_t remaining_;        // entry count left, or indefinite_map_key_marker
-        const uint8_t* key_end_;
-        const uint8_t* value_end_;
-        detail_view::item_head key_head_;
-        const uint8_t* key_content_;
-        detail_view::item_head value_head_;
-        const uint8_t* value_content_;
-    };
-
-    class item::entry_range
-    {
-    public:
-        using iterator = entry_iterator;
-        using const_iterator = entry_iterator;
-
-        entry_iterator begin() const noexcept { return entry_iterator(first_, end_, remaining_); }
-        entry_iterator end() const noexcept { return entry_iterator(); }
-        bool empty() const noexcept { return begin() == this->end(); }
-
-    private:
-        friend class item;
-        entry_range(const uint8_t* first, const uint8_t* end, uint64_t remaining) noexcept
-            : first_(first), end_(end), remaining_(remaining) {}
-
-        const uint8_t* first_;
-        const uint8_t* end_;
-        uint64_t remaining_;
-    };
-
-    inline item::entry_range item::entries() const noexcept
-    {
-        if (head_.major_type != cbor::detail::cbor_major_type::map)
-        {
-            return entry_range(nullptr, nullptr, 0);
-        }
-        return entry_range(content_, bytes_.data() + bytes_.size(),
-            head_.indefinite() ? detail_view::indefinite_map_key_marker : head_.value);
-    }
 
     // Iterates the contiguous spans of a string item's content.
     class item::chunk_iterator
@@ -1379,22 +1093,10 @@ namespace view {
             position_role role{position_role::root};
         };
 
-        enum class container_phase : uint8_t
-        {
-            array,
-            map_key,
-            map_value
-        };
-
         struct navigation_frame
         {
             node_state container{};
-            std::size_t next_offset{npos};
-            std::size_t content_fence{npos};
             uint64_t remaining{0};
-            container_phase phase{container_phase::array};
-            bool indefinite{false};
-            bool completed{false};
         };
 
     public:
@@ -1405,16 +1107,7 @@ namespace view {
 
         item_kind kind() const noexcept
         {
-            switch (current_.head.major_type)
-            {
-                case cbor::detail::cbor_major_type::unsigned_integer: return item_kind::unsigned_integer;
-                case cbor::detail::cbor_major_type::negative_integer: return item_kind::negative_integer;
-                case cbor::detail::cbor_major_type::byte_string:      return item_kind::byte_string;
-                case cbor::detail::cbor_major_type::text_string:      return item_kind::text_string;
-                case cbor::detail::cbor_major_type::array:            return item_kind::array;
-                case cbor::detail::cbor_major_type::map:              return item_kind::map;
-                default:                                              return item_kind::simple;
-            }
+            return detail_view::kind(current_.head);
         }
 
         uint64_t argument() const noexcept
@@ -1445,95 +1138,34 @@ namespace view {
 
         bool uint64_value(uint64_t& value) const noexcept
         {
-            if (current_.head.major_type != cbor::detail::cbor_major_type::unsigned_integer)
-            {
-                return false;
-            }
-            value = current_.head.value;
-            return true;
+            return detail_view::uint64_value(current_.head, value);
         }
 
         bool int64_value(int64_t& value) const noexcept
         {
-            const uint64_t int64_max = static_cast<uint64_t>((std::numeric_limits<int64_t>::max)());
-            if (current_.head.major_type == cbor::detail::cbor_major_type::unsigned_integer &&
-                current_.head.value <= int64_max)
-            {
-                value = static_cast<int64_t>(current_.head.value);
-                return true;
-            }
-            if (current_.head.major_type == cbor::detail::cbor_major_type::negative_integer &&
-                current_.head.value <= int64_max)
-            {
-                value = -1 - static_cast<int64_t>(current_.head.value);
-                return true;
-            }
-            return false;
+            return detail_view::int64_value(current_.head, value);
         }
 
         bool bool_value(bool& value) const noexcept
         {
-            if (current_.head.major_type != cbor::detail::cbor_major_type::simple ||
-                (current_.head.additional_info != 20 && current_.head.additional_info != 21))
-            {
-                return false;
-            }
-            value = current_.head.additional_info == 21;
-            return true;
+            return detail_view::bool_value(current_.head, value);
         }
 
         bool double_value(double& value) const noexcept
         {
-            if (current_.head.major_type != cbor::detail::cbor_major_type::simple)
-            {
-                return false;
-            }
-            switch (current_.head.additional_info)
-            {
-                case 25:
-                    value = binary::decode_half(static_cast<uint16_t>(current_.head.value));
-                    return true;
-                case 26:
-                {
-                    const uint32_t bits = static_cast<uint32_t>(current_.head.value);
-                    float single;
-                    std::memcpy(&single, &bits, sizeof single);
-                    value = single;
-                    return true;
-                }
-                case 27:
-                {
-                    const uint64_t bits = current_.head.value;
-                    std::memcpy(&value, &bits, sizeof value);
-                    return true;
-                }
-                default:
-                    return false;
-            }
+            return detail_view::double_value(current_.head, value);
         }
 
         bool text(string_view& value) const noexcept
         {
-            if (current_.head.major_type != cbor::detail::cbor_major_type::text_string ||
-                current_.head.indefinite())
-            {
-                return false;
-            }
-            value = string_view(reinterpret_cast<const char*>(input_.data() + current_.content_begin),
-                                static_cast<std::size_t>(current_.head.value));
-            return true;
+            return detail_view::text(current_.head,
+                                     input_.data() + current_.content_begin, value);
         }
 
         bool bytes(span<const uint8_t>& value) const noexcept
         {
-            if (current_.head.major_type != cbor::detail::cbor_major_type::byte_string ||
-                current_.head.indefinite())
-            {
-                return false;
-            }
-            value = span<const uint8_t>(input_.data() + current_.content_begin,
-                                        static_cast<std::size_t>(current_.head.value));
-            return true;
+            return detail_view::bytes(current_.head,
+                                      input_.data() + current_.content_begin, value);
         }
 
         bool enter() noexcept;
@@ -1557,19 +1189,17 @@ namespace view {
             span<const uint8_t> input,
             int max_nesting_depth = default_max_nesting_depth);
 
-        expected<void, scan_error> reset_exact(
+        expected<span<const uint8_t>, scan_error> reset_exact(
             span<const uint8_t> input,
             int max_nesting_depth = default_max_nesting_depth);
 
-        template <typename Container,
-                  typename std::enable_if<!std::is_trivially_copyable<Container>::value, int>::type = 0>
+        template <typename Container>
         expected<span<const uint8_t>, scan_error> reset_prefix(
             const Container&&,
             int = default_max_nesting_depth) = delete;
 
-        template <typename Container,
-                  typename std::enable_if<!std::is_trivially_copyable<Container>::value, int>::type = 0>
-        expected<void, scan_error> reset_exact(
+        template <typename Container>
+        expected<span<const uint8_t>, scan_error> reset_exact(
             const Container&&,
             int = default_max_nesting_depth) = delete;
 
@@ -1585,7 +1215,7 @@ namespace view {
 
         navigator(span<const uint8_t> root, std::size_t peak_depth,
                   detail_view::pending_stack&& validation_workspace)
-            : input_(root), root_(), current_(), frames_(peak_depth),
+            : input_(root), frames_(peak_depth),
               validation_workspace_(std::move(validation_workspace)), active_depth_(0)
         {
             initialize_root();
@@ -1593,29 +1223,7 @@ namespace view {
 
         void initialize_root() noexcept
         {
-            assert(!input_.empty());
-            const uint8_t* const base = input_.data();
-            const uint8_t* p = base;
-            const uint8_t* const end = base + input_.size();
-            detail_view::item_head head;
-            std::error_code ec;
-            std::size_t head_begin = 0;
-            bool ok;
-            do
-            {
-                head_begin = static_cast<std::size_t>(p - base);
-                ok = detail_view::read_head(p, end, head, ec);
-                assert(ok && !ec);
-            }
-            while (head.major_type == cbor::detail::cbor_major_type::semantic_tag);
-            (void)ok;
-
-            root_.begin = 0;
-            root_.head_begin = head_begin;
-            root_.content_begin = static_cast<std::size_t>(p - base);
-            root_.end = input_.size();
-            root_.head = head;
-            root_.role = position_role::root;
+            root_ = read_node(0, position_role::root, input_.size());
             current_ = root_;
             active_depth_ = 0;
         }
@@ -1652,16 +1260,6 @@ namespace view {
     {
         navigator first;
         span<const uint8_t> remainder;
-
-        navigation_result(navigator&& first, span<const uint8_t> remainder) noexcept
-            : first(std::move(first)), remainder(remainder)
-        {
-        }
-
-        navigation_result(navigation_result&&) noexcept = default;
-        navigation_result& operator=(navigation_result&&) noexcept = default;
-        navigation_result(const navigation_result&) = delete;
-        navigation_result& operator=(const navigation_result&) = delete;
     };
 
 
@@ -1706,11 +1304,6 @@ namespace view {
             {
                 return context.workspace_.peak_size();
             }
-
-            static void swap_workspace(scan_context& context, pending_stack& workspace) noexcept
-            {
-                context.workspace_.swap(workspace);
-            }
         };
 
         // All error codes assigned by the walker are cbor_errc values.
@@ -1727,7 +1320,7 @@ namespace view {
         span<const uint8_t> remainder;
     };
 
-    // Scans the first item in `input`, validating its well-formedness, and
+    // Scans the first item in `input`, validating structural well-formedness, and
     // returns it together with the remaining bytes. On failure the error
     // holds the offending code and the offset at which scanning stopped.
     inline expected<scan_result, scan_error> scan_prefix(span<const uint8_t> input, scan_context& context)
@@ -1811,11 +1404,6 @@ namespace view {
         return scanned.value().first;
     }
 
-    inline expected<item, scan_error> wire_cursor::read_item(int max_nesting_depth)
-    {
-        scan_context context(max_nesting_depth);
-        return read_item(context);
-    }
 
     inline expected<navigation_result, scan_error> navigate_prefix(
         span<const uint8_t> input,
@@ -1832,7 +1420,7 @@ namespace view {
             scanned.value().first.encoded_bytes(),
             detail_view::scan_access::peak_depth(context),
             std::move(detail_view::scan_access::workspace(context)));
-        return navigation_result(std::move(result), scanned.value().remainder);
+        return navigation_result{std::move(result), scanned.value().remainder};
     }
 
     inline expected<navigator, scan_error> navigate_exact(
@@ -1857,10 +1445,10 @@ namespace view {
         span<const uint8_t> input, int max_nesting_depth)
     {
         scan_context context(max_nesting_depth);
-        detail_view::scan_access::swap_workspace(context, validation_workspace_);
+        detail_view::scan_access::workspace(context) = std::move(validation_workspace_);
         auto scanned = scan_prefix(input, context);
         const std::size_t peak_depth = detail_view::scan_access::peak_depth(context);
-        detail_view::scan_access::swap_workspace(context, validation_workspace_);
+        validation_workspace_ = std::move(detail_view::scan_access::workspace(context));
         if (!scanned)
         {
             return expected<span<const uint8_t>, scan_error>(unexpect, scanned.error());
@@ -1870,27 +1458,27 @@ namespace view {
         return scanned.value().remainder;
     }
 
-    inline expected<void, scan_error> navigator::reset_exact(
+    inline expected<span<const uint8_t>, scan_error> navigator::reset_exact(
         span<const uint8_t> input, int max_nesting_depth)
     {
         scan_context context(max_nesting_depth);
-        detail_view::scan_access::swap_workspace(context, validation_workspace_);
+        detail_view::scan_access::workspace(context) = std::move(validation_workspace_);
         auto scanned = scan_prefix(input, context);
         const std::size_t peak_depth = detail_view::scan_access::peak_depth(context);
-        detail_view::scan_access::swap_workspace(context, validation_workspace_);
+        validation_workspace_ = std::move(detail_view::scan_access::workspace(context));
         if (!scanned)
         {
-            return expected<void, scan_error>(unexpect, scanned.error());
+            return expected<span<const uint8_t>, scan_error>(unexpect, scanned.error());
         }
         if (!scanned.value().remainder.empty())
         {
-            return expected<void, scan_error>(unexpect,
+            return expected<span<const uint8_t>, scan_error>(unexpect,
                 scan_error{cbor_errc::trailing_data,
                     scanned.value().first.encoded_bytes().size()});
         }
 
         prepare_checked(scanned.value().first.encoded_bytes(), peak_depth);
-        return expected<void, scan_error>();
+        return span<const uint8_t>();
     }
 
     inline navigator::node_state navigator::read_node(
@@ -1967,20 +1555,17 @@ namespace view {
         navigation_frame& frame, const node_state& container) noexcept
     {
         frame.container = container;
-        frame.next_offset = container.content_begin;
-        frame.content_fence = container.end;
-        frame.indefinite = container.head.indefinite();
-        frame.completed = false;
-        if (container.head.major_type == cbor::detail::cbor_major_type::array)
+        if (container.head.indefinite())
         {
-            frame.phase = container_phase::array;
-            frame.remaining = frame.indefinite ? 0 : container.head.value;
+            frame.remaining = container.head.major_type == cbor::detail::cbor_major_type::map
+                ? detail_view::indefinite_map_key_marker
+                : detail_view::indefinite_array_marker;
         }
         else
         {
-            assert(container.head.major_type == cbor::detail::cbor_major_type::map);
-            frame.phase = container_phase::map_key;
-            frame.remaining = frame.indefinite ? 0 : 2 * container.head.value;
+            frame.remaining = container.head.major_type == cbor::detail::cbor_major_type::map
+                ? 2 * container.head.value
+                : container.head.value;
         }
     }
 
@@ -1989,54 +1574,56 @@ namespace view {
         position_role& role, std::size_t& right_fence) noexcept
     {
         right_fence = npos;
-        if (frame.indefinite)
+        if (frame.remaining == 0)
         {
-            const bool at_item_boundary = frame.phase != container_phase::map_value;
-            if (at_item_boundary && input_[offset] == 0xff)
+            if (frame.container.end != npos)
             {
-                ++offset;
-                frame.container.end = offset;
-                frame.next_offset = offset;
-                frame.completed = true;
-                return false;
+                assert(offset == frame.container.end);
+                offset = frame.container.end;
             }
+            else
+            {
+                frame.container.end = offset;
+            }
+            return false;
         }
-        else
+
+        if (frame.remaining == detail_view::indefinite_array_marker ||
+            frame.remaining == detail_view::indefinite_map_key_marker)
         {
-            if (frame.remaining == 0)
+            if (input_[offset] == 0xff)
             {
-                if (frame.content_fence != npos)
-                {
-                    assert(offset == frame.content_fence);
-                    offset = frame.content_fence;
-                }
-                frame.container.end = offset;
-                frame.next_offset = offset;
-                frame.completed = true;
+                frame.container.end = ++offset;
+                frame.remaining = 0;
                 return false;
-            }
-            --frame.remaining;
-            if (frame.remaining == 0 && frame.content_fence != npos)
-            {
-                right_fence = frame.content_fence;
             }
         }
 
-        switch (frame.phase)
+        if (frame.remaining < detail_view::indefinite_map_value_marker)
         {
-            case container_phase::array:
-                role = position_role::array_element;
-                break;
-            case container_phase::map_key:
-                role = position_role::map_key;
-                frame.phase = container_phase::map_value;
-                break;
-            case container_phase::map_value:
-                role = position_role::map_value;
-                frame.phase = container_phase::map_key;
-                break;
+            role = frame.container.head.major_type == cbor::detail::cbor_major_type::map
+                ? ((frame.remaining & 1) == 0 ? position_role::map_key : position_role::map_value)
+                : position_role::array_element;
+            --frame.remaining;
+            if (frame.remaining == 0 && frame.container.end != npos)
+            {
+                right_fence = frame.container.end;
+            }
         }
-        frame.next_offset = offset;
+        else if (frame.remaining == detail_view::indefinite_array_marker)
+        {
+            role = position_role::array_element;
+        }
+        else if (frame.remaining == detail_view::indefinite_map_key_marker)
+        {
+            role = position_role::map_key;
+            frame.remaining = detail_view::indefinite_map_value_marker;
+        }
+        else
+        {
+            role = position_role::map_value;
+            frame.remaining = detail_view::indefinite_map_key_marker;
+        }
         return true;
     }
 
@@ -2048,65 +1635,18 @@ namespace view {
         }
 
         const uint8_t* const base = input_.data();
-        const uint8_t* const input_end = base + input_.size();
-        if (node.head.major_type != cbor::detail::cbor_major_type::array &&
-            node.head.major_type != cbor::detail::cbor_major_type::map)
-        {
-            const uint8_t* p = base + node.content_begin;
-            std::error_code ec;
-            const bool ok = detail_view::skip_scalar_or_string(node.head, p, input_end, ec);
-            assert(ok && !ec);
-            (void)ok;
-            node.end = static_cast<std::size_t>(p - base);
-            return;
-        }
-
-        std::size_t scratch_depth = 0;
-        assert(active_depth_ < frames_.size());
-        initialize_frame(frames_[active_depth_], node);
-        ++scratch_depth;
-        std::size_t offset = node.content_begin;
-
-        for (;;)
-        {
-            navigation_frame& frame = frames_[active_depth_ + scratch_depth - 1];
-            position_role child_role = position_role::array_element;
-            std::size_t right_fence = npos;
-            if (!take_child(frame, offset, child_role, right_fence))
-            {
-                offset = frame.container.end;
-                --scratch_depth;
-                if (scratch_depth == 0)
-                {
-                    node.end = offset;
-                    return;
-                }
-                continue;
-            }
-
-            node_state child = read_node(offset, child_role, right_fence);
-            if (child.end != npos)
-            {
-                offset = child.end;
-                continue;
-            }
-            if (child.head.major_type == cbor::detail::cbor_major_type::array ||
-                child.head.major_type == cbor::detail::cbor_major_type::map)
-            {
-                assert(active_depth_ + scratch_depth < frames_.size());
-                initialize_frame(frames_[active_depth_ + scratch_depth], child);
-                ++scratch_depth;
-                offset = child.content_begin;
-                continue;
-            }
-
-            const uint8_t* p = base + child.content_begin;
-            std::error_code ec;
-            const bool ok = detail_view::skip_scalar_or_string(child.head, p, input_end, ec);
-            assert(ok && !ec);
-            (void)ok;
-            offset = static_cast<std::size_t>(p - base);
-        }
+        const uint8_t* p = base + node.content_begin;
+        const uint8_t* const end = base + input_.size();
+        std::error_code ec;
+        const bool is_container = node.head.major_type == cbor::detail::cbor_major_type::array ||
+                                  node.head.major_type == cbor::detail::cbor_major_type::map;
+        const bool ok = is_container
+            ? detail_view::skip_container(p, end, node.head,
+                  (std::numeric_limits<int>::max)(), validation_workspace_, ec)
+            : detail_view::skip_scalar_or_string(node.head, p, end, ec);
+        assert(ok && !ec);
+        (void)ok;
+        node.end = static_cast<std::size_t>(p - base);
     }
 
     inline bool navigator::enter() noexcept
@@ -2144,8 +1684,13 @@ namespace view {
         }
 
         navigation_frame& frame = frames_[active_depth_ - 1];
-        if (frame.completed)
+        if (frame.remaining == 0)
         {
+            if (frame.container.end == npos)
+            {
+                establish_end(current_);
+                frame.container.end = current_.end;
+            }
             return false;
         }
         establish_end(current_);
@@ -2197,29 +1742,26 @@ namespace view {
             current_.head, input_.data() + current_.content_begin);
     }
 
-    template <typename Container,
-              typename std::enable_if<!std::is_trivially_copyable<Container>::value, int>::type = 0>
+    template <typename Container>
     expected<navigation_result, scan_error> navigate_prefix(
         const Container&&,
         int = default_max_nesting_depth) = delete;
 
-    template <typename Container,
-              typename std::enable_if<!std::is_trivially_copyable<Container>::value, int>::type = 0>
+    template <typename Container>
     expected<navigator, scan_error> navigate_exact(
         const Container&&,
         int = default_max_nesting_depth) = delete;
 
 
-    // Guard against scanning a temporary container: the resulting views
-    // would dangle immediately. Non-owning view types (spans, string views)
-    // are trivially copyable and pass through.
-    template <typename Container, typename std::enable_if<!std::is_trivially_copyable<Container>::value, int>::type = 0>
+    // Guard against temporary owning containers; the concrete span overloads
+    // remain available for explicit non-owning views.
+    template <typename Container>
     expected<scan_result, scan_error> scan_prefix(const Container&&, scan_context&) = delete;
-    template <typename Container, typename std::enable_if<!std::is_trivially_copyable<Container>::value, int>::type = 0>
+    template <typename Container>
     expected<scan_result, scan_error> scan_prefix(const Container&&) = delete;
-    template <typename Container, typename std::enable_if<!std::is_trivially_copyable<Container>::value, int>::type = 0>
+    template <typename Container>
     expected<item, scan_error> parse_exact(const Container&&, scan_context&) = delete;
-    template <typename Container, typename std::enable_if<!std::is_trivially_copyable<Container>::value, int>::type = 0>
+    template <typename Container>
     expected<item, scan_error> parse_exact(const Container&&) = delete;
 
     // Deterministic encoding orders over the encoded bytes of items.
@@ -2279,28 +1821,6 @@ namespace view {
         }
     };
 
-    // True if `map_item` is a map whose keys are strictly ascending in the
-    // given order, RFC 8949 4.2 deterministic encoding style. Duplicate
-    // keys are not ascending. Does not allocate.
-    template <typename Compare = bytewise_compare>
-    bool map_keys_sorted(const item& map_item, Compare compare = Compare())
-    {
-        if (map_item.kind() != item_kind::map)
-        {
-            return false;
-        }
-        span<const uint8_t> prev;
-        for (item::entry_iterator it = map_item.entries().begin(); it != item::entry_iterator(); ++it)
-        {
-            const span<const uint8_t> key = (*it).key.encoded_bytes();
-            if (!prev.empty() && compare(prev, key) >= 0)
-            {
-                return false;
-            }
-            prev = key;
-        }
-        return true;
-    }
 
     // Span-based order entry points for raw-span consumers (e.g. collation over
     // byte-string keys). Each validates its input(s) then orders the encoded
@@ -2329,13 +1849,41 @@ namespace view {
     expected<bool, scan_error> map_keys_sorted(span<const uint8_t> input,
         Order order = Order(), int max_nesting_depth = default_max_nesting_depth)
     {
-        scan_context context(max_nesting_depth);
-        auto result = scan_prefix(input, context);
+        auto result = navigate_prefix(input, max_nesting_depth);
         if (!result)
         {
             return expected<bool, scan_error>(unexpect, result.error());
         }
-        return map_keys_sorted(result.value().first, order);
+
+        navigator nav = std::move(result.value().first);
+        if (nav.kind() != item_kind::map)
+        {
+            return false;
+        }
+
+        span<const uint8_t> previous;
+        if (!nav.enter())
+        {
+            return true;
+        }
+        for (;;)
+        {
+            assert(nav.role() == position_role::map_key);
+            const span<const uint8_t> key = nav.finish_item().encoded_bytes();
+            if (!previous.empty() && order(previous, key) >= 0)
+            {
+                return false;
+            }
+            previous = key;
+
+            const bool has_value = nav.next();
+            assert(has_value && nav.role() == position_role::map_value);
+            (void)has_value;
+            if (!nav.next())
+            {
+                return true;
+            }
+        }
     }
 
     // True if `text_item` is a text string whose content is well-formed

--- a/include/jsoncons_ext/cbor/cbor_view.hpp
+++ b/include/jsoncons_ext/cbor/cbor_view.hpp
@@ -720,7 +720,7 @@ namespace view {
     public:
 
         explicit wire_cursor(span<const uint8_t> input) noexcept
-            : input_(input), offset_(0)
+            : begin_(input.data()), current_(input.data()), end_(input.data() + input.size())
         {
         }
 
@@ -729,35 +729,31 @@ namespace view {
 
         std::size_t position() const noexcept
         {
-            return offset_;
+            return static_cast<std::size_t>(current_ - begin_);
         }
 
         span<const uint8_t> remaining() const noexcept
         {
-            const uint8_t* data = offset_ == 0 ? input_.data() : input_.data() + offset_;
-            return span<const uint8_t>(data, input_.size() - offset_);
+            return span<const uint8_t>(current_, static_cast<std::size_t>(end_ - current_));
         }
 
         // Reads one head and advances past that head only. Tags are returned
         // as their own heads. On failure, position() is the reported offset.
         expected<item_head, scan_error> read_head() noexcept
         {
-            if (offset_ >= input_.size())
+            if (current_ >= end_)
             {
                 return expected<item_head, scan_error>(unexpect,
-                    scan_error{cbor_errc::unexpected_eof, offset_});
+                    scan_error{cbor_errc::unexpected_eof, position()});
             }
 
-            const uint8_t* p = input_.data() + offset_;
-            const uint8_t* end = input_.data() + input_.size();
             detail_view::item_head h;
             std::error_code ec;
-            const bool ok = detail_view::read_head(p, end, h, ec);
-            offset_ = static_cast<std::size_t>(p - input_.data());
+            const bool ok = detail_view::read_head(current_, end_, h, ec);
             if (!ok)
             {
                 return expected<item_head, scan_error>(unexpect,
-                    scan_error{static_cast<cbor_errc>(ec.value()), offset_});
+                    scan_error{static_cast<cbor_errc>(ec.value()), position()});
             }
 
             item_head head;
@@ -780,17 +776,18 @@ namespace view {
         // unchanged, when fewer bytes remain.
         bool skip(std::size_t count) noexcept
         {
-            if (input_.size() - offset_ < count)
+            if (static_cast<std::size_t>(end_ - current_) < count)
             {
                 return false;
             }
-            offset_ += count;
+            current_ += count;
             return true;
         }
 
     private:
-        span<const uint8_t> input_;
-        std::size_t offset_;
+        const uint8_t* begin_;
+        const uint8_t* current_;
+        const uint8_t* end_;
     };
 
     // Iterates the values of an item's leading semantic tags.
@@ -1387,38 +1384,33 @@ namespace view {
 
     inline expected<item, scan_error> wire_cursor::read_item(scan_context& context)
     {
-        const std::size_t start = offset_;
+        const std::size_t start = position();
         auto scanned = scan_prefix(remaining(), context);
         if (!scanned)
         {
             scan_error error = scanned.error();
-            const std::size_t available = input_.size() - offset_;
-            const std::size_t consumed = (std::min)(error.offset, available);
-            offset_ += consumed;
+            const std::size_t available = static_cast<std::size_t>(end_ - current_);
+            current_ += (std::min)(error.offset, available);
             error.offset += start;
             return expected<item, scan_error>(unexpect, error);
         }
 
-        offset_ += scanned.value().first.encoded_bytes().size();
+        current_ += scanned.value().first.encoded_bytes().size();
         return scanned.value().first;
     }
 
     inline expected<span<const uint8_t>, scan_error> wire_cursor::skip_item(scan_context& context)
     {
-        const uint8_t* const base = input_.data();
-        const uint8_t* p = base + offset_;
-        const uint8_t* const end = base + input_.size();
-        const std::size_t start = offset_;
+        const uint8_t* const start = current_;
         std::error_code ec;
-        const bool ok = detail_view::skip_item(p, end, context.max_nesting_depth(),
+        const bool ok = detail_view::skip_item(current_, end_, context.max_nesting_depth(),
             detail_view::scan_access::workspace(context), ec);
-        offset_ = static_cast<std::size_t>(p - base);
         if (!ok)
         {
             return expected<span<const uint8_t>, scan_error>(unexpect,
-                scan_error{detail_view::to_cbor_errc(ec), offset_});
+                scan_error{detail_view::to_cbor_errc(ec), position()});
         }
-        return span<const uint8_t>(base + start, offset_ - start);
+        return span<const uint8_t>(start, static_cast<std::size_t>(current_ - start));
     }
 
 

--- a/test/cbor/src/cbor_view_tests.cpp
+++ b/test/cbor/src/cbor_view_tests.cpp
@@ -390,125 +390,6 @@ TEST_CASE("cbor view copying accessors are transactional")
     }
 }
 
-TEST_CASE("cbor view container ranges")
-{
-    SECTION("elements are checked items in order")
-    {
-        // [1, "hi", [2, 3]]
-        std::vector<uint8_t> data = {0x83,0x01,0x62,'h','i',0x82,0x02,0x03};
-        cbor::view::item array_item = parse(data);
-
-        std::vector<cbor::view::item_kind> kinds;
-        std::vector<std::size_t> offsets;
-        for (cbor::view::item element : array_item.elements())
-        {
-            kinds.push_back(element.kind());
-            offsets.push_back(static_cast<std::size_t>(element.encoded_bytes().data() - data.data()));
-        }
-        CHECK((kinds == std::vector<cbor::view::item_kind>{
-            cbor::view::item_kind::unsigned_integer,
-            cbor::view::item_kind::text_string,
-            cbor::view::item_kind::array}));
-        CHECK((offsets == std::vector<std::size_t>{1,2,5}));
-    }
-
-    SECTION("nested containers iterate recursively")
-    {
-        std::vector<uint8_t> data = {0x82,0x81,0x0a,0x82,0x0b,0x0c};   // [[10],[11,12]]
-        uint64_t sum = 0;
-        for (cbor::view::item inner : parse(data).elements())
-        {
-            for (cbor::view::item element : inner.elements())
-            {
-                uint64_t v = 0;
-                REQUIRE(element.uint64_value(v));
-                sum += v;
-            }
-        }
-        CHECK(sum == 33);
-    }
-
-    SECTION("indefinite arrays iterate and may stop early")
-    {
-        std::vector<uint8_t> data = {0x9f,0x01,0x02,0x03,0xff};
-        std::size_t count = 0;
-        for (cbor::view::item element : parse(data).elements())
-        {
-            (void)element;
-            if (++count == 2)
-            {
-                break;
-            }
-        }
-        CHECK(count == 2);
-    }
-
-    SECTION("entries expose checked keys and values")
-    {
-        // {1: "a", "k": 2}
-        std::vector<uint8_t> data = {0xa2,0x01,0x61,0x61,0x61,0x6b,0x02};
-        std::size_t count = 0;
-        for (cbor::view::map_entry entry : parse(data).entries())
-        {
-            if (count == 0)
-            {
-                uint64_t k = 0;
-                REQUIRE(entry.key.uint64_value(k));
-                CHECK(k == 1);
-                jsoncons::string_view v;
-                REQUIRE(entry.value.text(v));
-                CHECK(std::string(v.data(), v.size()) == "a");
-                CHECK(entry.key.encoded_bytes().data() == data.data() + 1);
-                CHECK(entry.value.encoded_bytes().data() == data.data() + 2);
-            }
-            else
-            {
-                jsoncons::string_view k;
-                REQUIRE(entry.key.text(k));
-                CHECK(std::string(k.data(), k.size()) == "k");
-                uint64_t v = 0;
-                REQUIRE(entry.value.uint64_value(v));
-                CHECK(v == 2);
-            }
-            ++count;
-        }
-        CHECK(count == 2);
-    }
-
-    SECTION("indefinite and tagged maps iterate alike")
-    {
-        std::vector<uint8_t> indefinite = {0xbf,0x01,0x02,0x03,0x04,0xff};
-        std::size_t count = 0;
-        for (cbor::view::map_entry entry : parse(indefinite).entries())
-        {
-            (void)entry;
-            ++count;
-        }
-        CHECK(count == 2);
-
-        std::vector<uint8_t> tagged = {0xc0,0xa1,0x01,0x02};
-        cbor::view::item tagged_map = parse(tagged);
-        CHECK_FALSE(tagged_map.tags().empty());
-        count = 0;
-        for (cbor::view::map_entry entry : tagged_map.entries())
-        {
-            (void)entry;
-            ++count;
-        }
-        CHECK(count == 1);
-    }
-
-    SECTION("mismatched and empty ranges are empty")
-    {
-        CHECK(parse({0x80}).elements().empty());
-        CHECK(parse({0xa0}).entries().empty());
-        CHECK(parse({0x9f,0xff}).elements().empty());
-        CHECK(parse({0xbf,0xff}).entries().empty());
-        CHECK(parse({0xa1,0x01,0x02}).elements().empty());   // a map has no elements
-        CHECK(parse({0x81,0x01}).entries().empty());         // an array has no entries
-        CHECK(parse({0x01}).elements().empty());
-    }
-}
 
 TEST_CASE("cbor view string chunks")
 {
@@ -626,35 +507,6 @@ TEST_CASE("cbor view deterministic encoding orders")
     }
 }
 
-TEST_CASE("cbor view map_keys_sorted")
-{
-    SECTION("detects deterministically ordered keys")
-    {
-        std::vector<uint8_t> sorted_map = {0xa2,0x01,0x61,0x61,0x61,0x6b,0x02};
-        std::vector<uint8_t> unsorted_map = {0xa2,0x61,0x6b,0x02,0x01,0x61,0x61};
-        CHECK(cbor::view::map_keys_sorted(parse(sorted_map)));
-        CHECK_FALSE(cbor::view::map_keys_sorted(parse(unsorted_map)));
-    }
-
-    SECTION("duplicate keys are not sorted")
-    {
-        std::vector<uint8_t> dup_map = {0xa2,0x01,0x00,0x01,0x01};
-        CHECK_FALSE(cbor::view::map_keys_sorted(parse(dup_map)));
-    }
-
-    SECTION("bytewise and length-first orders can disagree")
-    {
-        std::vector<uint8_t> m = {0xa2,0x18,0x64,0x00,0x20,0x00};
-        CHECK(cbor::view::map_keys_sorted(parse(m)));
-        CHECK_FALSE(cbor::view::map_keys_sorted(parse(m), cbor::view::length_first_compare()));
-    }
-
-    SECTION("non-maps are not sorted maps")
-    {
-        CHECK_FALSE(cbor::view::map_keys_sorted(parse({0x81,0x01})));
-        CHECK_FALSE(cbor::view::map_keys_sorted(parse({0x01})));
-    }
-}
 
 TEST_CASE("cbor view validate_text")
 {
@@ -894,6 +746,7 @@ TEST_CASE("cbor view navigator movement")
             CHECK(navigator.role() == cbor::view::position_role::map_value);
             CHECK(navigator.argument() == 4);
             CHECK_FALSE(navigator.next());
+            CHECK_FALSE(navigator.next());
             REQUIRE(navigator.leave());
             CHECK(navigator.role() == cbor::view::position_role::root);
         }
@@ -1037,7 +890,7 @@ TEST_CASE("cbor view wire cursor")
 
     SECTION("read_head reports malformed and truncated heads")
     {
-        cbor::view::wire_cursor empty;
+        cbor::view::wire_cursor empty{jsoncons::span<const uint8_t>()};
         auto no_head = empty.read_head();
         REQUIRE_FALSE(no_head.has_value());
         CHECK(no_head.error().code == cbor::cbor_errc::unexpected_eof);
@@ -1076,7 +929,8 @@ TEST_CASE("cbor view wire cursor")
     {
         std::vector<uint8_t> data = {0x01,0x81,0x81,0x01};   // 1 then [[1]]
         cbor::view::wire_cursor cursor{jsoncons::span<const uint8_t>(data)};
-        REQUIRE(cursor.read_item().has_value());
+        cbor::view::scan_context default_context;
+        REQUIRE(cursor.read_item(default_context).has_value());
 
         cbor::view::scan_context context(1);
         auto result = cursor.read_item(context);
@@ -1086,20 +940,6 @@ TEST_CASE("cbor view wire cursor")
         CHECK(cursor.position() == 3);
     }
 
-    SECTION("reset reuses a cursor for a new span")
-    {
-        std::vector<uint8_t> first = {0x01};
-        std::vector<uint8_t> second = {0x02};
-        cbor::view::wire_cursor cursor{jsoncons::span<const uint8_t>(first)};
-        REQUIRE(cursor.read_item().has_value());
-        cursor.reset(jsoncons::span<const uint8_t>(second));
-        CHECK(cursor.position() == 0);
-        auto result = cursor.read_item();
-        REQUIRE(result.has_value());
-        uint64_t value = 0;
-        CHECK(result.value().uint64_value(value));
-        CHECK(value == 2);
-    }
 }
 
 TEST_CASE("cbor view span-based order entry points")
@@ -1138,16 +978,34 @@ TEST_CASE("cbor view span-based order entry points")
         CHECK(result.error().offset == 3);
     }
 
-    SECTION("map_keys_sorted over a span matches the item overload")
+    SECTION("map_keys_sorted validates and checks map keys")
     {
         std::vector<uint8_t> sorted_map = {0xa2,0x01,0x61,0x61,0x61,0x6b,0x02};
         std::vector<uint8_t> unsorted_map = {0xa2,0x61,0x6b,0x02,0x01,0x61,0x61};
+        std::vector<uint8_t> duplicate_map = {0xa2,0x01,0x00,0x01,0x01};
         auto sorted = cbor::view::map_keys_sorted(jsoncons::span<const uint8_t>(sorted_map));
         REQUIRE(sorted.has_value());
         CHECK(sorted.value());
         auto unsorted = cbor::view::map_keys_sorted(jsoncons::span<const uint8_t>(unsorted_map));
         REQUIRE(unsorted.has_value());
         CHECK_FALSE(unsorted.value());
+        auto duplicate = cbor::view::map_keys_sorted(jsoncons::span<const uint8_t>(duplicate_map));
+        REQUIRE(duplicate.has_value());
+        CHECK_FALSE(duplicate.value());
+
+        std::vector<uint8_t> length_order = {0xa2,0x18,0x64,0x00,0x20,0x00};
+        auto bytewise = cbor::view::map_keys_sorted(jsoncons::span<const uint8_t>(length_order));
+        auto length_first = cbor::view::map_keys_sorted(
+            jsoncons::span<const uint8_t>(length_order), cbor::view::length_first_compare());
+        REQUIRE(bytewise.has_value());
+        REQUIRE(length_first.has_value());
+        CHECK(bytewise.value());
+        CHECK_FALSE(length_first.value());
+
+        std::vector<uint8_t> array = {0x81,0x01};
+        auto not_map = cbor::view::map_keys_sorted(jsoncons::span<const uint8_t>(array));
+        REQUIRE(not_map.has_value());
+        CHECK_FALSE(not_map.value());
 
         std::vector<uint8_t> malformed = {0xa1,0x01};   // key, no value
         auto bad = cbor::view::map_keys_sorted(jsoncons::span<const uint8_t>(malformed));

--- a/test/cbor/src/cbor_view_tests.cpp
+++ b/test/cbor/src/cbor_view_tests.cpp
@@ -787,6 +787,17 @@ TEST_CASE("cbor view navigator construction and root access")
         CHECK(navigator.argument() == 1);
         CHECK(navigator.role() == cbor::view::position_role::root);
         CHECK(navigator.depth() == 0);
+        std::vector<uint8_t> deep(100, 0x81);
+        deep.push_back(0x05);
+        REQUIRE(navigator.reset_exact(jsoncons::span<const uint8_t>(deep), 200).has_value());
+        REQUIRE(navigator.reset_exact(jsoncons::span<const uint8_t>(replacement), 200).has_value());
+        REQUIRE(navigator.reset_exact(jsoncons::span<const uint8_t>(deep), 200).has_value());
+        for (std::size_t i = 0; i < 100; ++i)
+        {
+            REQUIRE(navigator.enter());
+        }
+        CHECK(navigator.argument() == 5);
+
     }
 }
 

--- a/test/cbor/src/cbor_view_tests.cpp
+++ b/test/cbor/src/cbor_view_tests.cpp
@@ -790,6 +790,205 @@ TEST_CASE("cbor view navigator construction and root access")
     }
 }
 
+TEST_CASE("cbor view navigator movement")
+{
+    SECTION("walks nested definite arrays without prefinishing parents")
+    {
+        std::vector<uint8_t> data = {0x83,0x01,0x82,0x02,0x03,0x04}; // [1,[2,3],4]
+        auto result = cbor::view::navigate_exact(jsoncons::span<const uint8_t>(data));
+        REQUIRE(result.has_value());
+        cbor::view::navigator navigator = std::move(result.value());
+
+        REQUIRE(navigator.enter());
+        CHECK(navigator.depth() == 1);
+        CHECK(navigator.role() == cbor::view::position_role::array_element);
+        CHECK(navigator.argument() == 1);
+
+        REQUIRE(navigator.next());
+        CHECK(navigator.kind() == cbor::view::item_kind::array);
+        CHECK_FALSE(navigator.extent_known());
+        REQUIRE(navigator.enter());
+        CHECK(navigator.depth() == 2);
+        CHECK(navigator.argument() == 2);
+        REQUIRE(navigator.next());
+        CHECK(navigator.argument() == 3);
+        CHECK_FALSE(navigator.next());
+        CHECK_FALSE(navigator.next());
+        REQUIRE(navigator.leave());
+        CHECK(navigator.depth() == 1);
+        CHECK(navigator.kind() == cbor::view::item_kind::array);
+        CHECK(navigator.extent_known());
+
+        REQUIRE(navigator.next());
+        CHECK(navigator.argument() == 4);
+        CHECK(navigator.extent_known());
+        CHECK_FALSE(navigator.next());
+        REQUIRE(navigator.leave());
+        CHECK(navigator.depth() == 0);
+        CHECK(navigator.kind() == cbor::view::item_kind::array);
+        CHECK_FALSE(navigator.leave());
+    }
+
+    SECTION("next skips an unopened container once")
+    {
+        std::vector<uint8_t> data = {0x82,0x82,0x01,0x02,0x03}; // [[1,2],3]
+        auto result = cbor::view::navigate_exact(jsoncons::span<const uint8_t>(data));
+        REQUIRE(result.has_value());
+        cbor::view::navigator navigator = std::move(result.value());
+        REQUIRE(navigator.enter());
+        CHECK(navigator.kind() == cbor::view::item_kind::array);
+        CHECK_FALSE(navigator.extent_known());
+        REQUIRE(navigator.next());
+        CHECK(navigator.argument() == 3);
+        CHECK(navigator.extent_known());
+    }
+
+    SECTION("early leave skips only the unread remainder")
+    {
+        std::vector<uint8_t> data = {0x82,0x82,0x01,0x02,0x03}; // [[1,2],3]
+        auto result = cbor::view::navigate_exact(jsoncons::span<const uint8_t>(data));
+        REQUIRE(result.has_value());
+        cbor::view::navigator navigator = std::move(result.value());
+        REQUIRE(navigator.enter());
+        REQUIRE(navigator.enter());
+        CHECK(navigator.argument() == 1);
+        REQUIRE(navigator.leave());
+        CHECK(navigator.kind() == cbor::view::item_kind::array);
+        CHECK(navigator.extent_known());
+        REQUIRE(navigator.next());
+        CHECK(navigator.argument() == 3);
+    }
+
+    SECTION("map roles alternate for definite and indefinite maps")
+    {
+        const std::vector<std::vector<uint8_t>> maps = {
+            {0xa2,0x01,0x02,0x03,0x04},
+            {0xbf,0x01,0x02,0x03,0x04,0xff}
+        };
+        for (const auto& data : maps)
+        {
+            auto result = cbor::view::navigate_exact(jsoncons::span<const uint8_t>(data));
+            REQUIRE(result.has_value());
+            cbor::view::navigator navigator = std::move(result.value());
+            REQUIRE(navigator.enter());
+            CHECK(navigator.role() == cbor::view::position_role::map_key);
+            CHECK(navigator.argument() == 1);
+            REQUIRE(navigator.next());
+            CHECK(navigator.role() == cbor::view::position_role::map_value);
+            CHECK(navigator.argument() == 2);
+            REQUIRE(navigator.next());
+            CHECK(navigator.role() == cbor::view::position_role::map_key);
+            CHECK(navigator.argument() == 3);
+            REQUIRE(navigator.next());
+            CHECK(navigator.role() == cbor::view::position_role::map_value);
+            CHECK(navigator.argument() == 4);
+            CHECK_FALSE(navigator.next());
+            REQUIRE(navigator.leave());
+            CHECK(navigator.role() == cbor::view::position_role::root);
+        }
+    }
+
+    SECTION("empty and non-container enter leave position unchanged")
+    {
+        const std::vector<std::vector<uint8_t>> values = {
+            {0x01}, {0x80}, {0x9f,0xff}, {0xa0}, {0xbf,0xff}
+        };
+        for (const auto& data : values)
+        {
+            auto result = cbor::view::navigate_exact(jsoncons::span<const uint8_t>(data));
+            REQUIRE(result.has_value());
+            cbor::view::navigator navigator = std::move(result.value());
+            const cbor::view::item_kind kind = navigator.kind();
+            CHECK_FALSE(navigator.enter());
+            CHECK(navigator.kind() == kind);
+            CHECK(navigator.depth() == 0);
+        }
+    }
+
+    SECTION("finish_item caches an unknown extent and descent remains legal")
+    {
+        std::vector<uint8_t> data = {0x82,0x82,0x01,0x02,0x03}; // [[1,2],3]
+        auto result = cbor::view::navigate_exact(jsoncons::span<const uint8_t>(data));
+        REQUIRE(result.has_value());
+        cbor::view::navigator navigator = std::move(result.value());
+        REQUIRE(navigator.enter());
+        CHECK_FALSE(navigator.extent_known());
+        cbor::view::item nested = navigator.finish_item();
+        CHECK(navigator.extent_known());
+        CHECK(nested.encoded_bytes().data() == data.data() + 1);
+        CHECK(nested.encoded_bytes().size() == 3);
+        REQUIRE(navigator.enter());
+        CHECK(navigator.argument() == 1);
+    }
+
+    SECTION("right fences make the final payload immediately finishable")
+    {
+        std::vector<uint8_t> data = {
+            0x87,0x01,0x02,0x03,0x04,0x05,0x06,
+            0x82,0x81,0x07,0x81,0x08
+        };
+        auto result = cbor::view::navigate_exact(jsoncons::span<const uint8_t>(data));
+        REQUIRE(result.has_value());
+        cbor::view::navigator navigator = std::move(result.value());
+        REQUIRE(navigator.enter());
+        for (int i = 0; i < 6; ++i)
+        {
+            REQUIRE(navigator.next());
+        }
+        CHECK(navigator.kind() == cbor::view::item_kind::array);
+        CHECK(navigator.extent_known());
+        cbor::view::item payload = navigator.finish_item();
+        CHECK(payload.encoded_bytes().data() == data.data() + 7);
+        CHECK(payload.encoded_bytes().size() == 5);
+
+        REQUIRE(navigator.enter());
+        CHECK(navigator.kind() == cbor::view::item_kind::array);
+        CHECK_FALSE(navigator.extent_known());
+        REQUIRE(navigator.enter());
+        CHECK(navigator.argument() == 7);
+        CHECK(navigator.extent_known());
+    }
+
+    SECTION("rewind restores the checked root")
+    {
+        std::vector<uint8_t> data = {0x81,0x81,0x01};
+        auto result = cbor::view::navigate_exact(jsoncons::span<const uint8_t>(data));
+        REQUIRE(result.has_value());
+        cbor::view::navigator navigator = std::move(result.value());
+        REQUIRE(navigator.enter());
+        REQUIRE(navigator.enter());
+        CHECK(navigator.depth() == 2);
+        navigator.rewind();
+        CHECK(navigator.depth() == 0);
+        CHECK(navigator.role() == cbor::view::position_role::root);
+        CHECK(navigator.kind() == cbor::view::item_kind::array);
+        REQUIRE(navigator.enter());
+        CHECK(navigator.depth() == 1);
+    }
+
+    SECTION("deep movement uses the validation-sized workspace")
+    {
+        const std::size_t depth = 100;
+        std::vector<uint8_t> data(depth, 0x81);
+        data.push_back(0x01);
+        auto result = cbor::view::navigate_exact(jsoncons::span<const uint8_t>(data));
+        REQUIRE(result.has_value());
+        cbor::view::navigator navigator = std::move(result.value());
+        for (std::size_t i = 0; i < depth; ++i)
+        {
+            REQUIRE(navigator.enter());
+            CHECK(navigator.depth() == i + 1);
+        }
+        CHECK(navigator.argument() == 1);
+        for (std::size_t i = 0; i < depth; ++i)
+        {
+            REQUIRE(navigator.leave());
+        }
+        CHECK(navigator.depth() == 0);
+    }
+}
+
+
 
 TEST_CASE("cbor view wire cursor")
 {

--- a/test/cbor/src/cbor_view_tests.cpp
+++ b/test/cbor/src/cbor_view_tests.cpp
@@ -852,7 +852,112 @@ TEST_CASE("cbor view navigator movement")
     }
 }
 
+TEST_CASE("cbor view item children")
+{
+    cbor::view::scan_context context;
 
+    SECTION("array children are checked items in order")
+    {
+        std::vector<uint8_t> data = {0x83,0x01,0x82,0x02,0x03,0x63,'a','b','c'};   // [1,[2,3],"abc"]
+        auto result = cbor::view::parse_exact(jsoncons::span<const uint8_t>(data), context);
+        REQUIRE(result.has_value());
+
+        std::vector<cbor::view::item> children;
+        for (cbor::view::item child : result.value().children(context))
+        {
+            children.push_back(child);
+        }
+        REQUIRE(children.size() == 3);
+        CHECK(children[0].kind() == cbor::view::item_kind::unsigned_integer);
+        CHECK(children[0].argument() == 1);
+        CHECK(children[1].kind() == cbor::view::item_kind::array);
+        CHECK(children[1].encoded_bytes().data() == data.data() + 2);
+        CHECK(children[1].encoded_bytes().size() == 3);
+        CHECK(children[2].kind() == cbor::view::item_kind::text_string);
+        jsoncons::string_view text;
+        CHECK(children[2].text(text));
+        CHECK(text == "abc");
+
+        std::vector<uint64_t> nested;
+        for (cbor::view::item grandchild : children[1].children(context))
+        {
+            uint64_t value = 0;
+            REQUIRE(grandchild.uint64_value(value));
+            nested.push_back(value);
+        }
+        REQUIRE(nested.size() == 2);
+        CHECK(nested[0] == 2);
+        CHECK(nested[1] == 3);
+    }
+
+    SECTION("map children alternate keys and values")
+    {
+        const std::vector<std::vector<uint8_t>> maps = {
+            {0xa2,0x01,0x02,0x03,0x04},
+            {0xbf,0x01,0x02,0x03,0x04,0xff}
+        };
+        for (const auto& data : maps)
+        {
+            auto result = cbor::view::parse_exact(jsoncons::span<const uint8_t>(data), context);
+            REQUIRE(result.has_value());
+            std::vector<uint64_t> values;
+            for (cbor::view::item child : result.value().children(context))
+            {
+                uint64_t value = 0;
+                REQUIRE(child.uint64_value(value));
+                values.push_back(value);
+            }
+            REQUIRE(values.size() == 4);
+            CHECK(values[0] == 1);
+            CHECK(values[1] == 2);
+            CHECK(values[2] == 3);
+            CHECK(values[3] == 4);
+        }
+    }
+
+    SECTION("empty containers and non-containers have no children")
+    {
+        const std::vector<std::vector<uint8_t>> values = {
+            {0x01}, {0x63,'a','d','a'}, {0x80}, {0x9f,0xff}, {0xa0}, {0xbf,0xff}
+        };
+        for (const auto& data : values)
+        {
+            auto result = cbor::view::parse_exact(jsoncons::span<const uint8_t>(data), context);
+            REQUIRE(result.has_value());
+            CHECK(result.value().children(context).empty());
+            CHECK(result.value().children(context).begin() == cbor::view::item::child_iterator());
+        }
+    }
+
+    SECTION("indefinite container children stop at the break")
+    {
+        std::vector<uint8_t> data = {0x9f,0x01,0x81,0x02,0xff};   // [_ 1,[2]]
+        auto result = cbor::view::parse_exact(jsoncons::span<const uint8_t>(data), context);
+        REQUIRE(result.has_value());
+        std::size_t count = 0;
+        for (cbor::view::item child : result.value().children(context))
+        {
+            (void)child;
+            ++count;
+        }
+        CHECK(count == 2);
+    }
+
+    SECTION("a deep container child grows and reuses the context workspace")
+    {
+        const std::size_t depth = 100;
+        std::vector<uint8_t> data(depth + 1, 0x81);
+        data.push_back(0x01);
+        cbor::view::scan_context deep_context(200);
+        auto result = cbor::view::parse_exact(jsoncons::span<const uint8_t>(data), deep_context);
+        REQUIRE(result.has_value());
+        auto it = result.value().children(deep_context).begin();
+        REQUIRE(it != cbor::view::item::child_iterator());
+        CHECK((*it).encoded_bytes().size() == data.size() - 1);
+        ++it;
+        CHECK(it == cbor::view::item::child_iterator());
+    }
+}
 
 TEST_CASE("cbor view wire cursor")
 {

--- a/test/cbor/src/cbor_view_tests.cpp
+++ b/test/cbor/src/cbor_view_tests.cpp
@@ -940,6 +940,53 @@ TEST_CASE("cbor view wire cursor")
         CHECK(cursor.position() == 3);
     }
 
+    SECTION("skip_item passes over one item, returning its bytes unparsed")
+    {
+        std::vector<uint8_t> data = {0x82,0x01,0x02,0x63,'a','b','c'};   // [1,2] then "abc"
+        cbor::view::wire_cursor cursor{jsoncons::span<const uint8_t>(data)};
+        cbor::view::scan_context context;
+
+        auto skipped = cursor.skip_item(context);
+        REQUIRE(skipped.has_value());
+        CHECK(skipped.value().data() == data.data());
+        CHECK(skipped.value().size() == 3);
+        CHECK(cursor.position() == 3);
+
+        auto text = cursor.read_item(context);
+        REQUIRE(text.has_value());
+        CHECK(text.value().kind() == cbor::view::item_kind::text_string);
+        CHECK(cursor.remaining().empty());
+    }
+
+    SECTION("skip_item honours the depth bound like read_item")
+    {
+        std::vector<uint8_t> data = {0x01,0x81,0x81,0x01};   // 1 then [[1]]
+        cbor::view::wire_cursor cursor{jsoncons::span<const uint8_t>(data)};
+        cbor::view::scan_context default_context;
+        REQUIRE(cursor.skip_item(default_context).has_value());
+
+        cbor::view::scan_context context(1);
+        auto result = cursor.skip_item(context);
+        REQUIRE_FALSE(result.has_value());
+        CHECK(result.error().code == cbor::cbor_errc::max_nesting_depth_exceeded);
+        CHECK(result.error().offset == 3);
+        CHECK(cursor.position() == 3);
+    }
+
+    SECTION("skip advances past measured content only when it is available")
+    {
+        std::vector<uint8_t> data = {0x63,'a','b','c'};
+        cbor::view::wire_cursor cursor{jsoncons::span<const uint8_t>(data)};
+        auto head = cursor.read_head();
+        REQUIRE(head.has_value());
+        REQUIRE(cursor.skip(static_cast<std::size_t>(head.value().value)));
+        CHECK(cursor.position() == data.size());
+        CHECK(cursor.remaining().empty());
+        CHECK(cursor.skip(0));
+        CHECK_FALSE(cursor.skip(1));
+        CHECK(cursor.position() == data.size());
+    }
+
 }
 
 TEST_CASE("cbor view span-based order entry points")

--- a/test/cbor/src/cbor_view_tests.cpp
+++ b/test/cbor/src/cbor_view_tests.cpp
@@ -684,73 +684,104 @@ TEST_CASE("cbor view validate_text")
     }
 }
 
-TEST_CASE("cbor view low-level tier")
+TEST_CASE("cbor view wire cursor")
 {
     SECTION("read_head decodes one head and advances past it only")
     {
         std::vector<uint8_t> data = {0x82,0x01,0x02};   // [1, 2]
-        const uint8_t* p = data.data();
-        const uint8_t* end = p + data.size();
-        cbor::view::item_head head;
-        std::error_code ec;
-        REQUIRE(cbor::view::read_head(p, end, head, ec));
-        CHECK_FALSE(ec);
-        CHECK(head.major_type == cbor::view::major_type::array);
-        CHECK(head.value == 2);
-        CHECK(p == data.data() + 1);   // past the head, not the elements
+        cbor::view::wire_cursor cursor{jsoncons::span<const uint8_t>(data)};
+        CHECK(cursor.position() == 0);
+        CHECK(cursor.remaining().size() == data.size());
+
+        auto result = cursor.read_head();
+        REQUIRE(result.has_value());
+        CHECK(result.value().major_type == cbor::view::major_type::array);
+        CHECK(result.value().value == 2);
+        CHECK(cursor.position() == 1);   // past the head, not the elements
+        CHECK(cursor.remaining().data() == data.data() + 1);
     }
 
     SECTION("read_head surfaces tags as their own heads")
     {
         std::vector<uint8_t> data = {0xc1,0x0a};   // tag 1, 10
-        const uint8_t* p = data.data();
-        const uint8_t* end = p + data.size();
-        cbor::view::item_head head;
-        std::error_code ec;
-        REQUIRE(cbor::view::read_head(p, end, head, ec));
-        CHECK(head.major_type == cbor::view::major_type::semantic_tag);
-        CHECK(head.value == 1);
-        REQUIRE(cbor::view::read_head(p, end, head, ec));
-        CHECK(head.major_type == cbor::view::major_type::unsigned_integer);
-        CHECK(head.value == 10);
-        CHECK(p == end);
+        cbor::view::wire_cursor cursor{jsoncons::span<const uint8_t>(data)};
+
+        auto tag = cursor.read_head();
+        REQUIRE(tag.has_value());
+        CHECK(tag.value().major_type == cbor::view::major_type::semantic_tag);
+        CHECK(tag.value().value == 1);
+
+        auto value = cursor.read_head();
+        REQUIRE(value.has_value());
+        CHECK(value.value().major_type == cbor::view::major_type::unsigned_integer);
+        CHECK(value.value().value == 10);
+        CHECK(cursor.remaining().empty());
     }
 
     SECTION("read_head reports malformed and truncated heads")
     {
-        std::vector<uint8_t> empty;
-        const uint8_t* p = empty.data();
-        cbor::view::item_head head;
-        std::error_code ec;
-        CHECK_FALSE(cbor::view::read_head(p, p, head, ec));
-        CHECK(ec == cbor::cbor_errc::unexpected_eof);
+        cbor::view::wire_cursor empty;
+        auto no_head = empty.read_head();
+        REQUIRE_FALSE(no_head.has_value());
+        CHECK(no_head.error().code == cbor::cbor_errc::unexpected_eof);
+        CHECK(no_head.error().offset == 0);
+        CHECK(empty.position() == 0);
 
         std::vector<uint8_t> truncated = {0x19,0x01};
-        p = truncated.data();
-        ec.clear();
-        CHECK_FALSE(cbor::view::read_head(p, p + truncated.size(), head, ec));
-        CHECK(ec == cbor::cbor_errc::unexpected_eof);
+        cbor::view::wire_cursor cursor{jsoncons::span<const uint8_t>(truncated)};
+        auto result = cursor.read_head();
+        REQUIRE_FALSE(result.has_value());
+        CHECK(result.error().code == cbor::cbor_errc::unexpected_eof);
+        CHECK(result.error().offset == 1);
+        CHECK(cursor.position() == 1);
     }
 
-    SECTION("skip_item advances past one complete item")
+    SECTION("read_item returns and advances past one complete item")
     {
         std::vector<uint8_t> data = {0x82,0x01,0x02,0x63,'a','b','c'};   // [1,2] then "abc"
-        const uint8_t* p = data.data();
-        const uint8_t* end = p + data.size();
-        std::error_code ec;
-        REQUIRE(cbor::view::skip_item(p, end, ec));
-        CHECK(p == data.data() + 3);
-        REQUIRE(cbor::view::skip_item(p, end, ec));
-        CHECK(p == end);
+        cbor::view::wire_cursor cursor{jsoncons::span<const uint8_t>(data)};
+        cbor::view::scan_context context;
+
+        auto array = cursor.read_item(context);
+        REQUIRE(array.has_value());
+        CHECK(array.value().kind() == cbor::view::item_kind::array);
+        CHECK(array.value().encoded_bytes().size() == 3);
+        CHECK(cursor.position() == 3);
+
+        auto text = cursor.read_item(context);
+        REQUIRE(text.has_value());
+        CHECK(text.value().kind() == cbor::view::item_kind::text_string);
+        CHECK(cursor.position() == data.size());
+        CHECK(cursor.remaining().empty());
     }
 
-    SECTION("skip_item honours the depth bound")
+    SECTION("read_item honours the depth bound and reports an absolute offset")
     {
-        std::vector<uint8_t> data = {0x81,0x81,0x01};   // [[1]]
-        const uint8_t* p = data.data();
-        std::error_code ec;
-        CHECK_FALSE(cbor::view::skip_item(p, p + data.size(), ec, 1));
-        CHECK(ec == cbor::cbor_errc::max_nesting_depth_exceeded);
+        std::vector<uint8_t> data = {0x01,0x81,0x81,0x01};   // 1 then [[1]]
+        cbor::view::wire_cursor cursor{jsoncons::span<const uint8_t>(data)};
+        REQUIRE(cursor.read_item().has_value());
+
+        cbor::view::scan_context context(1);
+        auto result = cursor.read_item(context);
+        REQUIRE_FALSE(result.has_value());
+        CHECK(result.error().code == cbor::cbor_errc::max_nesting_depth_exceeded);
+        CHECK(result.error().offset == 3);
+        CHECK(cursor.position() == 3);
+    }
+
+    SECTION("reset reuses a cursor for a new span")
+    {
+        std::vector<uint8_t> first = {0x01};
+        std::vector<uint8_t> second = {0x02};
+        cbor::view::wire_cursor cursor{jsoncons::span<const uint8_t>(first)};
+        REQUIRE(cursor.read_item().has_value());
+        cursor.reset(jsoncons::span<const uint8_t>(second));
+        CHECK(cursor.position() == 0);
+        auto result = cursor.read_item();
+        REQUIRE(result.has_value());
+        uint64_t value = 0;
+        CHECK(result.value().uint64_value(value));
+        CHECK(value == 2);
     }
 }
 

--- a/test/cbor/src/cbor_view_tests.cpp
+++ b/test/cbor/src/cbor_view_tests.cpp
@@ -684,6 +684,113 @@ TEST_CASE("cbor view validate_text")
     }
 }
 
+static_assert(std::is_move_constructible<cbor::view::navigator>::value,
+              "navigator must be movable");
+static_assert(!std::is_copy_constructible<cbor::view::navigator>::value,
+              "navigator must not be copyable");
+
+TEST_CASE("cbor view navigator construction and root access")
+{
+    SECTION("navigate_prefix returns a checked root and remainder")
+    {
+        std::vector<uint8_t> data = {0xc1,0x18,0x2a,0x01};   // tag(1) 42, then 1
+        auto result = cbor::view::navigate_prefix(jsoncons::span<const uint8_t>(data));
+        REQUIRE(result.has_value());
+        CHECK(result.value().first.kind() == cbor::view::item_kind::unsigned_integer);
+        CHECK(result.value().first.argument() == 42);
+        CHECK(result.value().first.role() == cbor::view::position_role::root);
+        CHECK(result.value().first.depth() == 0);
+        CHECK(result.value().first.extent_known());
+        REQUIRE(result.value().remainder.size() == 1);
+        CHECK(result.value().remainder.data() == data.data() + 3);
+
+        std::vector<uint64_t> tags;
+        for (uint64_t tag : result.value().first.tags())
+        {
+            tags.push_back(tag);
+        }
+        REQUIRE(tags.size() == 1);
+        CHECK(tags[0] == 1);
+
+        uint64_t value = 0;
+        CHECK(result.value().first.uint64_value(value));
+        CHECK(value == 42);
+    }
+
+    SECTION("navigate_exact exposes scalar and string content")
+    {
+        std::vector<uint8_t> text_data = {0x63,'a','d','a'};
+        auto text_result = cbor::view::navigate_exact(jsoncons::span<const uint8_t>(text_data));
+        REQUIRE(text_result.has_value());
+        jsoncons::string_view text;
+        CHECK(text_result.value().text(text));
+        CHECK(text == "ada");
+
+        std::vector<uint8_t> bytes_data = {0x42,0x01,0x02};
+        auto bytes_result = cbor::view::navigate_exact(jsoncons::span<const uint8_t>(bytes_data));
+        REQUIRE(bytes_result.has_value());
+        jsoncons::span<const uint8_t> bytes;
+        CHECK(bytes_result.value().bytes(bytes));
+        REQUIRE(bytes.size() == 2);
+        CHECK(bytes[0] == 1);
+        CHECK(bytes[1] == 2);
+
+        std::vector<uint8_t> boolean_data = {0xf5};
+        auto boolean_result = cbor::view::navigate_exact(jsoncons::span<const uint8_t>(boolean_data));
+        REQUIRE(boolean_result.has_value());
+        bool boolean = false;
+        CHECK(boolean_result.value().bool_value(boolean));
+        CHECK(boolean);
+    }
+
+    SECTION("navigate_exact rejects trailing data")
+    {
+        std::vector<uint8_t> data = {0x01,0x02};
+        auto result = cbor::view::navigate_exact(jsoncons::span<const uint8_t>(data));
+        REQUIRE_FALSE(result.has_value());
+        CHECK(result.error().code == cbor::cbor_errc::trailing_data);
+        CHECK(result.error().offset == 1);
+    }
+
+    SECTION("reset is transactional and reuses the navigator")
+    {
+        std::vector<uint8_t> first = {0x01};
+        auto made = cbor::view::navigate_exact(jsoncons::span<const uint8_t>(first));
+        REQUIRE(made.has_value());
+        cbor::view::navigator navigator = std::move(made.value());
+
+        std::vector<uint8_t> sequence = {0x02,0x03};
+        auto remainder = navigator.reset_prefix(jsoncons::span<const uint8_t>(sequence));
+        REQUIRE(remainder.has_value());
+        REQUIRE(remainder.value().size() == 1);
+        uint64_t value = 0;
+        REQUIRE(navigator.uint64_value(value));
+        CHECK(value == 2);
+
+        std::vector<uint8_t> malformed = {0x19,0x01};
+        auto malformed_result = navigator.reset_exact(jsoncons::span<const uint8_t>(malformed));
+        REQUIRE_FALSE(malformed_result.has_value());
+        value = 0;
+        REQUIRE(navigator.uint64_value(value));
+        CHECK(value == 2);
+
+        auto trailing_result = navigator.reset_exact(jsoncons::span<const uint8_t>(sequence));
+        REQUIRE_FALSE(trailing_result.has_value());
+        CHECK(trailing_result.error().code == cbor::cbor_errc::trailing_data);
+        value = 0;
+        REQUIRE(navigator.uint64_value(value));
+        CHECK(value == 2);
+
+        std::vector<uint8_t> replacement = {0x81,0x04};
+        REQUIRE(navigator.reset_exact(jsoncons::span<const uint8_t>(replacement)).has_value());
+        CHECK(navigator.kind() == cbor::view::item_kind::array);
+        CHECK(navigator.argument() == 1);
+        CHECK(navigator.role() == cbor::view::position_role::root);
+        CHECK(navigator.depth() == 0);
+    }
+}
+
+
 TEST_CASE("cbor view wire cursor")
 {
     SECTION("read_head decodes one head and advances past it only")


### PR DESCRIPTION
After *much* trial and error, I am starting to like the shape of this "two layer" cbor_view.

The lower layer is an offset-based wire_cursor, read_head, read_item, skip_item, skip - errors carry absolute offsets.

The upper layer is a move-only navigator. Movement over checked bytes cannot fail structurally and don't allocate after construction.

I am starting to think this is a decent blend of simplicity and performance. I have not really looked at MsgPack/BSON etc but I would not be surprised if a similar model carries over to those fairly directly.