### PR TITLE
rename navigator to walker, and shrink/simplify API

### DIFF
--- a/doc/ref/cbor/cbor_view.md
+++ b/doc/ref/cbor/cbor_view.md
@@ -9,12 +9,12 @@
 The `cbor::view` namespace reads the *encoded* structure of
 [Concise Binary Object Representation](http://cbor.io/) data in place,
 without copying it or building a data structure. Its checked-item layer
-borrows complete encodings; its move-only `navigator` owns reusable traversal
+borrows complete encodings; its move-only `walker` owns reusable traversal
 workspace while borrowing the same bytes. The data flow is:
-> owned bytes -> structural validation -> checked item or navigator -> application semantics
+> owned bytes -> structural validation -> checked item or walker -> application semantics
 
 Validation checks structural well-formedness once (framing only — not content
-validity such as UTF-8). Checked items and navigator movement then cannot fail
+validity such as UTF-8). Checked items and walker movement then cannot fail
 structurally. The last stage — what tag 2 bytes or a tag 25 string reference
 *mean* — belongs to [decode_cbor](decode_cbor.md) and
 [basic_cbor_cursor](basic_cbor_cursor.md), not here: tags are exposed, never
@@ -24,10 +24,10 @@ This namespace is experimental.
 
 #### Ownership and lifetime
 
-All views borrow the input bytes. An `item`, a `navigator`, and every span or
+All views borrow the input bytes. An `item`, a `walker`, and every span or
 string view obtained from them are
 invalidated by anything that invalidates those bytes: destroying the container,
-mutating it, or reallocation. A navigator owns only its mutable navigation and
+mutating it, or reallocation. A walker owns only its mutable traversal and
 validation workspace; it does not own the encoded bytes. Factory, reset, and
 `wire_cursor` entry points reject temporary owning containers at compile time.
 The copying item accessors (`text` into `std::string`, `bytes` into
@@ -50,49 +50,57 @@ struct scan_result
     span<const uint8_t> remainder;
 };
 
-expected<scan_result, scan_error> scan_prefix(span<const uint8_t> input);
-expected<scan_result, scan_error> scan_prefix(span<const uint8_t> input, scan_context& context);
+expected<scan_result, scan_error> scan(span<const uint8_t> input);
+expected<scan_result, scan_error> scan(span<const uint8_t> input, scan_context& context);
 
-expected<item, scan_error> parse_exact(span<const uint8_t> input);
-expected<item, scan_error> parse_exact(span<const uint8_t> input, scan_context& context);
+expected<item, scan_error> parse_item(span<const uint8_t> input);
+expected<item, scan_error> parse_item(span<const uint8_t> input, scan_context& context);
 ```
 
-`scan_prefix` validates and returns the first item in `input`, with the
+`scan` validates and returns the first item in `input`, with the
 bytes that follow it; scan a stream of items by looping on `remainder`.
-`parse_exact` requires `input` to be exactly one item, and reports
+`parse_item` requires `input` to be exactly one item, and reports
 anything after it as `cbor_errc::trailing_data`.
 
 Scanning enforces `scan_context::max_nesting_depth` (default
 `default_max_nesting_depth`, 1024) using constant call-stack space at
 any depth. It allocates only when nesting exceeds 32 open containers; a reused
-`scan_context`, `wire_cursor` with a supplied context, or navigator reset retains
+`scan_context`, `wire_cursor` with a supplied context, or walker reset retains
 that validation capacity.
 
-#### Structural navigation
+#### Structural traversal
 
 ```cpp
 enum class position_role { root, array_element, map_key, map_value };
 
-struct navigation_result
+struct prefix_t
 {
-    navigator first;
+    explicit constexpr prefix_t() = default;
+};
+class walker;
+constexpr prefix_t prefix{};
+
+struct walk_result
+{
+    walker first;
     span<const uint8_t> remainder;
 };
 
-expected<navigation_result, scan_error> navigate_prefix(
+expected<walker, scan_error> get_walker(
     span<const uint8_t> input,
     int max_nesting_depth = default_max_nesting_depth);
 
-expected<navigator, scan_error> navigate_exact(
+expected<walk_result, scan_error> get_walker(
     span<const uint8_t> input,
+    prefix_t,
     int max_nesting_depth = default_max_nesting_depth);
 
-class navigator
+class walker
 {
 public:
-    navigator(navigator&&) noexcept;
-    navigator& operator=(navigator&&) noexcept;
-    navigator(const navigator&) = delete;
+    walker(walker&&) noexcept;
+    walker& operator=(walker&&) noexcept;
+    walker(const walker&) = delete;
 
     item_kind kind() const noexcept;
     uint64_t argument() const noexcept;
@@ -116,16 +124,20 @@ public:
     item finish_item() noexcept;
     bool extent_known() const noexcept;
 
-    expected<span<const uint8_t>, scan_error> reset_prefix(
+    expected<span<const uint8_t>, scan_error> reset(
         span<const uint8_t> input,
         int max_nesting_depth = default_max_nesting_depth);
-    expected<span<const uint8_t>, scan_error> reset_exact(
+    expected<span<const uint8_t>, scan_error> reset(
         span<const uint8_t> input,
+        prefix_t,
         int max_nesting_depth = default_max_nesting_depth);
 };
 ```
 
-A navigator begins at the checked root. `enter()` moves into a nonempty array
+`get_walker(input)` requires exactly one item. Pass `prefix` to prepare a walker
+for the first item and receive the unconsumed bytes in a `walk_result`.
+
+A walker begins at the checked root. `enter()` moves into a nonempty array
 or map; maps expose raw children with alternating key/value roles. `next()`
 moves to the next raw sibling, skipping the current unopened container if
 necessary. At the end of the siblings it returns `false`; `leave()` restores
@@ -139,11 +151,12 @@ ordinary complete `item`. `extent_known()` makes that cost visible. Descent afte
 `finish_item()` is legal and revisits the subtree.
 
 Validation records the observed peak open-container depth, prepares that many
-navigation frames, and retains the validation scratch. Movement uses indexed
+container frames, and retains the validation scratch. Movement uses indexed
 frames; subtree skips reuse the retained scratch. Neither allocates after
 successful construction. Resets are transactional and retain both capacities.
-Both reset forms return the unconsumed remainder; it is empty after a
-successful exact reset.
+`reset(input)` requires exactly one item. Pass `prefix` to reset to the first
+item and receive the unconsumed bytes. Both overloads return the remainder;
+it is empty after a successful exact reset.
 
 A known parent boundary propagates to its final definite child. Consequently,
 the last payload in a definite transport tuple can be finished in O(1), even
@@ -200,7 +213,7 @@ item, measured once on the way past. The item's bytes are checked, so
 iteration cannot fail; the context, which must outlive the range, supplies
 skip workspace for container children and grows only past 32 open
 containers. `children` serves sibling iteration over checked bytes;
-`navigator` serves stateful traversal with retained parents and extents.
+`walker` serves stateful traversal with retained parents and extents.
 
 The typed accessors return `false`, leaving `value` untouched, exactly
 when the item is not of the requested kind; conversions are strict.
@@ -240,7 +253,7 @@ expected<bool, scan_error> map_keys_sorted(span<const uint8_t> input,
 The order function objects compare encoded bytes and accept either two items
 or two raw spans. The `*_compare` forms return a three-way result; the `*_less`
 forms are predicates for sorting and ordered containers. The span-based
-`map_keys_sorted` validates once, then walks keys with a navigator; malformed
+`map_keys_sorted` validates once, then walks keys with a walker; malformed
 input returns the code and byte offset, and trailing bytes are tolerated.
 
 #### Low-level tier
@@ -293,46 +306,46 @@ int main()
         0x66,'s','c','o','r','e','s', 0x82,0x01,0x02
     };
 
-    auto result = jsoncons::cbor::view::navigate_exact(
+    auto result = jsoncons::cbor::view::get_walker(
         jsoncons::span<const uint8_t>(data));
     if (!result)
     {
         return 1;
     }
 
-    auto nav = std::move(result.value());
-    if (!nav.enter())
+    auto walker = std::move(result.value());
+    if (!walker.enter())
     {
         return 0;
     }
     for (;;)
     {
         jsoncons::string_view name;
-        if (!nav.text(name) || !nav.next())
+        if (!walker.text(name) || !walker.next())
         {
             break;
         }
         std::cout << name << ":";
 
         uint64_t number = 0;
-        if (nav.uint64_value(number))
+        if (walker.uint64_value(number))
         {
             std::cout << " " << number;
         }
-        else if (nav.enter())
+        else if (walker.enter())
         {
             do
             {
-                if (nav.uint64_value(number))
+                if (walker.uint64_value(number))
                 {
                     std::cout << " " << number;
                 }
             }
-            while (nav.next());
-            nav.leave();
+            while (walker.next());
+            walker.leave();
         }
         std::cout << "\n";
-        if (!nav.next())
+        if (!walker.next())
         {
             break;
         }
@@ -352,7 +365,7 @@ scores: 1 2
 jsoncons::span<const uint8_t> rest(data.data(), data.size());
 while (!rest.empty())
 {
-    auto scanned = jsoncons::cbor::view::scan_prefix(rest);
+    auto scanned = jsoncons::cbor::view::scan(rest);
     if (!scanned.has_value())
     {
         break;   // scanned.error().code, scanned.error().offset

--- a/fuzzers/fuzz_cbor_view.cpp
+++ b/fuzzers/fuzz_cbor_view.cpp
@@ -40,7 +40,7 @@ namespace {
         require(bytes.size() > 0);
 
         // Self-similarity: an item's encoding is exactly one item.
-        auto reparsed = parse_exact(bytes);
+        auto reparsed = parse_item(bytes);
         require(reparsed.has_value());
         require(reparsed.value().encoded_bytes().data() == bytes.data());
         require(reparsed.value().encoded_bytes().size() == bytes.size());
@@ -143,11 +143,11 @@ namespace {
             require(heads.position() > before);
         }
 
-        // read_item agrees with scan_prefix on outcome and consumed length.
+        // read_item agrees with scan on outcome and consumed length.
         wire_cursor items(input);
         scan_context context;
         auto read = items.read_item(context);
-        auto scanned = scan_prefix(input, context);
+        auto scanned = scan(input, context);
         require(read.has_value() == scanned.has_value());
         if (read.has_value())
         {
@@ -197,9 +197,9 @@ namespace {
         }
 
         scan_context ca;
-        auto sa = scan_prefix(a, ca);
+        auto sa = scan(a, ca);
         scan_context cb;
-        auto sb = scan_prefix(b, cb);
+        auto sb = scan(b, cb);
         if (sa.has_value() && sb.has_value())
         {
             require(ab.has_value());
@@ -219,24 +219,24 @@ namespace {
         }
     }
 
-    void exercise_navigator(byte_span input, int depth)
+    void exercise_walker(byte_span input, int depth)
     {
-        auto navigated = navigate_prefix(input, depth);
+        auto result = get_walker(input, prefix, depth);
         scan_context context(depth);
-        auto scanned = scan_prefix(input, context);
-        require(navigated.has_value() == scanned.has_value());
-        if (!navigated.has_value())
+        auto scanned = scan(input, context);
+        require(result.has_value() == scanned.has_value());
+        if (!result.has_value())
         {
             return;
         }
 
-        navigator nav = std::move(navigated.value().first);
-        require(navigated.value().remainder.size() == scanned.value().remainder.size());
-        require(nav.role() == position_role::root);
-        require(nav.depth() == 0);
-        require(nav.extent_known());
+        auto walker = std::move(result.value().first);
+        require(result.value().remainder.size() == scanned.value().remainder.size());
+        require(walker.role() == position_role::root);
+        require(walker.depth() == 0);
+        require(walker.extent_known());
 
-        const item root = nav.finish_item();
+        const item root = walker.finish_item();
         require(root.encoded_bytes().data() == input.data());
         require(root.encoded_bytes().size() == scanned.value().first.encoded_bytes().size());
 
@@ -248,54 +248,54 @@ namespace {
             double d = 0;
             jsoncons::string_view text;
             byte_span bytes;
-            (void)nav.uint64_value(u);
-            (void)nav.int64_value(i);
-            (void)nav.bool_value(b);
-            (void)nav.double_value(d);
-            (void)nav.text(text);
-            (void)nav.bytes(bytes);
+            (void)walker.uint64_value(u);
+            (void)walker.int64_value(i);
+            (void)walker.bool_value(b);
+            (void)walker.double_value(d);
+            (void)walker.text(text);
+            (void)walker.bytes(bytes);
 
-            if (nav.enter())
+            if (walker.enter())
             {
-                require(nav.depth() > 0);
+                require(walker.depth() > 0);
                 continue;
             }
-            if (nav.next())
+            if (walker.next())
             {
                 continue;
             }
-            if (!nav.leave())
+            if (!walker.leave())
             {
                 break;
             }
         }
 
-        nav.rewind();
-        require(nav.depth() == 0);
-        require(nav.role() == position_role::root);
-        require(nav.finish_item().encoded_bytes().size() == root.encoded_bytes().size());
+        walker.rewind();
+        require(walker.depth() == 0);
+        require(walker.role() == position_role::root);
+        require(walker.finish_item().encoded_bytes().size() == root.encoded_bytes().size());
 
-        auto reset = nav.reset_prefix(input, depth);
+        auto reset = walker.reset(input, prefix, depth);
         require(reset.has_value());
-        require(reset.value().size() == navigated.value().remainder.size());
+        require(reset.value().size() == result.value().remainder.size());
     }
 
-    // Children agree with navigator movement over the same container.
+    // Children agree with walker movement over the same container.
     void exercise_children(byte_span input, scan_context& context)
     {
-        auto scanned = scan_prefix(input, context);
+        auto scanned = scan(input, context);
         if (!scanned.has_value())
         {
             return;
         }
         const item root = scanned.value().first;
 
-        auto navigated = navigate_prefix(input);
-        require(navigated.has_value());
-        navigator nav = std::move(navigated.value().first);
+        auto result = get_walker(input, prefix);
+        require(result.has_value());
+        auto walker = std::move(result.value().first);
 
         auto it = root.children(context).begin();
-        if (!nav.enter())
+        if (!walker.enter())
         {
             require(root.children(context).empty());
             require(it == item::child_iterator());
@@ -308,10 +308,10 @@ namespace {
         {
             require(it != item::child_iterator());
             const item child = *it;
-            require(child.kind() == nav.kind());
-            require(child.argument() == nav.argument());
-            require(child.indefinite() == nav.indefinite());
-            const item finished = nav.finish_item();
+            require(child.kind() == walker.kind());
+            require(child.argument() == walker.argument());
+            require(child.indefinite() == walker.indefinite());
+            const item finished = walker.finish_item();
             require(finished.encoded_bytes().data() == child.encoded_bytes().data());
             require(finished.encoded_bytes().size() == child.encoded_bytes().size());
             ++it;
@@ -319,7 +319,7 @@ namespace {
             {
                 return;
             }
-            if (!nav.next())
+            if (!walker.next())
             {
                 break;
             }
@@ -330,8 +330,8 @@ namespace {
 
     void exercise_input(byte_span input, scan_context& context)
     {
-        auto scanned = scan_prefix(input, context);
-        auto exact = parse_exact(input, context);
+        auto scanned = scan(input, context);
+        auto exact = parse_item(input, context);
 
         if (scanned.has_value())
         {
@@ -351,7 +351,7 @@ namespace {
             exercise_item(first, 24);
 
             // Comparison functors agree with their sign-flipped duals.
-            auto second = scan_prefix(remainder, context);
+            auto second = scan(remainder, context);
             if (second.has_value())
             {
                 const int ab = bytewise_compare()(first, second.value().first);
@@ -393,14 +393,14 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, std::size_t size)
     {
         scan_context context(depth);
         exercise_input(input, context);
-        exercise_navigator(input, depth);
+        exercise_walker(input, depth);
         exercise_children(input, context);
         exercise_input(byte_span(base, mid), context);
-        exercise_navigator(byte_span(base, mid), depth);
+        exercise_walker(byte_span(base, mid), depth);
         exercise_input(byte_span(base + mid, size - mid), context);
-        exercise_navigator(byte_span(base + mid, size - mid), depth);
+        exercise_walker(byte_span(base + mid, size - mid), depth);
         exercise_input(byte_span(base + p0, size - p0), context);
-        exercise_navigator(byte_span(base + p0, size - p0), depth);
+        exercise_walker(byte_span(base + p0, size - p0), depth);
     }
 
     return 0;

--- a/include/jsoncons_ext/cbor/cbor_view.hpp
+++ b/include/jsoncons_ext/cbor/cbor_view.hpp
@@ -26,7 +26,7 @@
 
 // A deliberately narrow, zero-copy facility for reading the *encoded*
 // structure of CBOR data in place. Scanning validates structural well-formedness
-// once; everything after that operates on checked items or navigation state and
+// once; everything after that operates on checked items or traversal state and
 // cannot fail structurally. Semantic interpretation (tag 2 bignums,
 // string references, typed arrays, ...) belongs to the parser and
 // cursor layers, not here: tags are exposed, never interpreted.
@@ -578,7 +578,7 @@ namespace view {
 
         struct item_access;
         struct scan_access;
-        struct navigator_access;
+        struct walker_access;
 
     } // namespace detail_view
 
@@ -586,7 +586,7 @@ namespace view {
 
     // A checked, zero-copy view of one complete, structurally well-formed CBOR
     // item: its leading semantic tags, head, and content. Obtained from
-    // scan_prefix, parse_exact, wire_cursor, or navigator::finish_item; never
+    // scan, parse_item, wire_cursor, or walker::finish_item; never
     // constructed from unvalidated bytes. Borrows the scanned input, so it
     // must not outlive the bytes it was scanned from.
     class item
@@ -881,7 +881,7 @@ namespace view {
 
     private:
         friend class item;
-        friend class navigator;
+        friend class walker;
         tag_range(const uint8_t* first, const uint8_t* stop) noexcept : first_(first), stop_(stop) {}
 
         const uint8_t* first_;
@@ -1080,7 +1080,14 @@ namespace view {
 
     using tag_range = item::tag_range;
 
-    class navigator
+    struct prefix_t
+    {
+        explicit constexpr prefix_t() = default;
+    };
+
+    constexpr prefix_t prefix{};
+
+    class walker
     {
         static constexpr std::size_t npos = (std::numeric_limits<std::size_t>::max)();
 
@@ -1094,17 +1101,17 @@ namespace view {
             position_role role{position_role::root};
         };
 
-        struct navigation_frame
+        struct container_frame
         {
             node_state container{};
             uint64_t remaining{0};
         };
 
     public:
-        navigator(navigator&&) noexcept = default;
-        navigator& operator=(navigator&&) noexcept = default;
-        navigator(const navigator&) = delete;
-        navigator& operator=(const navigator&) = delete;
+        walker(walker&&) noexcept = default;
+        walker& operator=(walker&&) noexcept = default;
+        walker(const walker&) = delete;
+        walker& operator=(const walker&) = delete;
 
         item_kind kind() const noexcept
         {
@@ -1186,35 +1193,37 @@ namespace view {
             return current_.end != npos;
         }
 
-        expected<span<const uint8_t>, scan_error> reset_prefix(
+        expected<span<const uint8_t>, scan_error> reset(
             span<const uint8_t> input,
             int max_nesting_depth = default_max_nesting_depth);
 
-        expected<span<const uint8_t>, scan_error> reset_exact(
+        expected<span<const uint8_t>, scan_error> reset(
             span<const uint8_t> input,
+            prefix_t,
             int max_nesting_depth = default_max_nesting_depth);
 
         template <typename Container>
-        expected<span<const uint8_t>, scan_error> reset_prefix(
+        expected<span<const uint8_t>, scan_error> reset(
             const Container&&,
             int = default_max_nesting_depth) = delete;
 
         template <typename Container>
-        expected<span<const uint8_t>, scan_error> reset_exact(
+        expected<span<const uint8_t>, scan_error> reset(
             const Container&&,
+            prefix_t,
             int = default_max_nesting_depth) = delete;
 
     private:
-        friend struct detail_view::navigator_access;
+        friend struct detail_view::walker_access;
 
         node_state read_node(std::size_t begin, position_role role,
                              std::size_t right_fence = npos) const noexcept;
-        void initialize_frame(navigation_frame& frame, const node_state& container) noexcept;
-        bool take_child(navigation_frame& frame, std::size_t& offset,
+        void initialize_frame(container_frame& frame, const node_state& container) noexcept;
+        bool take_child(container_frame& frame, std::size_t& offset,
                         position_role& role, std::size_t& right_fence) noexcept;
         void establish_end(node_state& node) noexcept;
 
-        navigator(span<const uint8_t> root, std::size_t peak_depth,
+        walker(span<const uint8_t> root, std::size_t peak_depth,
                   detail_view::pending_stack&& validation_workspace)
             : input_(root), frames_(peak_depth),
               validation_workspace_(std::move(validation_workspace)), active_depth_(0)
@@ -1239,27 +1248,28 @@ namespace view {
         span<const uint8_t> input_;
         node_state root_;
         node_state current_;
-        std::vector<navigation_frame> frames_;
+        std::vector<container_frame> frames_;
         detail_view::pending_stack validation_workspace_;
         std::size_t active_depth_;
     };
 
     namespace detail_view {
 
-        struct navigator_access
+        struct walker_access
         {
-            static navigator make(span<const uint8_t> root, std::size_t peak_depth,
+            static walker make(span<const uint8_t> root, std::size_t peak_depth,
                                   pending_stack&& validation_workspace)
             {
-                return navigator(root, peak_depth, std::move(validation_workspace));
+                return walker(root, peak_depth, std::move(validation_workspace));
             }
         };
 
     } // namespace detail_view
 
-    struct navigation_result
+
+    struct walk_result
     {
-        navigator first;
+        walker first;
         span<const uint8_t> remainder;
     };
 
@@ -1484,7 +1494,7 @@ namespace view {
     // Scans the first item in `input`, validating structural well-formedness, and
     // returns it together with the remaining bytes. On failure the error
     // holds the offending code and the offset at which scanning stopped.
-    inline expected<scan_result, scan_error> scan_prefix(span<const uint8_t> input, scan_context& context)
+    inline expected<scan_result, scan_error> scan(span<const uint8_t> input, scan_context& context)
     {
         const uint8_t* p = input.data();
         const uint8_t* end = p + input.size();
@@ -1518,17 +1528,17 @@ namespace view {
             span<const uint8_t>(p, static_cast<std::size_t>(end - p))};
     }
 
-    inline expected<scan_result, scan_error> scan_prefix(span<const uint8_t> input)
+    inline expected<scan_result, scan_error> scan(span<const uint8_t> input)
     {
         scan_context context;
-        return scan_prefix(input, context);
+        return scan(input, context);
     }
 
-    // Scans `input`, which must hold exactly one item: trailing bytes are
-    // an error (cbor_errc::trailing_data), unlike scan_prefix.
-    inline expected<item, scan_error> parse_exact(span<const uint8_t> input, scan_context& context)
+    // Parses `input`, which must hold exactly one item: trailing bytes are
+    // an error (cbor_errc::trailing_data), unlike scan.
+    inline expected<item, scan_error> parse_item(span<const uint8_t> input, scan_context& context)
     {
-        auto scanned = scan_prefix(input, context);
+        auto scanned = scan(input, context);
         if (!scanned)
         {
             return expected<item, scan_error>(unexpect, scanned.error());
@@ -1541,16 +1551,16 @@ namespace view {
         return scanned.value().first;
     }
 
-    inline expected<item, scan_error> parse_exact(span<const uint8_t> input)
+    inline expected<item, scan_error> parse_item(span<const uint8_t> input)
     {
         scan_context context;
-        return parse_exact(input, context);
+        return parse_item(input, context);
     }
 
     inline expected<item, scan_error> wire_cursor::read_item(scan_context& context)
     {
         const std::size_t start = position();
-        auto scanned = scan_prefix(remaining(), context);
+        auto scanned = scan(remaining(), context);
         if (!scanned)
         {
             scan_error error = scanned.error();
@@ -1579,48 +1589,49 @@ namespace view {
     }
 
 
-    inline expected<navigation_result, scan_error> navigate_prefix(
+    inline expected<walk_result, scan_error> get_walker(
         span<const uint8_t> input,
+        prefix_t,
         int max_nesting_depth = default_max_nesting_depth)
     {
         scan_context context(max_nesting_depth);
-        auto scanned = scan_prefix(input, context);
+        auto scanned = scan(input, context);
         if (!scanned)
         {
-            return expected<navigation_result, scan_error>(unexpect, scanned.error());
+            return expected<walk_result, scan_error>(unexpect, scanned.error());
         }
 
-        navigator result = detail_view::navigator_access::make(
+        walker result = detail_view::walker_access::make(
             scanned.value().first.encoded_bytes(),
             detail_view::scan_access::peak_depth(context),
             std::move(detail_view::scan_access::workspace(context)));
-        return navigation_result{std::move(result), scanned.value().remainder};
+        return walk_result{std::move(result), scanned.value().remainder};
     }
 
-    inline expected<navigator, scan_error> navigate_exact(
+    inline expected<walker, scan_error> get_walker(
         span<const uint8_t> input,
         int max_nesting_depth = default_max_nesting_depth)
     {
-        auto navigated = navigate_prefix(input, max_nesting_depth);
-        if (!navigated)
+        auto result = get_walker(input, prefix, max_nesting_depth);
+        if (!result)
         {
-            return expected<navigator, scan_error>(unexpect, navigated.error());
+            return expected<walker, scan_error>(unexpect, result.error());
         }
-        if (!navigated.value().remainder.empty())
+        if (!result.value().remainder.empty())
         {
-            return expected<navigator, scan_error>(unexpect,
+            return expected<walker, scan_error>(unexpect,
                 scan_error{cbor_errc::trailing_data,
-                    input.size() - navigated.value().remainder.size()});
+                    input.size() - result.value().remainder.size()});
         }
-        return std::move(navigated.value().first);
+        return std::move(result.value().first);
     }
 
-    inline expected<span<const uint8_t>, scan_error> navigator::reset_prefix(
-        span<const uint8_t> input, int max_nesting_depth)
+    inline expected<span<const uint8_t>, scan_error> walker::reset(
+        span<const uint8_t> input, prefix_t, int max_nesting_depth)
     {
         scan_context context(max_nesting_depth);
         detail_view::scan_access::workspace(context) = std::move(validation_workspace_);
-        auto scanned = scan_prefix(input, context);
+        auto scanned = scan(input, context);
         const std::size_t peak_depth = detail_view::scan_access::peak_depth(context);
         validation_workspace_ = std::move(detail_view::scan_access::workspace(context));
         if (!scanned)
@@ -1632,12 +1643,12 @@ namespace view {
         return scanned.value().remainder;
     }
 
-    inline expected<span<const uint8_t>, scan_error> navigator::reset_exact(
+    inline expected<span<const uint8_t>, scan_error> walker::reset(
         span<const uint8_t> input, int max_nesting_depth)
     {
         scan_context context(max_nesting_depth);
         detail_view::scan_access::workspace(context) = std::move(validation_workspace_);
-        auto scanned = scan_prefix(input, context);
+        auto scanned = scan(input, context);
         const std::size_t peak_depth = detail_view::scan_access::peak_depth(context);
         validation_workspace_ = std::move(detail_view::scan_access::workspace(context));
         if (!scanned)
@@ -1655,7 +1666,7 @@ namespace view {
         return span<const uint8_t>();
     }
 
-    inline navigator::node_state navigator::read_node(
+    inline walker::node_state walker::read_node(
         std::size_t begin, position_role role, std::size_t right_fence) const noexcept
     {
         const uint8_t* const base = input_.data();
@@ -1725,8 +1736,8 @@ namespace view {
         return node;
     }
 
-    inline void navigator::initialize_frame(
-        navigation_frame& frame, const node_state& container) noexcept
+    inline void walker::initialize_frame(
+        container_frame& frame, const node_state& container) noexcept
     {
         frame.container = container;
         if (container.head.indefinite())
@@ -1743,8 +1754,8 @@ namespace view {
         }
     }
 
-    inline bool navigator::take_child(
-        navigation_frame& frame, std::size_t& offset,
+    inline bool walker::take_child(
+        container_frame& frame, std::size_t& offset,
         position_role& role, std::size_t& right_fence) noexcept
     {
         right_fence = npos;
@@ -1801,7 +1812,7 @@ namespace view {
         return true;
     }
 
-    inline void navigator::establish_end(node_state& node) noexcept
+    inline void walker::establish_end(node_state& node) noexcept
     {
         if (node.end != npos)
         {
@@ -1823,7 +1834,7 @@ namespace view {
         node.end = static_cast<std::size_t>(p - base);
     }
 
-    inline bool navigator::enter() noexcept
+    inline bool walker::enter() noexcept
     {
         if (current_.head.major_type != cbor::detail::cbor_major_type::array &&
             current_.head.major_type != cbor::detail::cbor_major_type::map)
@@ -1837,7 +1848,7 @@ namespace view {
         }
 
         assert(active_depth_ < frames_.size());
-        navigation_frame& frame = frames_[active_depth_];
+        container_frame& frame = frames_[active_depth_];
         initialize_frame(frame, current_);
         std::size_t offset = current_.content_begin;
         position_role child_role = position_role::array_element;
@@ -1850,14 +1861,14 @@ namespace view {
         return true;
     }
 
-    inline bool navigator::next() noexcept
+    inline bool walker::next() noexcept
     {
         if (active_depth_ == 0)
         {
             return false;
         }
 
-        navigation_frame& frame = frames_[active_depth_ - 1];
+        container_frame& frame = frames_[active_depth_ - 1];
         if (frame.remaining == 0)
         {
             if (frame.container.end == npos)
@@ -1880,14 +1891,14 @@ namespace view {
         return true;
     }
 
-    inline bool navigator::leave() noexcept
+    inline bool walker::leave() noexcept
     {
         if (active_depth_ == 0)
         {
             return false;
         }
 
-        navigation_frame& frame = frames_[active_depth_ - 1];
+        container_frame& frame = frames_[active_depth_ - 1];
         if (frame.container.end == npos)
         {
             establish_end(current_);
@@ -1907,7 +1918,7 @@ namespace view {
         return true;
     }
 
-    inline item navigator::finish_item() noexcept
+    inline item walker::finish_item() noexcept
     {
         establish_end(current_);
         return detail_view::item_access::make(
@@ -1917,12 +1928,13 @@ namespace view {
     }
 
     template <typename Container>
-    expected<navigation_result, scan_error> navigate_prefix(
+    expected<walk_result, scan_error> get_walker(
         const Container&&,
+        prefix_t,
         int = default_max_nesting_depth) = delete;
 
     template <typename Container>
-    expected<navigator, scan_error> navigate_exact(
+    expected<walker, scan_error> get_walker(
         const Container&&,
         int = default_max_nesting_depth) = delete;
 
@@ -1930,13 +1942,13 @@ namespace view {
     // Guard against temporary owning containers; the concrete span overloads
     // remain available for explicit non-owning views.
     template <typename Container>
-    expected<scan_result, scan_error> scan_prefix(const Container&&, scan_context&) = delete;
+    expected<scan_result, scan_error> scan(const Container&&, scan_context&) = delete;
     template <typename Container>
-    expected<scan_result, scan_error> scan_prefix(const Container&&) = delete;
+    expected<scan_result, scan_error> scan(const Container&&) = delete;
     template <typename Container>
-    expected<item, scan_error> parse_exact(const Container&&, scan_context&) = delete;
+    expected<item, scan_error> parse_item(const Container&&, scan_context&) = delete;
     template <typename Container>
-    expected<item, scan_error> parse_exact(const Container&&) = delete;
+    expected<item, scan_error> parse_item(const Container&&) = delete;
 
     // Deterministic encoding orders over the encoded bytes of items.
     // The *_compare forms return a three-way result; the *_less forms are
@@ -2006,12 +2018,12 @@ namespace view {
         Order order = Order(), int max_nesting_depth = default_max_nesting_depth)
     {
         scan_context context(max_nesting_depth);
-        auto ra = scan_prefix(a, context);
+        auto ra = scan(a, context);
         if (!ra)
         {
             return expected<int, scan_error>(unexpect, ra.error());
         }
-        auto rb = scan_prefix(b, context);
+        auto rb = scan(b, context);
         if (!rb)
         {
             return expected<int, scan_error>(unexpect, rb.error());
@@ -2024,7 +2036,7 @@ namespace view {
         Order order = Order(), int max_nesting_depth = default_max_nesting_depth)
     {
         scan_context context(max_nesting_depth);
-        auto scanned = scan_prefix(input, context);
+        auto scanned = scan(input, context);
         if (!scanned)
         {
             return expected<bool, scan_error>(unexpect, scanned.error());

--- a/test/cbor/src/cbor_view_tests.cpp
+++ b/test/cbor/src/cbor_view_tests.cpp
@@ -19,19 +19,19 @@ namespace {
 
     cbor::view::item parse(const std::vector<uint8_t>& data)
     {
-        auto result = cbor::view::parse_exact(jsoncons::span<const uint8_t>(data.data(), data.size()));
+        auto result = cbor::view::parse_item(jsoncons::span<const uint8_t>(data.data(), data.size()));
         REQUIRE(result.has_value());
         return result.value();
     }
 
 } // namespace
 
-TEST_CASE("cbor view scan_prefix and parse_exact")
+TEST_CASE("cbor view scan and parse_item")
 {
-    SECTION("scan_prefix returns the first item and the remainder")
+    SECTION("scan returns the first item and the remainder")
     {
         std::vector<uint8_t> data = {0x01,0x02};
-        auto result = cbor::view::scan_prefix(jsoncons::span<const uint8_t>(data));
+        auto result = cbor::view::scan(jsoncons::span<const uint8_t>(data));
         REQUIRE(result.has_value());
         CHECK(result.value().first.encoded_bytes().data() == data.data());
         CHECK(result.value().first.encoded_bytes().size() == 1);
@@ -39,14 +39,14 @@ TEST_CASE("cbor view scan_prefix and parse_exact")
         CHECK(result.value().remainder.size() == 1);
     }
 
-    SECTION("scan_prefix walks a sequence of items")
+    SECTION("scan walks a sequence of items")
     {
         std::vector<uint8_t> data = {0x01,0x61,'a',0x80};
         jsoncons::span<const uint8_t> rest(data.data(), data.size());
         std::size_t count = 0;
         while (!rest.empty())
         {
-            auto result = cbor::view::scan_prefix(rest);
+            auto result = cbor::view::scan(rest);
             REQUIRE(result.has_value());
             rest = result.value().remainder;
             ++count;
@@ -54,21 +54,21 @@ TEST_CASE("cbor view scan_prefix and parse_exact")
         CHECK(count == 3);
     }
 
-    SECTION("parse_exact rejects trailing bytes with their offset")
+    SECTION("parse_item rejects trailing bytes with their offset")
     {
         std::vector<uint8_t> data = {0x01,0x02};
-        auto result = cbor::view::parse_exact(jsoncons::span<const uint8_t>(data));
+        auto result = cbor::view::parse_item(jsoncons::span<const uint8_t>(data));
         REQUIRE_FALSE(result.has_value());
         CHECK(result.error().code == cbor::cbor_errc::trailing_data);
         CHECK(result.error().offset == 1);
 
         std::vector<uint8_t> exact = {0x01};
-        CHECK(cbor::view::parse_exact(jsoncons::span<const uint8_t>(exact)).has_value());
+        CHECK(cbor::view::parse_item(jsoncons::span<const uint8_t>(exact)).has_value());
     }
 
     SECTION("empty input fails at offset zero")
     {
-        auto result = cbor::view::scan_prefix(jsoncons::span<const uint8_t>());
+        auto result = cbor::view::scan(jsoncons::span<const uint8_t>());
         REQUIRE_FALSE(result.has_value());
         CHECK(result.error().code == cbor::cbor_errc::unexpected_eof);
         CHECK(result.error().offset == 0);
@@ -78,7 +78,7 @@ TEST_CASE("cbor view scan_prefix and parse_exact")
     {
         // [1, <invalid head 0x1f>]
         std::vector<uint8_t> data = {0x82,0x01,0x1f};
-        auto result = cbor::view::scan_prefix(jsoncons::span<const uint8_t>(data));
+        auto result = cbor::view::scan(jsoncons::span<const uint8_t>(data));
         REQUIRE_FALSE(result.has_value());
         CHECK(result.error().code == cbor::cbor_errc::unknown_type);
         CHECK(result.error().offset == 3);
@@ -91,9 +91,9 @@ TEST_CASE("cbor view scan_prefix and parse_exact")
         deep.push_back(0x01);
         std::vector<uint8_t> shallow = {0x01};
 
-        CHECK(cbor::view::parse_exact(jsoncons::span<const uint8_t>(deep), context).has_value());
-        CHECK(cbor::view::parse_exact(jsoncons::span<const uint8_t>(shallow), context).has_value());
-        CHECK(cbor::view::parse_exact(jsoncons::span<const uint8_t>(deep), context).has_value());
+        CHECK(cbor::view::parse_item(jsoncons::span<const uint8_t>(deep), context).has_value());
+        CHECK(cbor::view::parse_item(jsoncons::span<const uint8_t>(shallow), context).has_value());
+        CHECK(cbor::view::parse_item(jsoncons::span<const uint8_t>(deep), context).has_value());
     }
 }
 
@@ -103,7 +103,7 @@ TEST_CASE("cbor view scanning validates well-formedness")
     {
         std::vector<uint8_t> data(cbor::view::default_max_nesting_depth, 0x81);
         data.push_back(0x01);
-        auto result = cbor::view::parse_exact(jsoncons::span<const uint8_t>(data));
+        auto result = cbor::view::parse_item(jsoncons::span<const uint8_t>(data));
         REQUIRE(result.has_value());
         CHECK(result.value().encoded_bytes().size() == data.size());
     }
@@ -112,19 +112,19 @@ TEST_CASE("cbor view scanning validates well-formedness")
     {
         std::vector<uint8_t> data(cbor::view::default_max_nesting_depth + 1, 0x81);
         data.push_back(0x01);
-        auto result = cbor::view::parse_exact(jsoncons::span<const uint8_t>(data));
+        auto result = cbor::view::parse_item(jsoncons::span<const uint8_t>(data));
         REQUIRE_FALSE(result.has_value());
         CHECK(result.error().code == cbor::cbor_errc::max_nesting_depth_exceeded);
 
         cbor::view::scan_context deeper(4000);
-        CHECK(cbor::view::parse_exact(jsoncons::span<const uint8_t>(data), deeper).has_value());
+        CHECK(cbor::view::parse_item(jsoncons::span<const uint8_t>(data), deeper).has_value());
     }
 
     SECTION("tag chains do not consume nesting depth or stack")
     {
         std::vector<uint8_t> data(1000000, 0xc0);
         data.push_back(0x01);
-        auto result = cbor::view::parse_exact(jsoncons::span<const uint8_t>(data));
+        auto result = cbor::view::parse_item(jsoncons::span<const uint8_t>(data));
         REQUIRE(result.has_value());
 
         std::size_t count = 0;
@@ -139,12 +139,12 @@ TEST_CASE("cbor view scanning validates well-formedness")
     SECTION("containers claiming huge counts are rejected")
     {
         std::vector<uint8_t> array = {0x9a,0xff,0xff,0xff,0xff};
-        auto array_result = cbor::view::scan_prefix(jsoncons::span<const uint8_t>(array));
+        auto array_result = cbor::view::scan(jsoncons::span<const uint8_t>(array));
         REQUIRE_FALSE(array_result.has_value());
         CHECK(array_result.error().code == cbor::cbor_errc::unexpected_eof);
 
         std::vector<uint8_t> map = {0xba,0xff,0xff,0xff,0xff};
-        auto map_result = cbor::view::scan_prefix(jsoncons::span<const uint8_t>(map));
+        auto map_result = cbor::view::scan(jsoncons::span<const uint8_t>(map));
         REQUIRE_FALSE(map_result.has_value());
         CHECK(map_result.error().code == cbor::cbor_errc::unexpected_eof);
     }
@@ -153,7 +153,7 @@ TEST_CASE("cbor view scanning validates well-formedness")
     {
         // [_ {1: [2]}, [], {} ] followed by trailing bytes
         std::vector<uint8_t> data = {0x9f,0xa1,0x01,0x81,0x02,0x80,0xa0,0xff,0x63,'a','b','c'};
-        auto result = cbor::view::scan_prefix(jsoncons::span<const uint8_t>(data));
+        auto result = cbor::view::scan(jsoncons::span<const uint8_t>(data));
         REQUIRE(result.has_value());
         CHECK(result.value().first.encoded_bytes().size() == 8);
         CHECK(result.value().remainder.size() == 4);
@@ -162,18 +162,18 @@ TEST_CASE("cbor view scanning validates well-formedness")
     SECTION("an indefinite map break may not split a key from its value")
     {
         std::vector<uint8_t> dangling_key = {0xbf,0x01,0xff};
-        auto result = cbor::view::scan_prefix(jsoncons::span<const uint8_t>(dangling_key));
+        auto result = cbor::view::scan(jsoncons::span<const uint8_t>(dangling_key));
         REQUIRE_FALSE(result.has_value());
         CHECK(result.error().code == cbor::cbor_errc::unknown_type);
 
         std::vector<uint8_t> complete_entry = {0xbf,0x01,0x02,0xff};
-        CHECK(cbor::view::parse_exact(jsoncons::span<const uint8_t>(complete_entry)).has_value());
+        CHECK(cbor::view::parse_item(jsoncons::span<const uint8_t>(complete_entry)).has_value());
     }
 
     SECTION("an invalid indefinite integer is rejected")
     {
         std::vector<uint8_t> data = {0x1f};
-        auto result = cbor::view::scan_prefix(jsoncons::span<const uint8_t>(data));
+        auto result = cbor::view::scan(jsoncons::span<const uint8_t>(data));
         REQUIRE_FALSE(result.has_value());
         CHECK(result.error().code == cbor::cbor_errc::unknown_type);
     }
@@ -182,15 +182,15 @@ TEST_CASE("cbor view scanning validates well-formedness")
     {
         // RFC 8949 3.3
         std::vector<uint8_t> below = {0xf8,0x13};
-        auto below_result = cbor::view::scan_prefix(jsoncons::span<const uint8_t>(below));
+        auto below_result = cbor::view::scan(jsoncons::span<const uint8_t>(below));
         REQUIRE_FALSE(below_result.has_value());
         CHECK(below_result.error().code == cbor::cbor_errc::unknown_type);
 
         std::vector<uint8_t> nested = {0x81,0xf8,0x00};
-        CHECK_FALSE(cbor::view::scan_prefix(jsoncons::span<const uint8_t>(nested)).has_value());
+        CHECK_FALSE(cbor::view::scan(jsoncons::span<const uint8_t>(nested)).has_value());
 
         std::vector<uint8_t> at_32 = {0xf8,0x20};
-        auto at_32_result = cbor::view::parse_exact(jsoncons::span<const uint8_t>(at_32));
+        auto at_32_result = cbor::view::parse_item(jsoncons::span<const uint8_t>(at_32));
         REQUIRE(at_32_result.has_value());
         CHECK(at_32_result.value().kind() == cbor::view::item_kind::simple);
         CHECK(at_32_result.value().argument() == 32);
@@ -383,7 +383,7 @@ TEST_CASE("cbor view copying accessors are transactional")
     SECTION("the destination may alias the scanned bytes")
     {
         std::vector<uint8_t> data = {0x42,0x01,0x02};
-        auto result = cbor::view::parse_exact(jsoncons::span<const uint8_t>(data));
+        auto result = cbor::view::parse_item(jsoncons::span<const uint8_t>(data));
         REQUIRE(result.has_value());
         REQUIRE(result.value().bytes(data));   // the item borrows `data` itself
         CHECK((data == std::vector<uint8_t>{0x01,0x02}));
@@ -536,17 +536,17 @@ TEST_CASE("cbor view validate_text")
     }
 }
 
-static_assert(std::is_move_constructible<cbor::view::navigator>::value,
-              "navigator must be movable");
-static_assert(!std::is_copy_constructible<cbor::view::navigator>::value,
-              "navigator must not be copyable");
+static_assert(std::is_move_constructible<cbor::view::walker>::value,
+              "walker must be movable");
+static_assert(!std::is_copy_constructible<cbor::view::walker>::value,
+              "walker must not be copyable");
 
-TEST_CASE("cbor view navigator construction and root access")
+TEST_CASE("cbor view walker construction and root access")
 {
-    SECTION("navigate_prefix returns a checked root and remainder")
+    SECTION("get_walker with prefix returns a checked root and remainder")
     {
         std::vector<uint8_t> data = {0xc1,0x18,0x2a,0x01};   // tag(1) 42, then 1
-        auto result = cbor::view::navigate_prefix(jsoncons::span<const uint8_t>(data));
+        auto result = cbor::view::get_walker(jsoncons::span<const uint8_t>(data), cbor::view::prefix);
         REQUIRE(result.has_value());
         CHECK(result.value().first.kind() == cbor::view::item_kind::unsigned_integer);
         CHECK(result.value().first.argument() == 42);
@@ -569,17 +569,17 @@ TEST_CASE("cbor view navigator construction and root access")
         CHECK(value == 42);
     }
 
-    SECTION("navigate_exact exposes scalar and string content")
+    SECTION("get_walker exposes scalar and string content")
     {
         std::vector<uint8_t> text_data = {0x63,'a','d','a'};
-        auto text_result = cbor::view::navigate_exact(jsoncons::span<const uint8_t>(text_data));
+        auto text_result = cbor::view::get_walker(jsoncons::span<const uint8_t>(text_data));
         REQUIRE(text_result.has_value());
         jsoncons::string_view text;
         CHECK(text_result.value().text(text));
         CHECK(text == "ada");
 
         std::vector<uint8_t> bytes_data = {0x42,0x01,0x02};
-        auto bytes_result = cbor::view::navigate_exact(jsoncons::span<const uint8_t>(bytes_data));
+        auto bytes_result = cbor::view::get_walker(jsoncons::span<const uint8_t>(bytes_data));
         REQUIRE(bytes_result.has_value());
         jsoncons::span<const uint8_t> bytes;
         CHECK(bytes_result.value().bytes(bytes));
@@ -588,138 +588,140 @@ TEST_CASE("cbor view navigator construction and root access")
         CHECK(bytes[1] == 2);
 
         std::vector<uint8_t> boolean_data = {0xf5};
-        auto boolean_result = cbor::view::navigate_exact(jsoncons::span<const uint8_t>(boolean_data));
+        auto boolean_result = cbor::view::get_walker(jsoncons::span<const uint8_t>(boolean_data));
         REQUIRE(boolean_result.has_value());
         bool boolean = false;
         CHECK(boolean_result.value().bool_value(boolean));
         CHECK(boolean);
     }
 
-    SECTION("navigate_exact rejects trailing data")
+    SECTION("get_walker rejects trailing data")
     {
         std::vector<uint8_t> data = {0x01,0x02};
-        auto result = cbor::view::navigate_exact(jsoncons::span<const uint8_t>(data));
+        auto result = cbor::view::get_walker(jsoncons::span<const uint8_t>(data));
         REQUIRE_FALSE(result.has_value());
         CHECK(result.error().code == cbor::cbor_errc::trailing_data);
         CHECK(result.error().offset == 1);
     }
 
-    SECTION("reset is transactional and reuses the navigator")
+    SECTION("reset is transactional and reuses the walker")
     {
         std::vector<uint8_t> first = {0x01};
-        auto made = cbor::view::navigate_exact(jsoncons::span<const uint8_t>(first));
+        auto made = cbor::view::get_walker(jsoncons::span<const uint8_t>(first));
         REQUIRE(made.has_value());
-        cbor::view::navigator navigator = std::move(made.value());
+        cbor::view::walker walker = std::move(made.value());
 
         std::vector<uint8_t> sequence = {0x02,0x03};
-        auto remainder = navigator.reset_prefix(jsoncons::span<const uint8_t>(sequence));
+        auto remainder = walker.reset(jsoncons::span<const uint8_t>(sequence), cbor::view::prefix);
         REQUIRE(remainder.has_value());
         REQUIRE(remainder.value().size() == 1);
         uint64_t value = 0;
-        REQUIRE(navigator.uint64_value(value));
+        REQUIRE(walker.uint64_value(value));
         CHECK(value == 2);
 
         std::vector<uint8_t> malformed = {0x19,0x01};
-        auto malformed_result = navigator.reset_exact(jsoncons::span<const uint8_t>(malformed));
+        auto malformed_result = walker.reset(jsoncons::span<const uint8_t>(malformed));
         REQUIRE_FALSE(malformed_result.has_value());
         value = 0;
-        REQUIRE(navigator.uint64_value(value));
+        REQUIRE(walker.uint64_value(value));
         CHECK(value == 2);
 
-        auto trailing_result = navigator.reset_exact(jsoncons::span<const uint8_t>(sequence));
+        auto trailing_result = walker.reset(jsoncons::span<const uint8_t>(sequence));
         REQUIRE_FALSE(trailing_result.has_value());
         CHECK(trailing_result.error().code == cbor::cbor_errc::trailing_data);
         value = 0;
-        REQUIRE(navigator.uint64_value(value));
+        REQUIRE(walker.uint64_value(value));
         CHECK(value == 2);
 
         std::vector<uint8_t> replacement = {0x81,0x04};
-        REQUIRE(navigator.reset_exact(jsoncons::span<const uint8_t>(replacement)).has_value());
-        CHECK(navigator.kind() == cbor::view::item_kind::array);
-        CHECK(navigator.argument() == 1);
-        CHECK(navigator.role() == cbor::view::position_role::root);
-        CHECK(navigator.depth() == 0);
+        auto exact_remainder = walker.reset(jsoncons::span<const uint8_t>(replacement));
+        REQUIRE(exact_remainder.has_value());
+        CHECK(exact_remainder.value().empty());
+        CHECK(walker.kind() == cbor::view::item_kind::array);
+        CHECK(walker.argument() == 1);
+        CHECK(walker.role() == cbor::view::position_role::root);
+        CHECK(walker.depth() == 0);
         std::vector<uint8_t> deep(100, 0x81);
         deep.push_back(0x05);
-        REQUIRE(navigator.reset_exact(jsoncons::span<const uint8_t>(deep), 200).has_value());
-        REQUIRE(navigator.reset_exact(jsoncons::span<const uint8_t>(replacement), 200).has_value());
-        REQUIRE(navigator.reset_exact(jsoncons::span<const uint8_t>(deep), 200).has_value());
+        REQUIRE(walker.reset(jsoncons::span<const uint8_t>(deep), 200).has_value());
+        REQUIRE(walker.reset(jsoncons::span<const uint8_t>(replacement), 200).has_value());
+        REQUIRE(walker.reset(jsoncons::span<const uint8_t>(deep), 200).has_value());
         for (std::size_t i = 0; i < 100; ++i)
         {
-            REQUIRE(navigator.enter());
+            REQUIRE(walker.enter());
         }
-        CHECK(navigator.argument() == 5);
+        CHECK(walker.argument() == 5);
 
     }
 }
 
-TEST_CASE("cbor view navigator movement")
+TEST_CASE("cbor view walker movement")
 {
     SECTION("walks nested definite arrays without prefinishing parents")
     {
         std::vector<uint8_t> data = {0x83,0x01,0x82,0x02,0x03,0x04}; // [1,[2,3],4]
-        auto result = cbor::view::navigate_exact(jsoncons::span<const uint8_t>(data));
+        auto result = cbor::view::get_walker(jsoncons::span<const uint8_t>(data));
         REQUIRE(result.has_value());
-        cbor::view::navigator navigator = std::move(result.value());
+        cbor::view::walker walker = std::move(result.value());
 
-        REQUIRE(navigator.enter());
-        CHECK(navigator.depth() == 1);
-        CHECK(navigator.role() == cbor::view::position_role::array_element);
-        CHECK(navigator.argument() == 1);
+        REQUIRE(walker.enter());
+        CHECK(walker.depth() == 1);
+        CHECK(walker.role() == cbor::view::position_role::array_element);
+        CHECK(walker.argument() == 1);
 
-        REQUIRE(navigator.next());
-        CHECK(navigator.kind() == cbor::view::item_kind::array);
-        CHECK_FALSE(navigator.extent_known());
-        REQUIRE(navigator.enter());
-        CHECK(navigator.depth() == 2);
-        CHECK(navigator.argument() == 2);
-        REQUIRE(navigator.next());
-        CHECK(navigator.argument() == 3);
-        CHECK_FALSE(navigator.next());
-        CHECK_FALSE(navigator.next());
-        REQUIRE(navigator.leave());
-        CHECK(navigator.depth() == 1);
-        CHECK(navigator.kind() == cbor::view::item_kind::array);
-        CHECK(navigator.extent_known());
+        REQUIRE(walker.next());
+        CHECK(walker.kind() == cbor::view::item_kind::array);
+        CHECK_FALSE(walker.extent_known());
+        REQUIRE(walker.enter());
+        CHECK(walker.depth() == 2);
+        CHECK(walker.argument() == 2);
+        REQUIRE(walker.next());
+        CHECK(walker.argument() == 3);
+        CHECK_FALSE(walker.next());
+        CHECK_FALSE(walker.next());
+        REQUIRE(walker.leave());
+        CHECK(walker.depth() == 1);
+        CHECK(walker.kind() == cbor::view::item_kind::array);
+        CHECK(walker.extent_known());
 
-        REQUIRE(navigator.next());
-        CHECK(navigator.argument() == 4);
-        CHECK(navigator.extent_known());
-        CHECK_FALSE(navigator.next());
-        REQUIRE(navigator.leave());
-        CHECK(navigator.depth() == 0);
-        CHECK(navigator.kind() == cbor::view::item_kind::array);
-        CHECK_FALSE(navigator.leave());
+        REQUIRE(walker.next());
+        CHECK(walker.argument() == 4);
+        CHECK(walker.extent_known());
+        CHECK_FALSE(walker.next());
+        REQUIRE(walker.leave());
+        CHECK(walker.depth() == 0);
+        CHECK(walker.kind() == cbor::view::item_kind::array);
+        CHECK_FALSE(walker.leave());
     }
 
     SECTION("next skips an unopened container once")
     {
         std::vector<uint8_t> data = {0x82,0x82,0x01,0x02,0x03}; // [[1,2],3]
-        auto result = cbor::view::navigate_exact(jsoncons::span<const uint8_t>(data));
+        auto result = cbor::view::get_walker(jsoncons::span<const uint8_t>(data));
         REQUIRE(result.has_value());
-        cbor::view::navigator navigator = std::move(result.value());
-        REQUIRE(navigator.enter());
-        CHECK(navigator.kind() == cbor::view::item_kind::array);
-        CHECK_FALSE(navigator.extent_known());
-        REQUIRE(navigator.next());
-        CHECK(navigator.argument() == 3);
-        CHECK(navigator.extent_known());
+        cbor::view::walker walker = std::move(result.value());
+        REQUIRE(walker.enter());
+        CHECK(walker.kind() == cbor::view::item_kind::array);
+        CHECK_FALSE(walker.extent_known());
+        REQUIRE(walker.next());
+        CHECK(walker.argument() == 3);
+        CHECK(walker.extent_known());
     }
 
     SECTION("early leave skips only the unread remainder")
     {
         std::vector<uint8_t> data = {0x82,0x82,0x01,0x02,0x03}; // [[1,2],3]
-        auto result = cbor::view::navigate_exact(jsoncons::span<const uint8_t>(data));
+        auto result = cbor::view::get_walker(jsoncons::span<const uint8_t>(data));
         REQUIRE(result.has_value());
-        cbor::view::navigator navigator = std::move(result.value());
-        REQUIRE(navigator.enter());
-        REQUIRE(navigator.enter());
-        CHECK(navigator.argument() == 1);
-        REQUIRE(navigator.leave());
-        CHECK(navigator.kind() == cbor::view::item_kind::array);
-        CHECK(navigator.extent_known());
-        REQUIRE(navigator.next());
-        CHECK(navigator.argument() == 3);
+        cbor::view::walker walker = std::move(result.value());
+        REQUIRE(walker.enter());
+        REQUIRE(walker.enter());
+        CHECK(walker.argument() == 1);
+        REQUIRE(walker.leave());
+        CHECK(walker.kind() == cbor::view::item_kind::array);
+        CHECK(walker.extent_known());
+        REQUIRE(walker.next());
+        CHECK(walker.argument() == 3);
     }
 
     SECTION("map roles alternate for definite and indefinite maps")
@@ -730,25 +732,25 @@ TEST_CASE("cbor view navigator movement")
         };
         for (const auto& data : maps)
         {
-            auto result = cbor::view::navigate_exact(jsoncons::span<const uint8_t>(data));
+            auto result = cbor::view::get_walker(jsoncons::span<const uint8_t>(data));
             REQUIRE(result.has_value());
-            cbor::view::navigator navigator = std::move(result.value());
-            REQUIRE(navigator.enter());
-            CHECK(navigator.role() == cbor::view::position_role::map_key);
-            CHECK(navigator.argument() == 1);
-            REQUIRE(navigator.next());
-            CHECK(navigator.role() == cbor::view::position_role::map_value);
-            CHECK(navigator.argument() == 2);
-            REQUIRE(navigator.next());
-            CHECK(navigator.role() == cbor::view::position_role::map_key);
-            CHECK(navigator.argument() == 3);
-            REQUIRE(navigator.next());
-            CHECK(navigator.role() == cbor::view::position_role::map_value);
-            CHECK(navigator.argument() == 4);
-            CHECK_FALSE(navigator.next());
-            CHECK_FALSE(navigator.next());
-            REQUIRE(navigator.leave());
-            CHECK(navigator.role() == cbor::view::position_role::root);
+            cbor::view::walker walker = std::move(result.value());
+            REQUIRE(walker.enter());
+            CHECK(walker.role() == cbor::view::position_role::map_key);
+            CHECK(walker.argument() == 1);
+            REQUIRE(walker.next());
+            CHECK(walker.role() == cbor::view::position_role::map_value);
+            CHECK(walker.argument() == 2);
+            REQUIRE(walker.next());
+            CHECK(walker.role() == cbor::view::position_role::map_key);
+            CHECK(walker.argument() == 3);
+            REQUIRE(walker.next());
+            CHECK(walker.role() == cbor::view::position_role::map_value);
+            CHECK(walker.argument() == 4);
+            CHECK_FALSE(walker.next());
+            CHECK_FALSE(walker.next());
+            REQUIRE(walker.leave());
+            CHECK(walker.role() == cbor::view::position_role::root);
         }
     }
 
@@ -759,30 +761,30 @@ TEST_CASE("cbor view navigator movement")
         };
         for (const auto& data : values)
         {
-            auto result = cbor::view::navigate_exact(jsoncons::span<const uint8_t>(data));
+            auto result = cbor::view::get_walker(jsoncons::span<const uint8_t>(data));
             REQUIRE(result.has_value());
-            cbor::view::navigator navigator = std::move(result.value());
-            const cbor::view::item_kind kind = navigator.kind();
-            CHECK_FALSE(navigator.enter());
-            CHECK(navigator.kind() == kind);
-            CHECK(navigator.depth() == 0);
+            cbor::view::walker walker = std::move(result.value());
+            const cbor::view::item_kind kind = walker.kind();
+            CHECK_FALSE(walker.enter());
+            CHECK(walker.kind() == kind);
+            CHECK(walker.depth() == 0);
         }
     }
 
     SECTION("finish_item caches an unknown extent and descent remains legal")
     {
         std::vector<uint8_t> data = {0x82,0x82,0x01,0x02,0x03}; // [[1,2],3]
-        auto result = cbor::view::navigate_exact(jsoncons::span<const uint8_t>(data));
+        auto result = cbor::view::get_walker(jsoncons::span<const uint8_t>(data));
         REQUIRE(result.has_value());
-        cbor::view::navigator navigator = std::move(result.value());
-        REQUIRE(navigator.enter());
-        CHECK_FALSE(navigator.extent_known());
-        cbor::view::item nested = navigator.finish_item();
-        CHECK(navigator.extent_known());
+        cbor::view::walker walker = std::move(result.value());
+        REQUIRE(walker.enter());
+        CHECK_FALSE(walker.extent_known());
+        cbor::view::item nested = walker.finish_item();
+        CHECK(walker.extent_known());
         CHECK(nested.encoded_bytes().data() == data.data() + 1);
         CHECK(nested.encoded_bytes().size() == 3);
-        REQUIRE(navigator.enter());
-        CHECK(navigator.argument() == 1);
+        REQUIRE(walker.enter());
+        CHECK(walker.argument() == 1);
     }
 
     SECTION("right fences make the final payload immediately finishable")
@@ -791,43 +793,43 @@ TEST_CASE("cbor view navigator movement")
             0x87,0x01,0x02,0x03,0x04,0x05,0x06,
             0x82,0x81,0x07,0x81,0x08
         };
-        auto result = cbor::view::navigate_exact(jsoncons::span<const uint8_t>(data));
+        auto result = cbor::view::get_walker(jsoncons::span<const uint8_t>(data));
         REQUIRE(result.has_value());
-        cbor::view::navigator navigator = std::move(result.value());
-        REQUIRE(navigator.enter());
+        cbor::view::walker walker = std::move(result.value());
+        REQUIRE(walker.enter());
         for (int i = 0; i < 6; ++i)
         {
-            REQUIRE(navigator.next());
+            REQUIRE(walker.next());
         }
-        CHECK(navigator.kind() == cbor::view::item_kind::array);
-        CHECK(navigator.extent_known());
-        cbor::view::item payload = navigator.finish_item();
+        CHECK(walker.kind() == cbor::view::item_kind::array);
+        CHECK(walker.extent_known());
+        cbor::view::item payload = walker.finish_item();
         CHECK(payload.encoded_bytes().data() == data.data() + 7);
         CHECK(payload.encoded_bytes().size() == 5);
 
-        REQUIRE(navigator.enter());
-        CHECK(navigator.kind() == cbor::view::item_kind::array);
-        CHECK_FALSE(navigator.extent_known());
-        REQUIRE(navigator.enter());
-        CHECK(navigator.argument() == 7);
-        CHECK(navigator.extent_known());
+        REQUIRE(walker.enter());
+        CHECK(walker.kind() == cbor::view::item_kind::array);
+        CHECK_FALSE(walker.extent_known());
+        REQUIRE(walker.enter());
+        CHECK(walker.argument() == 7);
+        CHECK(walker.extent_known());
     }
 
     SECTION("rewind restores the checked root")
     {
         std::vector<uint8_t> data = {0x81,0x81,0x01};
-        auto result = cbor::view::navigate_exact(jsoncons::span<const uint8_t>(data));
+        auto result = cbor::view::get_walker(jsoncons::span<const uint8_t>(data));
         REQUIRE(result.has_value());
-        cbor::view::navigator navigator = std::move(result.value());
-        REQUIRE(navigator.enter());
-        REQUIRE(navigator.enter());
-        CHECK(navigator.depth() == 2);
-        navigator.rewind();
-        CHECK(navigator.depth() == 0);
-        CHECK(navigator.role() == cbor::view::position_role::root);
-        CHECK(navigator.kind() == cbor::view::item_kind::array);
-        REQUIRE(navigator.enter());
-        CHECK(navigator.depth() == 1);
+        cbor::view::walker walker = std::move(result.value());
+        REQUIRE(walker.enter());
+        REQUIRE(walker.enter());
+        CHECK(walker.depth() == 2);
+        walker.rewind();
+        CHECK(walker.depth() == 0);
+        CHECK(walker.role() == cbor::view::position_role::root);
+        CHECK(walker.kind() == cbor::view::item_kind::array);
+        REQUIRE(walker.enter());
+        CHECK(walker.depth() == 1);
     }
 
     SECTION("deep movement uses the validation-sized workspace")
@@ -835,20 +837,20 @@ TEST_CASE("cbor view navigator movement")
         const std::size_t depth = 100;
         std::vector<uint8_t> data(depth, 0x81);
         data.push_back(0x01);
-        auto result = cbor::view::navigate_exact(jsoncons::span<const uint8_t>(data));
+        auto result = cbor::view::get_walker(jsoncons::span<const uint8_t>(data));
         REQUIRE(result.has_value());
-        cbor::view::navigator navigator = std::move(result.value());
+        cbor::view::walker walker = std::move(result.value());
         for (std::size_t i = 0; i < depth; ++i)
         {
-            REQUIRE(navigator.enter());
-            CHECK(navigator.depth() == i + 1);
+            REQUIRE(walker.enter());
+            CHECK(walker.depth() == i + 1);
         }
-        CHECK(navigator.argument() == 1);
+        CHECK(walker.argument() == 1);
         for (std::size_t i = 0; i < depth; ++i)
         {
-            REQUIRE(navigator.leave());
+            REQUIRE(walker.leave());
         }
-        CHECK(navigator.depth() == 0);
+        CHECK(walker.depth() == 0);
     }
 }
 
@@ -859,7 +861,7 @@ TEST_CASE("cbor view item children")
     SECTION("array children are checked items in order")
     {
         std::vector<uint8_t> data = {0x83,0x01,0x82,0x02,0x03,0x63,'a','b','c'};   // [1,[2,3],"abc"]
-        auto result = cbor::view::parse_exact(jsoncons::span<const uint8_t>(data), context);
+        auto result = cbor::view::parse_item(jsoncons::span<const uint8_t>(data), context);
         REQUIRE(result.has_value());
 
         std::vector<cbor::view::item> children;
@@ -898,7 +900,7 @@ TEST_CASE("cbor view item children")
         };
         for (const auto& data : maps)
         {
-            auto result = cbor::view::parse_exact(jsoncons::span<const uint8_t>(data), context);
+            auto result = cbor::view::parse_item(jsoncons::span<const uint8_t>(data), context);
             REQUIRE(result.has_value());
             std::vector<uint64_t> values;
             for (cbor::view::item child : result.value().children(context))
@@ -922,7 +924,7 @@ TEST_CASE("cbor view item children")
         };
         for (const auto& data : values)
         {
-            auto result = cbor::view::parse_exact(jsoncons::span<const uint8_t>(data), context);
+            auto result = cbor::view::parse_item(jsoncons::span<const uint8_t>(data), context);
             REQUIRE(result.has_value());
             CHECK(result.value().children(context).empty());
             CHECK(result.value().children(context).begin() == cbor::view::item::child_iterator());
@@ -932,7 +934,7 @@ TEST_CASE("cbor view item children")
     SECTION("indefinite container children stop at the break")
     {
         std::vector<uint8_t> data = {0x9f,0x01,0x81,0x02,0xff};   // [_ 1,[2]]
-        auto result = cbor::view::parse_exact(jsoncons::span<const uint8_t>(data), context);
+        auto result = cbor::view::parse_item(jsoncons::span<const uint8_t>(data), context);
         REQUIRE(result.has_value());
         std::size_t count = 0;
         for (cbor::view::item child : result.value().children(context))
@@ -949,7 +951,7 @@ TEST_CASE("cbor view item children")
         std::vector<uint8_t> data(depth + 1, 0x81);
         data.push_back(0x01);
         cbor::view::scan_context deep_context(200);
-        auto result = cbor::view::parse_exact(jsoncons::span<const uint8_t>(data), deep_context);
+        auto result = cbor::view::parse_item(jsoncons::span<const uint8_t>(data), deep_context);
         REQUIRE(result.has_value());
         auto it = result.value().children(deep_context).begin();
         REQUIRE(it != cbor::view::item::child_iterator());


### PR DESCRIPTION
Having lived with this for a few days, I've renamed "navigator" to the better, shorter "walker", and simplified/cleaned up the API a little (no real functional change, just improved ergonomics)