### PR TITLE
Constrain and document supported JSON Schema types

### DIFF
--- a/doc/ref/jsonschema/json_schema.md
+++ b/doc/ref/jsonschema/json_schema.md
@@ -12,6 +12,14 @@ A `json_schema` is immutable and thread-safe.
 
 The class satisfies the requirements of MoveConstructible and MoveAssignable, but not CopyConstructible or CopyAssignable.
 
+`Json` must be a `basic_json` specialization with `char_type` equal to `char`
+and a default-constructible allocator. For `std::scoped_allocator_adaptor`,
+the outer allocator and all inner allocators must be default constructible.
+This includes `json`, `ojson`, and their `jsoncons::pmr` variants. Wide-character
+types such as `wjson` and `wojson`, and allocators without a default constructor,
+are not supported. Instantiating `json_schema` with these unsupported types
+produces a compile-time diagnostic.
+
 #### Member functions
 
 <table border="0">

--- a/doc/ref/jsonschema/jsonschema.md
+++ b/doc/ref/jsonschema/jsonschema.md
@@ -3,6 +3,12 @@
 Since 0.174.0, the jsonschema extension implements Drafts 4, 6, 7, 2019-9 and 2020-12 of the [JSON Schema Specification](https://json-schema.org/specification).
 Previous versions supported Draft 7.
 
+The extension requires a `basic_json` type with `char_type` equal to `char`
+and a default-constructible allocator, including any underlying scoped allocators.
+It supports `json`, `ojson`, and their `jsoncons::pmr` variants, but not
+wide-character types such as `wjson` and `wojson` or allocators without a default
+constructor. See [json_schema](json_schema.md) for the type requirements.
+
 The documentation below describes the new features for the jsonschema extension since 0.174.0.
 For earlier releases, please refer to [jsonschema (until 0.174.0)](https://github.com/danielaparker/jsoncons/tree/main).
 

--- a/doc/ref/jsonschema/make_json_schema.md
+++ b/doc/ref/jsonschema/make_json_schema.md
@@ -27,6 +27,13 @@ json_schema<Json> make_json_schema(Json root_schema,
 
 Returns a [json_schema<Json>](json_schema.md) that represents a compiled JSON Schema document.
 
+All overloads require `Json::char_type` to be `char` and `Json::allocator_type`
+to be default constructible. For `std::scoped_allocator_adaptor`, this requirement
+also applies to its outer allocator and all inner allocators. Overloads do not
+participate in overload resolution when these requirements are not met.
+`json`, `ojson`, and their `jsoncons::pmr` variants are supported;
+wide-character types such as `wjson` and `wojson` are not supported.
+
 #### Parameters
 
 <table>

--- a/include/jsoncons_ext/jsonschema/json_schema.hpp
+++ b/include/jsoncons_ext/jsonschema/json_schema.hpp
@@ -8,6 +8,8 @@
 #define JSONCONS_EXT_JSONSCHEMA_JSON_SCHEMA_HPP
 
 #include <functional>
+#include <scoped_allocator>
+#include <type_traits>
 
 #include <jsoncons/config/compiler_support.hpp>
 #include <jsoncons/config/jsoncons_config.hpp>
@@ -18,6 +20,30 @@
 
 namespace jsoncons {
 namespace jsonschema {
+
+namespace detail {
+
+template <typename Allocator>
+struct is_default_constructible_allocator : std::is_default_constructible<Allocator>
+{
+};
+
+// scoped_allocator_adaptor's default constructor may be unconstrained even
+// when an underlying allocator cannot be default constructed.
+template <typename OuterAllocator>
+struct is_default_constructible_allocator<std::scoped_allocator_adaptor<OuterAllocator>>
+    : is_default_constructible_allocator<OuterAllocator>
+{
+};
+
+template <typename OuterAllocator,typename InnerAllocator,typename... InnerAllocators>
+struct is_default_constructible_allocator<std::scoped_allocator_adaptor<OuterAllocator,InnerAllocator,InnerAllocators...>>
+    : std::integral_constant<bool, is_default_constructible_allocator<OuterAllocator>::value &&
+        is_default_constructible_allocator<std::scoped_allocator_adaptor<InnerAllocator,InnerAllocators...>>::value>
+{
+};
+
+} // namespace detail
 
 class validation_message_to_json_events 
 {
@@ -192,6 +218,11 @@ private:
 template <typename Json>
 class json_schema
 {
+    static_assert(std::is_same<typename Json::char_type,char>::value,
+        "json_schema requires Json::char_type to be char");
+    static_assert(detail::is_default_constructible_allocator<typename Json::allocator_type>::value,
+        "json_schema requires a default-constructible allocator (including scoped allocators)");
+
     using keyword_validator_ptr_type = std::unique_ptr<keyword_validator<Json>>;
     using document_schema_validator_type = std::unique_ptr<document_schema_validator<Json>>;
 

--- a/include/jsoncons_ext/jsonschema/json_schema_factory.hpp
+++ b/include/jsoncons_ext/jsonschema/json_schema_factory.hpp
@@ -8,6 +8,7 @@
 #define JSONCONS_EXT_JSONSCHEMA_JSON_SCHEMA_FACTORY_HPP
 
 #include <string>
+#include <type_traits>
 #include <unordered_map>
 
 #include <jsoncons/config/compiler_support.hpp>
@@ -225,7 +226,9 @@ namespace jsonschema {
     }
 
     template <typename Json,typename SchemaResolver>
-    typename std::enable_if<ext_traits::is_function_object_exact<SchemaResolver,Json,jsoncons::uri>::value,json_schema<Json>>::type
+    typename std::enable_if<std::is_same<typename Json::char_type,char>::value &&
+        detail::is_default_constructible_allocator<typename Json::allocator_type>::value &&
+        ext_traits::is_function_object_exact<SchemaResolver,Json,jsoncons::uri>::value,json_schema<Json>>::type
     make_json_schema(Json root_schema, const std::string& retrieval_uri, const SchemaResolver& resolver, 
         const evaluation_options& options = evaluation_options{})
     {
@@ -242,7 +245,9 @@ namespace jsonschema {
     }
 
     template <typename Json>
-    json_schema<Json> make_json_schema(Json root_schema, const std::string& retrieval_uri, 
+    typename std::enable_if<std::is_same<typename Json::char_type,char>::value &&
+        detail::is_default_constructible_allocator<typename Json::allocator_type>::value,json_schema<Json>>::type
+    make_json_schema(Json root_schema, const std::string& retrieval_uri,
         const evaluation_options& options = evaluation_options{})
     {
         using schema_store_type = std::map<jsoncons::uri, schema_validator<Json>*>;
@@ -258,7 +263,9 @@ namespace jsonschema {
     }
 
     template <typename Json,typename SchemaResolver>
-    typename std::enable_if<ext_traits::is_function_object_exact<SchemaResolver,Json,jsoncons::uri>::value,json_schema<Json>>::type
+    typename std::enable_if<std::is_same<typename Json::char_type,char>::value &&
+        detail::is_default_constructible_allocator<typename Json::allocator_type>::value &&
+        ext_traits::is_function_object_exact<SchemaResolver,Json,jsoncons::uri>::value,json_schema<Json>>::type
     make_json_schema(Json root_schema, const SchemaResolver& resolver, 
         const evaluation_options& options = evaluation_options{})
     {
@@ -275,7 +282,9 @@ namespace jsonschema {
     }
  
     template <typename Json>
-    json_schema<Json> make_json_schema(Json root_schema, 
+    typename std::enable_if<std::is_same<typename Json::char_type,char>::value &&
+        detail::is_default_constructible_allocator<typename Json::allocator_type>::value,json_schema<Json>>::type
+    make_json_schema(Json root_schema,
         const evaluation_options& options = evaluation_options{})
     {
         using schema_store_type = std::map<jsoncons::uri, schema_validator<Json>*>;

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -192,6 +192,7 @@ add_executable(unit_tests
                jsonschema/src/jsonschema_draft6_tests.cpp
                jsonschema/src/jsonschema_draft7_tests.cpp
                jsonschema/src/jsonschema_keyword_tests.cpp
+               jsonschema/src/jsonschema_type_constraints_tests.cpp
                jsonschema/src/schema_version_tests.cpp
                jsonschema/src/validation_report_tests.cpp
                jsonschema/src/validation_with_pmr_allocator_tests.cpp

--- a/test/jsonschema/src/jsonschema_type_constraints_tests.cpp
+++ b/test/jsonschema/src/jsonschema_type_constraints_tests.cpp
@@ -1,0 +1,86 @@
+// Copyright 2013-2026 Daniel Parker
+// Distributed under the Boost license, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <jsoncons/json.hpp>
+#include <jsoncons_ext/jsonschema/jsonschema.hpp>
+#include <common/mock_stateful_allocator.hpp>
+#include <catch/catch.hpp>
+#include <scoped_allocator>
+#include <string>
+#include <utility>
+
+namespace
+{
+    namespace jsonschema = jsoncons::jsonschema;
+
+    template <typename Json, typename... Args>
+    using make_schema_result = decltype(jsonschema::make_json_schema(
+        std::declval<Json>(), std::declval<Args>()...));
+
+    template <typename Json>
+    void check_schema_overloads(bool supported)
+    {
+        using resolver_type = Json (*)(const jsoncons::uri&);
+        using options_type = jsonschema::evaluation_options;
+        CHECK((jsoncons::ext_traits::is_detected<make_schema_result, Json>::value == supported));
+        CHECK((jsoncons::ext_traits::is_detected<make_schema_result, Json, options_type>::value == supported));
+        CHECK((jsoncons::ext_traits::is_detected<make_schema_result, Json, std::string>::value == supported));
+        CHECK((jsoncons::ext_traits::is_detected<make_schema_result, Json, std::string, options_type>::value == supported));
+        CHECK((jsoncons::ext_traits::is_detected<make_schema_result, Json, resolver_type>::value == supported));
+        CHECK((jsoncons::ext_traits::is_detected<make_schema_result, Json, resolver_type, options_type>::value == supported));
+        CHECK((jsoncons::ext_traits::is_detected<make_schema_result, Json, std::string, resolver_type>::value == supported));
+        CHECK((jsoncons::ext_traits::is_detected<make_schema_result, Json, std::string, resolver_type, options_type>::value == supported));
+    }
+
+    template <typename Json>
+    void check_schema_validation()
+    {
+        auto root = Json::parse(R"({"$ref":"https://example.com/string"})");
+        auto resolver = [](const jsoncons::uri&) { return Json::parse(R"({"type":"string"})"); };
+        auto resolved = jsonschema::make_json_schema(root, resolver);
+        CHECK(resolved.is_valid(Json("value")));
+        CHECK_FALSE(resolved.is_valid(Json(42)));
+        auto retrieved = jsonschema::make_json_schema(root, "https://example.com/root", resolver);
+        CHECK(retrieved.is_valid(Json("value")));
+        CHECK_FALSE(retrieved.is_valid(Json(42)));
+
+        root = Json::parse(R"({"type":"string"})");
+        auto local = jsonschema::make_json_schema(root);
+        CHECK(local.is_valid(Json("value")));
+        CHECK_FALSE(local.is_valid(Json(42)));
+        auto local_retrieved = jsonschema::make_json_schema(root, "https://example.com/root");
+        CHECK(local_retrieved.is_valid(Json("value")));
+        CHECK_FALSE(local_retrieved.is_valid(Json(42)));
+    }
+}
+
+TEST_CASE("jsonschema supported JSON types")
+{
+    check_schema_overloads<jsoncons::json>(true);
+    check_schema_overloads<jsoncons::ojson>(true);
+    check_schema_validation<jsoncons::json>();
+    check_schema_validation<jsoncons::ojson>();
+    using scoped_json = jsoncons::basic_json<char, jsoncons::sorted_policy,
+        std::scoped_allocator_adaptor<std::allocator<char>, std::allocator<char>>>;
+    check_schema_overloads<scoped_json>(true);
+
+#if defined(JSONCONS_HAS_POLYMORPHIC_ALLOCATOR) && JSONCONS_HAS_POLYMORPHIC_ALLOCATOR == 1
+    check_schema_overloads<jsoncons::pmr::json>(true);
+    check_schema_overloads<jsoncons::pmr::ojson>(true);
+    check_schema_validation<jsoncons::pmr::json>();
+    check_schema_validation<jsoncons::pmr::ojson>();
+#endif
+}
+
+TEST_CASE("jsonschema unsupported JSON types")
+{
+    check_schema_overloads<jsoncons::wjson>(false);
+    check_schema_overloads<jsoncons::wojson>(false);
+    using stateful_json = jsoncons::basic_json<char, jsoncons::sorted_policy,
+        std::scoped_allocator_adaptor<mock_stateful_allocator<char>>>;
+    check_schema_overloads<stateful_json>(false);
+    using inner_stateful_json = jsoncons::basic_json<char, jsoncons::sorted_policy,
+        std::scoped_allocator_adaptor<std::allocator<char>, mock_stateful_allocator<char>>>;
+    check_schema_overloads<inner_stateful_json>(false);
+}


### PR DESCRIPTION
Fixes #734.

`make_json_schema(wjson)` currently reaches narrow-string operations in the schema factories before failing to compile. Constrain all four overloads to `char` JSON types with default-constructible allocators, and add explicit diagnostics for direct `json_schema` instantiation. Document the requirements on the extension and both API pages.

The allocator check also inspects the underlying allocators of `std::scoped_allocator_adaptor`: its declared default constructor can appear usable to `std::is_default_constructible` even when an underlying allocator deletes its default constructor. Default-constructible allocators, including PMR allocators, remain supported.

Tests cover overload selection with default and explicit options, rejection of wide-character and unsupported outer/inner allocator types, and validation through all four overloads with `json`, `ojson`, and their PMR variants. The original 24 unsupported-call assertions failed before the change. The final focused tests pass all 104 assertions; all upstream-registered JSON Schema tests pass (5,726 assertions, 40 cases) under GCC 15 in C++17 with `-Wall -Wextra -Werror`. The new test file also passes a C++11 syntax-only check, and direct unsupported class instantiations produce the expected diagnostics.

AI assistance: prepared with OpenAI Codex, with reproduction and verification performed locally.
